### PR TITLE
Explicitly query localhost for nslookup

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -159,11 +159,11 @@ check_dnsmasq()
 
 	for domain in google.com amazon.com microsoft.com
 	do
-		if ! nslookup "${domain}" &> /dev/null 
+		if ! nslookup "${domain}" 127.0.0.1 &> /dev/null 
 		then
 			log_msg "Lookup of '${domain}' failed with new blocklist."
 			return 1
-		elif nslookup "${domain}" | grep -A1 ^Name | grep -q '^Address: *0\.0\.0\.0$'
+		elif nslookup "${domain}" 127.0.0.1 | grep -A1 ^Name | grep -q '^Address: *0\.0\.0\.0$'
 		then
 			log_msg "Lookup of '${domain}' resulted in 0.0.0.0 with new blocklist."
 			return 1


### PR DESCRIPTION
It is possible some users might disable the router’s own use of dnsmasq by setting localuse option to 0.

If /etc/resolv.conf does not point to 127.0.0.1 or ::1, nslookup will not be testing the local dnsmasq instance.