### PR TITLE
 Improve efficiency of allowlist line counting

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -26,6 +26,11 @@ adblock-lean custom commands:
 	gen_config	generate default config
 	update		update adblock-lean to the latest version"
 
+get_file_size_KB()
+{
+	du -bk "$1" | awk '{print $1}'
+}
+
 get_uptime_ms()
 {
 	read -r uptime_ms _ < /proc/uptime
@@ -236,7 +241,7 @@ generate_preprocessed_blocklist_file_parts()
 			uclient-fetch "${allowlist_url}" -O- --timeout=2 2> /tmp/uclient-fetch_err > /tmp/allowlist.${allowlist_id}
 			if grep -q "Download completed" /tmp/uclient-fetch_err
 			then
-				allowlist_file_part_size_KB=$(du -bk /tmp/allowlist.${allowlist_id} | awk '{print $1}')
+				allowlist_file_part_size_KB=$(get_file_size_KB /tmp/allowlist.${allowlist_id})
 				log_msg "Download of new allowlist file part from: ${allowlist_url} suceeded (downloaded file size: ${allowlist_file_part_size_KB} KB)."
 				log_msg "Sanitizing allowlist file part."
 				# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Add newline
@@ -306,7 +311,7 @@ generate_preprocessed_blocklist_file_parts()
 			uclient-fetch "${blocklist_url}" -O- --timeout=2 2> /tmp/uclient-fetch_err | head -c "${max_blocklist_file_part_size_KB}k" > "/tmp/blocklist.${blocklist_id}"
 			if grep -q "Download completed" /tmp/uclient-fetch_err
 			then
-				blocklist_file_part_size_KB=$(du -bk /tmp/blocklist.${blocklist_id} | awk '{print $1}')
+				blocklist_file_part_size_KB=$(get_file_size_KB /tmp/blocklist.${blocklist_id})
 				blocklist_file_part_line_count=$(grep -vEc '^\s*$|^#' /tmp/blocklist.${blocklist_id})
 
 				if [[ "${blocklist_file_part_line_count}" -ge "${min_blocklist_file_part_line_count}" ]]
@@ -357,7 +362,7 @@ generate_preprocessed_blocklist_file_parts()
 				log_msg "Download of new blocklist file part from: ${blocklist_url} failed."
 				if [[ -f "/tmp/blocklist.${blocklist_id}" ]]
 				then
-					blocklist_file_part_size_KB=$(du -bk /tmp/blocklist.${blocklist_id} | awk '{print $1}')
+					blocklist_file_part_size_KB=$(get_file_size_KB /tmp/blocklist.${blocklist_id})
 					if [[ "${blocklist_file_part_size_KB}" -eq "${max_blocklist_file_part_size_KB}" ]]
 					then
 						log_msg "Downloaded blocklist file part size exceeded the maximum value set in config (${max_blocklist_file_part_size_KB} KB)."
@@ -421,7 +426,7 @@ generate_and_process_blocklist_file()
 		return 1
 	fi
 
-	blocklist_file_size_KB=$(du -bk /tmp/blocklist | awk '{print $1}')
+	blocklist_file_size_KB=$(get_file_size_KB /tmp/blocklist)
 	
 	if [[ "${blocklist_file_size_KB}" -gt "${max_blocklist_file_size_KB}" ]]
 	then
@@ -525,11 +530,11 @@ import_blocklist_file()
 		printf "busybox gunzip -c /tmp/dnsmasq.d/.blocklist.gz\nexit 0\n" > /tmp/dnsmasq.d/.extract_blocklist
 		gzip -f /tmp/blocklist
 		mv /tmp/blocklist.gz /tmp/dnsmasq.d/.blocklist.gz
-		imported_blocklist_file_size_KB=$(du -bk /tmp/dnsmasq.d/.blocklist.gz | awk '{print $1}')
+		imported_blocklist_file_size_KB=$(get_file_size_KB /tmp/dnsmasq.d/.blocklist.gz)
 	else
 			clean_dnsmasq_dir
 			mv /tmp/blocklist /tmp/dnsmasq.d/blocklist
-			imported_blocklist_file_size_KB=$(du -bk /tmp/dnsmasq.d/blocklist | awk '{print $1}')
+			imported_blocklist_file_size_KB=$(get_file_size_KB /tmp/dnsmasq.d/blocklist)
 			return 0
 	fi
 }

--- a/adblock-lean
+++ b/adblock-lean
@@ -208,18 +208,26 @@ check_blocklist_compression_support()
 generate_preprocessed_blocklist_file_parts()
 {
 	rm -f /tmp/allowlist*
+	allowlist_line_count=0
+	allowlist_id=0
 
-	if [[ -f "${local_allowlist_path}" ]] && local_allowlist_line_count=$(grep -vEc '^\s*$|^#' ${local_allowlist_path}) && [[ $local_allowlist_line_count -gt 0 ]]
+	if [[ -f "${local_allowlist_path}" ]]
 	then
-		log_msg "Found local allowlist with ${local_allowlist_line_count} lines."
+		log_msg "Found local allowlist."
 		log_msg "Sanitizing allowlist file part."
 		# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Add newline
-		cat ${local_allowlist_path} | tr 'A-Z' 'a-z' | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; $a\' > /tmp/allowlist
+		allowlist_file_part_line_count="$(tr 'A-Z' 'a-z' < "${local_allowlist_path}" | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; $a\' | tee /tmp/allowlist | wc -l)"
+		if [[ "${allowlist_file_part_line_count}" -gt 0 ]]
+		then
+			log_msg "Sanitized allowlist file part line count: ${allowlist_file_part_line_count}."
+		else
+			log_msg "No lines remaining in allowlist file part after sanitization."
+		fi
+		allowlist_line_count=$(( allowlist_line_count + allowlist_file_part_line_count))
 	else
 		log_msg "No local allowlist identified."
 	fi
 
-	allowlist_id=0
 	for allowlist_url in ${allowlist_urls}
 	do
 		for retries in $(seq 1 3)
@@ -229,11 +237,17 @@ generate_preprocessed_blocklist_file_parts()
 			if grep -q "Download completed" /tmp/uclient-fetch_err
 			then
 				allowlist_file_part_size_KB=$(du -bk /tmp/allowlist.${allowlist_id} | awk '{print $1}')
-				allowlist_file_part_line_count=$(grep -vEc '^\s*$|^#' /tmp/allowlist.${allowlist_id})
-				log_msg "Download of new allowlist file part from: ${allowlist_url} suceeded (downloaded file size: ${allowlist_file_part_size_KB} KB; line count: ${allowlist_file_part_line_count})."
+				log_msg "Download of new allowlist file part from: ${allowlist_url} suceeded (downloaded file size: ${allowlist_file_part_size_KB} KB)."
 				log_msg "Sanitizing allowlist file part."
 				# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Add newline
-				cat /tmp/allowlist.${allowlist_id} | tr 'A-Z' 'a-z' | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; $a\' >> /tmp/allowlist
+				allowlist_file_part_line_count="$(tr 'A-Z' 'a-z' < /tmp/allowlist.${allowlist_id} | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; $a\' | tee -a /tmp/allowlist | wc -l)"
+				if [[ "${allowlist_file_part_line_count}" -gt 0 ]]
+				then
+					log_msg "Sanitized allowlist file part line count: ${allowlist_file_part_line_count}."
+				else
+					log_msg "No lines remaining in allowlist file part after sanitization."
+				fi
+				allowlist_line_count=$(( allowlist_line_count + allowlist_file_part_line_count))
 				rm -f  /tmp/allowlist.${allowlist_id}
 				allowlist_id=$((allowlist_id+1))
 				continue 2
@@ -249,7 +263,7 @@ generate_preprocessed_blocklist_file_parts()
 
 	rm -f /tmp/allowlist.*
 
-	if [[ -f "/tmp/allowlist" ]] && allowlist_line_count=$(grep -vEc '^\s*$|^#' /tmp/allowlist) && [[ $allowlist_line_count -gt 0 ]]
+	if [[ -f "/tmp/allowlist" ]] && [[ $allowlist_line_count -gt 0 ]]
 	then
 		log_msg "Successfully generated allowlist with ${allowlist_line_count} lines."
 		log_msg "Will remove any (sub)domain matches present in the generated allowlist from the blocklist file part(s) and append corresponding server entries to the combined blocklist."
@@ -271,7 +285,7 @@ generate_preprocessed_blocklist_file_parts()
 
 	rm -f /tmp/blocklist*
 
-	if [[ -f "${local_blocklist_path}" ]] 
+	if [[ -f "${local_blocklist_path}" ]]
 	then
 		local_blocklist_line_count=$(grep -vEc '^\s*$|^#' "${local_blocklist_path}")
 		log_msg "Found local blocklist with ${local_blocklist_line_count} line(s)."


### PR DESCRIPTION
- avoid processing allowlist contents with grep, count lines with wc -l instead
- increment allowlist lines count when processing each allowlist part, rather than counting lines again for the complete allowlist