### PR TITLE
Use pipe for sort version check

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -711,7 +711,7 @@ start()
 		awk_cmd="awk"
 	fi
 
-	if grep <(sort --version) -qe coreutils
+	if sort --version 2>/dev/null | grep -qe coreutils
 	then
 		log_msg "coreutils-sort detected so sort will be fast."
 	else


### PR DESCRIPTION
Replace non-POSIX syntax (process substitution) with POSIX syntax, redirect STDERR from `sort --version` to `/dev/null`