### PR TITLE
Line count correction.  Local list sed check improvments

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -54,9 +54,9 @@ generate_preprocessed_blocklist_file()
 
 	if [[ -f "${local_blocklist_path}" ]] 
 	then
-		local_blocklist_line_count=$(grep -v -E -c "^$|#.*" "${local_blocklist_path}")
+		local_blocklist_line_count=$(grep -vEc '^\s*$|^#' "${local_blocklist_path}")
 		log_msg "Found local blocklist with ${local_blocklist_line_count} line(s)."
-		sed 's~..*~local=/&/~;$a\' "${local_blocklist_path}" >> /tmp/blocklist
+		sed 's/^[ \t]*//; s/[ \t]*$//; /^$/d; s~.*~local=/&/~; $a\' "${local_blocklist_path}" >> /tmp/blocklist
 	else
 		log_msg "No local blocklist identified."
 	fi
@@ -73,9 +73,9 @@ generate_preprocessed_blocklist_file()
 			if grep -q "Download completed" /tmp/wget_err
 			then
 				log_msg "Download of new blocklist file part from: ${blocklist_url} suceeded."
-				# Clean whitespace and format all blocklist file part entries as local=/.../
 				log_msg "Cleaning whitespace and formatting blocklist file part as local=/.../."
-				sed 's/#$//;\~^\s*$~d;s/^[ \t]*//;s/[ \t]*$//;s/\(^address\|^server\)/local/;$a\' /tmp/blocklist.${blocklist_id} >> /tmp/blocklist
+				# '$a\' adds newline at end of file part
+				sed 's/#$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; s/\(^address\|^server\)/local/; $a\' /tmp/blocklist.${blocklist_id} >> /tmp/blocklist
 				rm -f "/tmp/blocklist.${blocklist_id}"
 				blocklist_id=$((blocklist_id+1))
 				continue 2
@@ -90,7 +90,7 @@ generate_preprocessed_blocklist_file()
 
 	rm -f /tmp/wget_err
 
-	preprocessed_blocklist_line_count=$(grep -v -E -c "^$|#.*" /tmp/blocklist)
+	preprocessed_blocklist_line_count=$(grep -vEc '^\s*$|^#' /tmp/blocklist)
 	[[ "${preprocessed_blocklist_line_count}" -gt 0 ]] || return 1
 
 	return 0
@@ -113,14 +113,14 @@ process_and_check_blocklist_file()
 	mv /tmp/blocklist.tmp /tmp/blocklist
 	log_msg "Duplicates removed."
 
-	if [[ -f "${local_allowlist_path}" ]] && [[ $(du "${local_allowlist_path}" | awk '{print $1}') -gt 0 ]]
+	if [[ -f "${local_allowlist_path}" ]] && local_allowlist_line_count=$(grep -vEc '^\s*$|^#' ${local_allowlist_path}) && [[ $local_allowlist_line_count -gt 0 ]]
 	then
-		local_allowlist_line_count=$(grep -v -E -c "^$|#.*" "${local_allowlist_path}")
-		log_msg "Found local allowlist with ${local_allowlist_line_count} lines."
-		log_msg "Modifying blocklist based on local allowlist."
-		awk -F'/' 'NR==FNR { allow[$0]; next } { n=split($2,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "${allowlist_path}" "/tmp/blocklist" > "/tmp/blocklist.tmp"
+		log_msg "Found local allowlist with ${local_allowlist_line_count} lines.  Removing (sub)domain matches from blocklist."
+		sed 's/^[ \t]*//; s/[ \t]*$//; /^$/d' ${local_allowlist_path} > /tmp/allowlist
+		awk -F'/' 'NR==FNR { allow[$0]; next } { n=split($2,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "/tmp/allowlist" "/tmp/blocklist" > "/tmp/blocklist.tmp"
+		rm /tmp/allowlist
 		mv /tmp/blocklist.tmp /tmp/blocklist
-		log_msg "Blocklist modification based on local allowlist complete."
+		log_msg "Removal of allowlist (sub)domain matches from blocklist complete."
 	else
 		log_msg "No local allowlist identified."
 	fi
@@ -136,7 +136,7 @@ process_and_check_blocklist_file()
 		return 1
 	fi
 
-	good_line_count=$(grep -v -E -c "^$|#.*" /tmp/blocklist)
+	good_line_count=$(grep -vEc '^\s*$|^#' /tmp/blocklist)
 
 	if [[ "${good_line_count}" -lt "${min_good_line_count}" ]]
 	then
@@ -268,7 +268,7 @@ status()
 	fi
 	if check_dnsmasq
 	then
-		good_line_count=$(grep -v -E -c "^$|#.*" /tmp/dnsmasq.d/blocklist)
+		good_line_count=$(grep -vEc '^\s*$|^#' /tmp/dnsmasq.d/blocklist)
 		log_msg "The dnsmasq check passed and the presently installed blocklist has good line count: ${good_line_count}."
 		log_msg "adblock-lean appears to be active."
 	else


### PR DESCRIPTION
Formatted some sed commands for readability.
Corrected grep line count commands.
Add whitespace cleaning for local blocklist.
Add minimum one line check for allowlist, and whitespace cleaning.  An empty line otherwise results in the entire blocklist being deleted.