### PR TITLE
Add luci_status function

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -34,6 +34,16 @@ adblock-lean custom commands:
 	gen_config	generate default config
 	update		update adblock-lean to the latest version"
 
+# Result values used by various functions.
+# If values are changed here, they must change in luci-app-adblock-lean as well (overview and status)
+RESULT_DNSMASQ_LOOKUP_FAILED=1
+RESULT_DNSMASQ_LOOKUP_QUADZERO=2
+RESULT_DNSMASQ_NOT_RUNNING=3
+RESULT_NOT_ACTIVE=4
+RESULT_UPDATE_CHECK_ERROR=5
+RESULT_UPDATE_CHECK_LATEST=6
+RESULT_UPDATE_CHECK_OUTDATED=7
+
 mkdir -p /var/run/adblock-lean
 
 trap cleanup_and_exit INT TERM EXIT
@@ -597,7 +607,7 @@ check_dnsmasq()
 	if ! pgrep -x /usr/sbin/dnsmasq &> /dev/null
 	then
 		log_msg -err "No instance of dnsmasq detected with new blocklist."
-		return 1
+		return $RESULT_DNSMASQ_NOT_RUNNING
 	fi
 
 	for domain in google.com amazon.com microsoft.com
@@ -605,11 +615,11 @@ check_dnsmasq()
 		if ! nslookup "${domain}" 127.0.0.1 &> /dev/null 
 		then
 			log_msg -err "Lookup of '${domain}' failed with new blocklist."
-			return 2
+			return $RESULT_DNSMASQ_LOOKUP_FAILED
 		elif nslookup "${domain}" 127.0.0.1 | grep -A1 ^Name | grep -q '^Address: *0\.0\.0\.0$'
 		then
 			log_msg -err "Lookup of '${domain}' resulted in 0.0.0.0 with new blocklist."
-			return 3
+			return $RESULT_DNSMASQ_LOOKUP_QUADZERO
 		fi
 	done
 	
@@ -845,7 +855,7 @@ luci_status()
 	msgs_dest="/dev/null"
 
 	# Default values, which may be updated below based on current status
-	status=4 # 4 = Not running (check_dnsmasq returns values 1-3 for its error status, so we start at 4 here)
+	status=$RESULT_NOT_ACTIVE
 	good_line_count=0
 	secs_since_blocklist_update=0
 
@@ -902,7 +912,7 @@ resume()
 
 check_for_updates()
 {
-	result=0
+	result=$RESULT_UPDATE_CHECK_ERROR
 
 	sha256sum_adblock_lean_local=$(sha256sum /etc/init.d/adblock-lean | awk '{print $1}')
 	sha256sum_adblock_lean_remote=$(uclient-fetch https://raw.githubusercontent.com/lynxthecat/adblock-lean/master/adblock-lean -O - 2> /var/run/adblock-lean/uclient-fetch_update_check_err | sha256sum | awk '{print $1}')
@@ -912,15 +922,15 @@ check_for_updates()
 		if [[ "${sha256sum_adblock_lean_local}" == "${sha256sum_adblock_lean_remote}" ]]
 		then
 			log_msg "The locally installed adblock-lean is the latest version."
-			result=0
+			result=$RESULT_UPDATE_CHECK_LATEST
 		else
 			log_msg "The locally installed adblock-lean seems to be outdated."
 			log_msg "Consider running: 'service adblock-lean update' to update it to the latest version."
-			result=1
+			result=$RESULT_UPDATE_CHECK_OUTDATED
 		fi
 	else
 		log_msg -err "Unable to download latest version of adblock-lean to check for any updates."
-		result=2
+		result=$RESULT_UPDATE_CHECK_ERROR
 	fi
 	rm -f /var/run/adblock-lean/uclient-fetch_update_check_err
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -841,8 +841,10 @@ status()
 
 luci_status()
 {
+	# luci_status returns a json string, so we don't want any other functions printing to stdout
 	msgs_dest="/dev/null"
 
+	# Default values, which may be updated below based on current status
 	status=4 # 4 = Not running (check_dnsmasq returns values 1-3 for its error status, so we start at 4 here)
 	good_line_count=0
 	secs_since_blocklist_update=0
@@ -875,6 +877,11 @@ luci_status()
 	printf "  \"secs_since_blocklist_update\": ${secs_since_blocklist_update},\n"
 	printf "  \"update_status\": ${update_status}\n"
 	printf "}\n"
+
+	# Remove trap, so if we view status via luci while adblock-lean is processing the blocklist, we don't
+	# remove /var/run/adblock-lean here and cause problems there
+	trap - INT TERM EXIT
+	exit
 }
 
 pause()
@@ -898,9 +905,9 @@ check_for_updates()
 	result=0
 
 	sha256sum_adblock_lean_local=$(sha256sum /etc/init.d/adblock-lean | awk '{print $1}')
-	sha256sum_adblock_lean_remote=$(uclient-fetch https://raw.githubusercontent.com/lynxthecat/adblock-lean/master/adblock-lean -O - 2> /var/run/adblock-lean/uclient-fetch_err | sha256sum | awk '{print $1}')
+	sha256sum_adblock_lean_remote=$(uclient-fetch https://raw.githubusercontent.com/lynxthecat/adblock-lean/master/adblock-lean -O - 2> /var/run/adblock-lean/uclient-fetch_update_check_err | sha256sum | awk '{print $1}')
 
-	if grep -q "Download completed" /var/run/adblock-lean/uclient-fetch_err
+	if grep -q "Download completed" /var/run/adblock-lean/uclient-fetch_update_check_err
 	then
 		if [[ "${sha256sum_adblock_lean_local}" == "${sha256sum_adblock_lean_remote}" ]]
 		then
@@ -915,7 +922,7 @@ check_for_updates()
 		log_msg -err "Unable to download latest version of adblock-lean to check for any updates."
 		result=2
 	fi
-	rm -f /var/run/adblock-lean/uclient-fetch_err
+	rm -f /var/run/adblock-lean/uclient-fetch_update_check_err
 
 	return $result
 }

--- a/adblock-lean
+++ b/adblock-lean
@@ -845,6 +845,7 @@ luci_status()
 
 	status=4 # 4 = Not running (check_dnsmasq returns values 1-3 for its error status, so we start at 4 here)
 	good_line_count=0
+	secs_since_blocklist_update=0
 
 	if [[ -f /tmp/dnsmasq.d/.blocklist.gz || -f /tmp/dnsmasq.d/blocklist ]]
 	then
@@ -856,9 +857,11 @@ luci_status()
 			if [[ -f /tmp/dnsmasq.d/.blocklist.gz ]]
 			then
 				good_line_count=$(gunzip -c /tmp/dnsmasq.d/.blocklist.gz | wc -l)
+				secs_since_blocklist_update=$(($(date +%s) - $(date -r /tmp/dnsmasq.d/.blocklist.gz +%s)))
 			elif [[ -f /tmp/dnsmasq.d/blocklist ]]
 			then
 				good_line_count=$(wc -l /tmp/dnsmasq.d/blocklist)
+				secs_since_blocklist_update=$(($(date +%s) - $(date -r /tmp/dnsmasq.d/blocklist +%s)))
 			fi
 		fi
 	fi
@@ -869,6 +872,7 @@ luci_status()
 	printf "{\n"
 	printf "  \"status\": ${status},\n"
 	printf "  \"good_line_count\": \"$(int2human ${good_line_count})\",\n"
+	printf "  \"secs_since_blocklist_update\": ${secs_since_blocklist_update},\n"
 	printf "  \"update_status\": ${update_status}\n"
 	printf "}\n"
 }

--- a/adblock-lean
+++ b/adblock-lean
@@ -24,7 +24,7 @@ export HOME=/root
 START=99
 STOP=4
 
-EXTRA_COMMANDS="status pause resume gen_stats gen_config update"
+EXTRA_COMMANDS="status luci_status pause resume gen_stats gen_config update"
 EXTRA_HELP="	
 adblock-lean custom commands:
 	status		check dnsmasq and good line count of existing blocklist
@@ -605,11 +605,11 @@ check_dnsmasq()
 		if ! nslookup "${domain}" 127.0.0.1 &> /dev/null 
 		then
 			log_msg -err "Lookup of '${domain}' failed with new blocklist."
-			return 1
+			return 2
 		elif nslookup "${domain}" 127.0.0.1 | grep -A1 ^Name | grep -q '^Address: *0\.0\.0\.0$'
 		then
 			log_msg -err "Lookup of '${domain}' resulted in 0.0.0.0 with new blocklist."
-			return 1
+			return 3
 		fi
 	done
 	
@@ -839,6 +839,40 @@ status()
 	check_for_updates
 }
 
+luci_status()
+{
+	msgs_dest="/dev/null"
+
+	status=4 # 4 = Not running (check_dnsmasq returns values 1-3 for its error status, so we start at 4 here)
+	good_line_count=0
+
+	if [[ -f /tmp/dnsmasq.d/.blocklist.gz || -f /tmp/dnsmasq.d/blocklist ]]
+	then
+		check_dnsmasq
+		status=$?
+
+		if [[ $status -eq 0 ]]
+		then
+			if [[ -f /tmp/dnsmasq.d/.blocklist.gz ]]
+			then
+				good_line_count=$(gunzip -c /tmp/dnsmasq.d/.blocklist.gz | wc -l)
+			elif [[ -f /tmp/dnsmasq.d/blocklist ]]
+			then
+				good_line_count=$(wc -l /tmp/dnsmasq.d/blocklist)
+			fi
+		fi
+	fi
+
+	check_for_updates
+	update_status=$?
+
+	printf "{\n"
+	printf "  \"status\": ${status},\n"
+	printf "  \"good_line_count\": \"$(int2human ${good_line_count})\",\n"
+	printf "  \"update_status\": ${update_status}\n"
+	printf "}\n"
+}
+
 pause()
 {
 	log_msg "Received pause request."
@@ -857,6 +891,8 @@ resume()
 
 check_for_updates()
 {
+	result=0
+
 	sha256sum_adblock_lean_local=$(sha256sum /etc/init.d/adblock-lean | awk '{print $1}')
 	sha256sum_adblock_lean_remote=$(uclient-fetch https://raw.githubusercontent.com/lynxthecat/adblock-lean/master/adblock-lean -O - 2> /var/run/adblock-lean/uclient-fetch_err | sha256sum | awk '{print $1}')
 
@@ -865,14 +901,19 @@ check_for_updates()
 		if [[ "${sha256sum_adblock_lean_local}" == "${sha256sum_adblock_lean_remote}" ]]
 		then
 			log_msg "The locally installed adblock-lean is the latest version."
+			result=0
 		else
 			log_msg "The locally installed adblock-lean seems to be outdated."
 			log_msg "Consider running: 'service adblock-lean update' to update it to the latest version."
+			result=1
 		fi
 	else
 		log_msg -err "Unable to download latest version of adblock-lean to check for any updates."
+		result=2
 	fi
 	rm -f /var/run/adblock-lean/uclient-fetch_err
+
+	return $result
 }
 
 update()


### PR DESCRIPTION
This returns status information as a json string, which the luci app can use to display a status table. 
Also modifies two other functions to return unique exit codes for different status conditions.