### PR TITLE
Pipe downloads into further processing chains

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -232,49 +232,58 @@ generate_preprocessed_blocklist_file_parts()
 		else
 			log_msg "No lines remaining in allowlist file part after sanitization."
 		fi
-		allowlist_line_count=$(( allowlist_line_count + allowlist_file_part_line_count))
+		allowlist_line_count=$(( allowlist_line_count + allowlist_file_part_line_count ))
 	else
 		log_msg "No local allowlist identified."
 	fi
 
 	for allowlist_url in ${allowlist_urls}
 	do
-		retry=0
+		retry=1
 		while [[ "$retry" -le "$max_download_retries" ]]
 		do
 			retry=$((retry + 1))
-			log_msg "Downloading new allowlist file part from: ${allowlist_url}."
-			uclient-fetch "${allowlist_url}" -O- --timeout=2 2> /tmp/uclient-fetch_err > /tmp/allowlist.${allowlist_id}
-			if grep -q "Download completed" /tmp/uclient-fetch_err
+			log_msg "Downloading and sanitizing new allowlist file part from: ${allowlist_url}."
+			uclient-fetch "${allowlist_url}" -O- --timeout=2 2> /tmp/uclient-fetch_err |
+			tee >(wc -c > /tmp/allowlist_file_part_size_B) |
+			tr 'A-Z' 'a-z' | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; $a\' |
+			tee >(wc -l > /tmp/allowlist_file_part_line_count) > \
+				/tmp/allowlist.${allowlist_id}
+
+			allowlist_file_part_size_KB=$(( ($(cat /tmp/allowlist_file_part_size_B 2>/dev/null) + 0) / 1024 ))
+			allowlist_file_part_line_count="$(cat /tmp/allowlist_file_part_line_count 2>/dev/null)"
+			: "${allowlist_file_part_line_count:=0}"
+			rm -f /tmp/allowlist_file_part_size_B /tmp/allowlist_file_part_line_count
+
+			if ! grep -q "Download completed" /tmp/uclient-fetch_err
 			then
-				allowlist_file_part_size_KB=$(get_file_size_KB /tmp/allowlist.${allowlist_id})
-				log_msg "Download of new allowlist file part from: ${allowlist_url} succeeded (downloaded file size: ${allowlist_file_part_size_KB} KB)."
-				log_msg "Sanitizing allowlist file part."
-				# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Add newline
-				allowlist_file_part_line_count="$(tr 'A-Z' 'a-z' < /tmp/allowlist.${allowlist_id} | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; $a\' | tee -a /tmp/allowlist | wc -l)"
-				if [[ "${allowlist_file_part_line_count}" -gt 0 ]]
-				then
-					log_msg "Sanitized allowlist file part line count: ${allowlist_file_part_line_count}."
-				else
-					log_msg "No lines remaining in allowlist file part after sanitization."
-				fi
-				allowlist_line_count=$(( allowlist_line_count + allowlist_file_part_line_count))
-				rm -f  /tmp/allowlist.${allowlist_id}
-				allowlist_id=$((allowlist_id+1))
-				continue 2
-			else
 				log_msg "Download of new allowlist file part from: ${allowlist_url} failed."
 				log_msg "Sleeping for 5 seconds after failed download attempt."
 				sleep 5
 				continue
 			fi
+
+			log_msg "Download of new allowlist file part from: ${allowlist_url} succeeded (downloaded file size: ${allowlist_file_part_size_KB} KB)."
+
+			if [[ "${allowlist_file_part_line_count}" -gt 0 ]]
+			then
+				log_msg "Sanitized allowlist file part line count: ${allowlist_file_part_line_count}."
+				allowlist_line_count=$(( allowlist_line_count + allowlist_file_part_line_count ))
+				cat "/tmp/allowlist.${allowlist_id}" >> /tmp/allowlist
+			else
+				log_msg "No lines remaining in allowlist file part after sanitization."
+			fi
+
+			rm -f  "/tmp/allowlist.${allowlist_id}"
+			allowlist_id=$(( allowlist_id + 1 ))
+			continue 2
 		done
 		log_msg "Download failed after three failed download attempts. Continuing further operation."
 	done
 
 	rm -f /tmp/allowlist.*
 
-	if [[ -f "/tmp/allowlist" ]] && [[ $allowlist_line_count -gt 0 ]]
+	if [[ -f /tmp/allowlist ]] && [[ $allowlist_line_count -gt 0 ]]
 	then
 		log_msg "Successfully generated allowlist with ${allowlist_line_count} lines."
 		log_msg "Will remove any (sub)domain matches present in the generated allowlist from the blocklist file part(s) and append corresponding server entries to the combined blocklist."
@@ -294,84 +303,89 @@ generate_preprocessed_blocklist_file_parts()
 	else
 		log_msg "No local blocklist identified."
 	fi
-	
+
 	[[ -n "${blocklist_urls}" ]] && log_msg "Downloading new blocklist file part(s)."
 
 	preprocessed_blocklist_line_count=0
 	blocklist_id=1
 	for blocklist_url in ${blocklist_urls}
 	do
-		retry=0
+		retry=1
 		while [[ "$retry" -le "$max_download_retries" ]]
 		do
 			retry=$((retry + 1))
-			log_msg "Downloading new blocklist file part from: ${blocklist_url}."
-			uclient-fetch "${blocklist_url}" -O- --timeout=2 2> /tmp/uclient-fetch_err | head -c "${max_blocklist_file_part_size_KB}k" > "/tmp/blocklist.${blocklist_id}"
-			if grep -q "Download completed" /tmp/uclient-fetch_err
+			log_msg "Downloading, checking and sanitizing new blocklist file part from: ${blocklist_url}."
+			uclient-fetch "${blocklist_url}" -O- --timeout=2 2> /tmp/uclient-fetch_err | head -c "${max_blocklist_file_part_size_KB}k" |
+			tee >(wc -c > /tmp/blocklist_part_size_B) |
+			# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Convert to local=; 5 Add newline
+			tr 'A-Z' 'a-z' | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; s/^\(address=\|server=\)/local=/; $a\' |
+			if [[ "${use_allowlist}" == 1 ]]
 			then
-				blocklist_file_part_size_KB=$(get_file_size_KB /tmp/blocklist.${blocklist_id})
-				blocklist_file_part_line_count=$(grep -vEc '^\s*$|^#' /tmp/blocklist.${blocklist_id})
-
-				if [[ "${blocklist_file_part_line_count}" -ge "${min_blocklist_file_part_line_count}" ]]
-				then
-					log_msg "Download of new blocklist file part from: ${blocklist_url} succeeded (downloaded file size: ${blocklist_file_part_size_KB} KB; line count: ${blocklist_file_part_line_count})."
-
-					log_msg "Sanitizing blocklist file part."
-
-					# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Convert to local=; 5 Add newline
-					tr 'A-Z' 'a-z' < /tmp/blocklist.${blocklist_id} | sed 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d; s/^\(address=\|server=\)/local=/; $a\' |
-					if [[ "${use_allowlist}" == 1 ]]
-					then
-						${awk_cmd} -F'/' 'NR==FNR { allow[$0]; next } { n=split($2,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "/tmp/allowlist" -
-					else
-						cat
-					fi |
-
-					if [[ "${rogue_element_action}" != "IGNORE" ]] 
-					then
-						log_msg "Checking for any rogue elements."
-						tee >(grep -Evn -m1 '^(local=/[[:alnum:]*][[:alnum:]*_.-]+/|bogus-nxdomain=[0-9.]+){0,1}$' > /tmp/rogue_element)
-					fi | gzip > "/tmp/blocklist.${blocklist_id}.gz"
-
-					if read -r rogue_element < /tmp/rogue_element
-					then
-						log_msg "Rogue element: '${rogue_element}' identified originating in blocklist file part from: ${blocklist_url}."
-
-						if [[ "${rogue_element_action}" == "STOP" ]]
-						then
-							return 1
-						else
-							log_msg "Skipping file part and continuing."
-							rm -f "/tmp/blocklist.${blocklist_id}" /tmp/rogue_element
-							continue 2
-						fi
-					fi
-
-					rm -f "/tmp/blocklist.${blocklist_id}" /tmp/rogue_element
-
-					preprocessed_blocklist_line_count=$(( preprocessed_blocklist_line_count + blocklist_file_part_line_count ))
-					blocklist_id=$((blocklist_id+1))
-					continue 2
-				else
-					log_msg "Downloaded blocklist file part line count: ${blocklist_file_part_line_count} less than configured minimum: ${min_blocklist_file_part_line_count}."
-					break
-				fi
+				${awk_cmd} -F'/' 'NR==FNR { allow[$0]; next } { n=split($2,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' /tmp/allowlist -
 			else
+				cat
+			fi |
+			tee >(wc -l > /tmp/blocklist_part_line_count) |
+
+			if [[ "${rogue_element_action}" != "IGNORE" ]]
+			then
+				tee >(sed -nE '\~^(local=/[[:alnum:]*][[:alnum:]*_.-]+/$|bogus-nxdomain=[0-9.]+$|$)~d;p;:1 n;b1' > /tmp/rogue_element)
+			else
+				cat
+			fi | gzip > /tmp/blocklist.${blocklist_id}.gz
+
+			blocklist_file_part_size_KB=$(( ($(cat /tmp/blocklist_part_size_B 2>/dev/null) + 0) / 1024 ))
+			blocklist_file_part_line_count="$(cat /tmp/blocklist_part_line_count 2>/dev/null)"
+			: "${blocklist_file_part_line_count:=0}"
+
+			rm -f /tmp/blocklist_part_size_B /tmp/blocklist_part_line_count
+
+			if ! grep -q "Download completed" /tmp/uclient-fetch_err
+			then
 				log_msg "Download of new blocklist file part from: ${blocklist_url} failed."
-				if [[ -f "/tmp/blocklist.${blocklist_id}" ]]
+				if [[ "${blocklist_file_part_size_KB}" -ge "${max_blocklist_file_part_size_KB}" ]]
 				then
-					blocklist_file_part_size_KB=$(get_file_size_KB /tmp/blocklist.${blocklist_id})
-					if [[ "${blocklist_file_part_size_KB}" -eq "${max_blocklist_file_part_size_KB}" ]]
-					then
 						log_msg "Downloaded blocklist file part size exceeded the maximum value set in config (${max_blocklist_file_part_size_KB} KB)."
 						log_msg "Consider either increasing this value in the config or removing the correasponding blocklist url."
 						break
-					fi
+				fi
+				log_msg "Sleeping for 5 seconds after failed download attempt."
+				sleep 5
+				continue
+			fi
+
+			if read -r rogue_element < /tmp/rogue_element
+			then
+				log_msg "Rogue element: '${rogue_element}' identified originating in blocklist file part from: ${blocklist_url}."
+
+				if [[ "${rogue_element_action}" == "STOP" ]]
+				then
+					return 1
+				else
+					log_msg "Skipping file part and continuing."
+					rm -f /tmp/rogue_element
+					continue 2
 				fi
 			fi
+
+			if [[ "${blocklist_file_part_line_count}" -ge "${min_blocklist_file_part_line_count}" ]]
+			then
+				log_msg "Download of new blocklist file part from: ${blocklist_url} succeeded (downloaded file size: ${blocklist_file_part_size_KB} KB; sanitized line count: ${blocklist_file_part_line_count})."
+
+				rm -f /tmp/rogue_element
+
+				preprocessed_blocklist_line_count=$(( preprocessed_blocklist_line_count + blocklist_file_part_line_count ))
+				blocklist_id=$((blocklist_id+1))
+				continue 2
+			else
+				log_msg "Downloaded blocklist file part line count: ${blocklist_file_part_line_count} less than configured minimum: ${min_blocklist_file_part_line_count}."
+				break
+			fi
+
 			log_msg "Sleeping for 5 seconds after failed download attempt."
 			sleep 5
 		done
+
 		if [[ "${download_failed_action}" == "STOP" ]]
 		then
 			log_msg "Exiting after three failed download attempts."


### PR DESCRIPTION
- Reduce processing time by starting to process data as it's getting downloaded
- Fix bug where if rogue_element_action is "IGNORE", gzip will receive an empty string rather than the blocklist

NOTE: more testing is recommended, especially testing under fault conditions (eg failed downloads, rogue elements, excessive file size or insufficient lines count)