### PR TITLE
Update default blocklists to Small 128mb routers.

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -207,7 +207,7 @@ gen_config()
 	# adblock-lean configuration options
 
 	# One or more dnsmasq blocklist urls separated by spaces
-	blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/dnsmasq/pro.txt https://raw.githubusercontent.com/hagezi/dns-blocklists/main/dnsmasq/tif-ips.txt"
+	blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/dnsmasq/pro.txt https://raw.githubusercontent.com/hagezi/dns-blocklists/main/dnsmasq/tif.mini.txt"
 
 	# One or more allowlist urls separated by spaces
 	allowlist_urls=""


### PR DESCRIPTION
Default to Small 128mb routers.

This is get most people up and running without issue. 

The current default includes TIF-IPS which is only beneficial for people running IPV4 solo.  Does not benefit users running IPV6.