### PR TITLE
Consolidate processing of local and downloaded list parts

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -449,7 +449,7 @@ load_config()
 
 	[ -z "${conf_fixes}" ] && { reg_failure "Failed to parse config."; return 1; }
 
-	if [ "${msgs_dest}" = "/dev/tty" ]
+	if [ "${msgs_dest}" = "/dev/tty" ] && [ "${1}" != '-f' ]
 	then
 		echo
 		print_msg "${blue}Perform following automatic changes?${n_c}"
@@ -625,69 +625,86 @@ cleanup_dl_status_files()
 	rm -f "${abl_dir}/rogue_element" "${abl_dir}/dnsmasq_err" "${abl_dir}/uclient-fetch_err"
 }
 
-# removes allowlist domains from STDIN, outputs to STDOUT
-# 1 - path to allowlist file
-rm_allow_domains()
-{
-	${awk_cmd} -F'/' 'NR==FNR { sub(/^server=\//,""); sub(/\/#$/,""); allow[$0]; next } { n=split($2,arr,"."); addr = arr[n]; \
-							for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "${1}" -
-}
-
 # 1 - list id
 # 2 - list type (allowlist or blocklist)
-# 3 - list URL
+# 3 - list origin (local or downloaded)
+# 4 - local list path (for local lists) or URL (for downloaded lists)
 #
 # return codes:
 # 0 - Success
 # 1 - General error (stop processing)
 # 2 - Bad List (retry doesn't make sense)
 # 3 - Download Failure (retry makes sense)
-download_and_process_list_part()
+process_list_part()
 {
-	local list_id="${1}" list_type="${2}" list_url="${3}" me="download_and_process_list_part"
+	local list_id="${1}" list_type="${2}" list_origin="${3}" list_path="${4}" me="process_list_part"
 	local dest_file="${abl_dir}/${list_type}.${list_id}" compress='' \
 		min_list_part_line_count='' list_part_size_B='' list_part_size_KB=''
 	local sed_rogue_expr='(\*|[[:alnum:]_-]+)([.][[:alnum:]_-]+)+' sed_conv_expr=''
 
-	[ -z "${list_id}" ] && { reg_failure "${me}: No list id specified."; return 1; }
+	[ -z "${list_id}" ] || [ -z "${list_origin}" ] || [ -z "${list_path}" ] && { reg_failure "${me}: Missing arguments."; return 1; }
 	case ${list_type} in
 		allowlist)
 			sed_rogue_expr="^(server=/${sed_rogue_expr}/#$|$)"
-			sed_conv_expr='s~.*~server=/&/#~' ;;
+			sed_conv_expr='s~.*~server=/&/#~'
+			[ "${list_origin}" = local ] && dest_file="${abl_dir}/allowlist" ;;
 		blocklist)
 			sed_rogue_expr="^(local=/${sed_rogue_expr}/$|bogus-nxdomain=[0-9]+([.][0-9]+)+$|$)"
-			sed_conv_expr="s/^address=/local=/"
+			case ${list_origin} in
+				local) sed_conv_expr="s~.*~local=/&/~" ;;
+				downloaded) sed_conv_expr="s/^address=/local=/"
+			esac
+
 			dest_file="${dest_file}.gz"
 			compress=1 ;;
 		*) reg_failure "${me}: Missing or invalid list type '${list_type}'"; return 1
 	esac
-	[ -z "${list_url}" ] && { reg_failure "${me}: no URL specified."; return 1; }
 
 	eval "min_list_part_line_count=\"\${min_${list_type}_part_line_count}\""
 
 	cleanup_dl_status_files
 
-	reg_action "Downloading, checking and sanitizing new ${list_type} file part from: ${list_url}." || return 1
-	uclient-fetch "${list_url}" -O- --timeout=3 2> "${abl_dir}/uclient-fetch_err" | 
+	# Download or cat the list
+	case "${list_origin}" in
+		downloaded) uclient-fetch "${list_path}" -O- --timeout=3 2> "${abl_dir}/uclient-fetch_err";;
+		local) cat "${list_path}"
+	esac |
 	{ head -c "${max_file_part_size_KB}k"; cat 1>/dev/null; } |
+
+	# Count bytes
 	tee >(wc -c > "${abl_dir}/list_part_size_B") |
-	# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace
-	# 4 Convert blocklist to 'local=/[domain]/', allowlist to 'server=/[domain]/#'
+
+	# 1 Convert to lowercase; 2 Remove comment lines and trailing comments, remove whitespaces
+	# 3 Convert blocklist to 'local=/[domain]/', allowlist to 'server=/[domain]/#'
 	tr 'A-Z' 'a-z' | sed "${sed_san_expr}; ${sed_conv_expr}" |
+
 	if [ "${list_type}" = blocklist ] && [ "${use_allowlist}" = 1 ]
 	then
-		rm_allow_domains "${abl_dir}/allowlist"
+		# remove allowlist domains from blocklist
+		${awk_cmd} -F'/' 'NR==FNR { sub(/^server=\//,""); sub(/\/#$/,""); allow[$0]; next } { n=split($2,arr,"."); addr = arr[n]; \
+								for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "${abl_dir}/allowlist" -
 	else
 		cat
 	fi |
 	tee >(wc -w > "${abl_dir}/list_part_line_count") |
-	tee >(sed -nE "\~${sed_rogue_expr}~d;p;:1 n;b1" > "${abl_dir}/rogue_element") |
+
+	# check downloaded lists for rogue elements
+	if [ "${list_origin}" = downloaded ]
+	then
+		tee >(sed -nE "\~${sed_rogue_expr}~d;p;:1 n;b1" > "${abl_dir}/rogue_element")
+	else
+		cat
+	fi |
+
+	# compress blocklist parts
 	if [ -n "${compress}" ]
 	then
 		tee >(gzip > "${dest_file}")
 	else
 		tee "${dest_file}"
 	fi |
+
+	# check parts with dnsmasq --test
 	{ dnsmasq --test -C - 2> "${abl_dir}/dnsmasq_err" && rm -f "${abl_dir}/dnsmasq_err"; cat 1>/dev/null; }
 
 	read -r list_part_size_B _ < "${abl_dir}/list_part_size_B" 2>/dev/null
@@ -700,24 +717,24 @@ download_and_process_list_part()
 
 	if [ "${list_part_size_KB}" -ge "${max_file_part_size_KB}" ]
 	then
-		reg_failure "Downloaded ${list_type} part size reached the maximum value set in config (${max_file_part_size_KB} KB)."
-		log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} url."
+		reg_failure "${list_origin} ${list_type} part size reached the maximum value set in config (${max_file_part_size_KB} KB)."
+		log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config."
 		log_msg "Skipping ${list_type} part and continuing."
 		rm -f "${dest_file}"
 		return 2
 	fi
 
-	if ! grep -q "Download completed" "${abl_dir}/uclient-fetch_err"
+	if [ "${list_origin}" = downloaded ] && ! grep -q "Download completed" "${abl_dir}/uclient-fetch_err"
 	then
 		rm -f "${dest_file}"
-		reg_failure "Download of new ${list_type} file part from: ${list_url} failed."
+		reg_failure "Download of new ${list_type} file part from: ${list_path} failed."
 		return 3
 	fi
 
-	if read -r rogue_element < "${abl_dir}/rogue_element"
+	if [ "${list_origin}" = downloaded ] && read -r rogue_element < "${abl_dir}/rogue_element"
 	then
 		rm -f "${dest_file}"
-		log_msg -warn "Rogue element: '${rogue_element}' identified originating in ${list_type} file part from: ${list_url}."
+		log_msg -warn "Rogue element: '${rogue_element}' identified originating in ${list_type} file part from: ${list_path}."
 		return 2
 	fi
 	rm -f "${abl_dir}/rogue_element"
@@ -726,13 +743,14 @@ download_and_process_list_part()
 	then
 		rm -f "${dest_file}"
 		reg_failure "The dnsmasq --test on the ${list_type} part failed."
-		log_msg "dnsmasq --test error:"
-		log_msg "$(cat "${abl_dir}/dnsmasq_err")"
+		log_msg "dnsmasq --test errors:"
+		log_msg "$(head -n10 "${abl_dir}/dnsmasq_err")"
+		rm -f "${abl_dir}/dnsmasq_err"
 		return 2
 	fi
 	rm -f "${abl_dir}/dnsmasq_err"
 
-	if [ "${list_part_line_count}" -lt "${min_list_part_line_count}" ]
+	if [ "${list_origin}" = downloaded ] && [ "${list_part_line_count}" -lt "${min_list_part_line_count}" ]
 	then
 		rm -f "${dest_file}"
 		reg_failure "Downloaded ${list_type} part line count: $(int2human ${list_part_line_count}) less than configured minimum: $(int2human ${min_list_part_line_count})."
@@ -740,107 +758,99 @@ download_and_process_list_part()
 	fi
 
 	cleanup_dl_status_files
-	log_msg "Processing of new ${list_type} part from: ${list_url} succeeded."
-	log_msg "Downloaded file size: ${list_part_size_human}; sanitized line count: $(int2human ${list_part_line_count})."
-
 	:
 }
 
 gen_list_parts()
 {
-	local list_type='' list_id list_line_count=0 list_part_line_count=0 and_compressing='' sed_expr_local list_urls list_url local_list_path
+	# 1 - list origin (local or downloaded)
+	log_process_success()
+	{
+		local part=
+		[ "${1}" = downloaded ] && part=" part"
+		log_msg "Successfully processed ${1} ${list_type}${part} (source file size: ${list_part_size_human}, sanitized line count: $(int2human ${list_part_line_count}))."
+	}
+
+	handle_process_failure()
+	{
+		[ "${list_part_failed_action}" = "STOP" ] && { log_msg "list_part_failed_action is set to 'STOP', exiting."; return 1; }
+		log_msg "Skipping file part and continuing."
+		:
+	}
+
+	local list_type='' list_id list_line_count list_part_line_count and_compressing='' list_urls list_url local_list_path
 
 	for list_type in allowlist blocklist
 	do
-		case ${list_type} in
-			allowlist) sed_expr_local="${sed_san_expr}; s~.*~server=/&/#~" ;;
-			blocklist)
-				sed_expr_local="${sed_san_expr}; s~.*~local=/&/~"
-				and_compressing=" and compressing"
-		esac
-		list_id=0
-
 		rm -f "${abl_dir}/${list_type}"*
+		list_id=0 list_line_count=0 list_part_line_count=0
+		and_compressing=
+		[ ${list_type} = blocklist ] && and_compressing=" and compressing"
 
 		# Local list
-		echo
 		eval "local_list_path=\"\${local_${list_type}_path}\""
-		eval "list_urls=\"\${${list_type}_urls}\""
-
-		if [ -s "${local_list_path}" ]
+		if [ ! -f "${local_list_path}" ]
 		then
-			log_msg -blue "Found local ${list_type}. Sanitizing${and_compressing}."
-			reg_action -nolog "Sanitizing${and_compressing} the local ${list_type}." || return 1
-			# 1 Convert to lowercase; 2 Remove comment lines and trailing comments; 3 Remove trailing address hash, and all whitespace; 4 Add newline
-			list_part_line_count="$(
-				tr 'A-Z' 'a-z' < "${local_list_path}" | sed "${sed_expr_local}" |
-				if [ "${list_type}" = blocklist ]
-				then
-					if [ "${use_allowlist}" = 1 ]
-					then
-						rm_allow_domains "${abl_dir}/allowlist"
-					else
-						cat
-					fi |
-					tee >(gzip > "${abl_dir}/blocklist.${list_id}.gz")
-				else
-					tee -a "${abl_dir}/allowlist"
-				fi | wc -w
-			)"
-			: "${list_part_line_count:=0}"
-			case ${list_part_line_count} in
-				''|*[!0-9]*) reg_failure "Failed to process local ${list_type}."; return 1 ;;
-				0) log_msg -warn "No lines remaining in local ${list_type} after sanitization." ;;
-				*)
-					log_msg "Sanitized local ${list_type} line count: $(int2human ${list_part_line_count})."
-					list_line_count=$(( list_line_count + list_part_line_count ))
-			esac
-		elif [ -f "${local_list_path}" ]
+			log_msg -blue "No local ${list_type} identified."
+		elif [ ! -s "${local_list_path}" ]
 		then
 			log_msg -warn "Local ${list_type} file is empty."
 		else
-			log_msg -blue "No local ${list_type} identified."
+			echo
+			log_msg -blue "Found local ${list_type}. Sanitizing${and_compressing}."
+			reg_action -nolog "Sanitizing${and_compressing} the local ${list_type}." || return 1
+			process_list_part "${list_id}" "${list_type}" "local" "${local_list_path}"
+			case ${?} in
+				0)
+					log_process_success "local"
+					list_line_count=$(( list_line_count + list_part_line_count )) ;;
+				*)
+					handle_process_failure || return 1
+			esac
 		fi
 
-		echo
 		# List parts download
-		if [ -n "${list_urls}" ]
+		eval "list_urls=\"\${${list_type}_urls}\""
+		if [ -z "${list_urls}" ]
 		then
-			reg_action -blue "Downloading new ${list_type} file part(s)." || return 1
-		elif [ "${list_type}" = blocklist ]
-		then
-			log_msg -yellow "NOTE: No URLs specified for blocklist download. Skipping download."
+			[ "${list_type}" = blocklist ] && log_msg -yellow "NOTE: No URLs specified for blocklist download. Skipping download."
+		else
+			echo
+			reg_action -blue "Starting ${list_type} part(s) download." || return 1
 		fi
 
 		for list_url in ${list_urls}
 		do
+			reg_action "Downloading, checking and sanitizing ${list_type} part from: ${list_url}." || return 1
 			list_id=$((list_id+1))
 			retry=0
 			while :
 			do
 				retry=$((retry + 1))
-				download_and_process_list_part "${list_id}" "${list_type}" "${list_url}"
+				list_part_line_count=0
+				process_list_part "${list_id}" "${list_type}" "downloaded" "${list_url}"
 				case ${?} in
 					0)
-						list_line_count=$(( list_line_count + list_part_line_count ))
 						if [ "${list_type}" = allowlist ]
 						then
 							cat "${abl_dir}/${list_type}.${list_id}" >> "${abl_dir}/allowlist" ||
 								{ reg_failure "Failed to merge allowlist part."; return 1; }
+							rm -f "${abl_dir}/${list_type}.${list_id}"
 						fi
+						log_process_success "downloaded"
+						list_line_count=$(( list_line_count + list_part_line_count ))
 						continue 2 ;;
 					1) return 1 ;;
 					2)
-						[ "${list_part_failed_action}" = "STOP" ] && { reg_failure "list_part_failed_action is set to 'STOP', exiting."; return 1; }
-						log_msg "Skipping file part and continuing."
+						handle_process_failure || return 1
 						continue 2 ;;
 					3) ;;
 				esac
 
 				if [ "${retry}" -ge "${max_download_retries}" ]
 				then
-					[ "${list_part_failed_action}" = "STOP" ] && { reg_failure "Giving up after three failed download attempts."; return 1; }
-					log_msg "Skipping file part and continuing."
+					reg_failure "Three download attempts failed."
+					handle_process_failure || return 1
 					continue 2
 				fi
 
@@ -848,7 +858,6 @@ gen_list_parts()
 				sleep 5
 				continue
 			done
-
 		done
 
 		if [ "${list_line_count}" = 0 ] || { [ "${list_type}" = allowlist ] && [ ! -f "${abl_dir}/allowlist" ]; }
@@ -864,6 +873,7 @@ gen_list_parts()
 
 		if [ "${list_type}" = allowlist ]
 		then
+			echo
 			log_msg -green "Successfully generated allowlist with $(int2human ${list_line_count}) lines."
 			log_msg "Will remove any (sub)domain matches present in the allowlist from the blocklist and append corresponding server entries to the blocklist."
 			use_allowlist=1
@@ -877,18 +887,16 @@ gen_list_parts()
 generate_and_process_blocklist_file()
 {
 	echo
-	reg_action -blue "Sorting and merging the blocklist lines into a single blocklist file." || return 1
+	reg_action -blue "Sorting and merging the blocklist parts into a single blocklist file." || return 1
 
 	{
 		[ "${use_allowlist}" = 1 ] && cat "${abl_dir}/allowlist"
 		rm -f "${abl_dir}/allowlist"
 
 		find "${abl_dir}" -name 'blocklist.*.gz' -exec gunzip -c {} \; -exec rm -f {} \;
-	} | sort -u | sed -n '/^$/d;p' |
+	} | sort -u |
 	{ head -c "${max_blocklist_file_size_KB}k"; cat 1>/dev/null; } |
-	tee >(wc -w > "${abl_dir}/blocklist_file_line_count") |
-	tee >(wc -c > "${abl_dir}/blocklist_file_size_B") |
-	{ cat; printf '%s\n' "address=/adblocklean-test123.info/127.0.0.1"; } |
+	{ tee >(wc -wc > "${abl_dir}/blocklist_stats"); printf '%s\n' "address=/adblocklean-test123.info/127.0.0.1"; } |
 
 	if  [ "${compress_blocklist}" = 1 ]
 	then
@@ -897,10 +905,10 @@ generate_and_process_blocklist_file()
 		cat > "${abl_dir}/blocklist"
 	fi
 
-	good_line_count="$(cat "${abl_dir}/blocklist_file_line_count" 2>/dev/null)"
+	read -r good_line_count blocklist_file_size_B < "${abl_dir}/blocklist_stats" 2>/dev/null
+
 	: "${good_line_count:=0}"
 
-	blocklist_file_size_B="$(cat "${abl_dir}/blocklist_file_size_B" 2>/dev/null)"
 	blocklist_file_size_KB=$(( (blocklist_file_size_B + 0) / 1024 ))
 	blocklist_file_size_human="$(bytes2human "${blocklist_file_size_B}")"
 
@@ -1013,6 +1021,7 @@ restore_saved_blocklist()
 {
 	if [ -f "${abl_dir}/prev_blocklist.gz" ]
 	then
+		echo
 		reg_action -blue "Restoring saved blocklist file." || return 1
 		try_mv "${abl_dir}/prev_blocklist.gz" "${abl_dir}/blocklist.gz" || return 1
 		if [ "${compress_blocklist}" != 1 ]
@@ -1255,8 +1264,7 @@ init_command()
 			reg_action -purple "Stopping adblock-lean." || exit 1
 			cleanup_req=1 kill_req=1 lock_req=1 ;;
 		reload|restart)
-			reg_action -purple "Restarting adblock-lean." || exit 1
-			cleanup_req=1 kill_req=1 lock_req=1 ;;
+			reg_action -purple "Restarting adblock-lean." || exit 1 ;;
 		*)
 			reg_failure "Invalid action '${action}'."
 			exit 1
@@ -1275,7 +1283,7 @@ init_command()
 	fi
 
 	case ${action} in
-		help|gen_config|enable|disable|enabled|'') ;;
+		help|gen_config|enable|disable|enabled|restart|reload|'') ;;
 		*)
 			dnsmasq_tmp_d="$(uci get dhcp.@dnsmasq[0].confdir 2>/dev/null)"
 			: "${dnsmasq_tmp_d:=/tmp/dnsmasq.d}"
@@ -1287,7 +1295,7 @@ init_command()
 	fi
 
 	case ${action} in
-		help|gen_config|enable|disable|enabled|stop|'') ;;
+		help|gen_config|enable|disable|enabled|stop|restart|reload|'') ;;
 		status) mkdir -p "${abl_dir}" ;;
 		*)
 			check_dnsmasq_instance || exit 1
@@ -1339,10 +1347,11 @@ boot()
 	start "$@"
 }
 
-start() 
+start()
 {
 	init_command start || exit 1
 	log_msg -purple "Started adblock-lean."
+	echo
 
 	if type gawk &> /dev/null
 	then
@@ -1391,6 +1400,7 @@ start()
 		exit 1
 	fi
 
+	echo
 	log_msg -green "Successfully generated preprocessed blocklist file with $(int2human ${preprocessed_blocklist_line_count}) lines."
 
 	if ! generate_and_process_blocklist_file
@@ -1575,17 +1585,13 @@ resume()
 	exit 0
 }
 
+# 1 - (optional) '-no-check-config' to skip checking config compatibility with the newer version
 update()
 {
-	log_fallback()
+	failsafe_log()
 	{
-		if command -v log_msg
-		then
-			log_msg "${1}"
-		else
-			printf '%s\n' "${1}" > "${msgs_dest:-/dev/tty}"
-			logger -t adblock-lean "${1}"
-		fi
+		printf '%s\n' "${1}" > "${msgs_dest:-/dev/tty}"
+		logger -t adblock-lean "${1}"
 	}
 
 	init_command update || exit 1
@@ -1599,27 +1605,30 @@ update()
 		exit 1
 	fi
 
-	(
-		prev_config_format="${curr_config_format}"
-		. "${abl_dir}/adblock-lean.latest" || exit 1
-		command -v print_def_config && command -v get_config_format && upd_config_format="$(print_def_config | get_config_format)"
-		if [ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && [ "${upd_config_format}" != "${prev_config_format}" ]
-		then
-			log_fallback "NOTE: config format has changed."
-			if command -v load_config
+	if [ "${1}" != '-no-check-config' ]
+	then
+		(
+			prev_config_format="${curr_config_format}"
+			. "${abl_dir}/adblock-lean.latest" || exit 1
+			command -v print_def_config && command -v get_config_format && upd_config_format="$(print_def_config | get_config_format)"
+			if [ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && [ "${upd_config_format}" != "${prev_config_format}" ]
 			then
-				load_config
-			else
-				log_fallback "Please run 'service adblock-lean start' to initialize the new config."
+				failsafe_log "NOTE: config format has changed."
+				if command -v load_config
+				then
+					load_config
+				else
+					failsafe_log "Please run 'service adblock-lean start' to initialize the new config."
+				fi
 			fi
-		fi
-		:
-	) 1>/dev/null ||
-	{
-		report_failure "Failed to source the downloaded file. Canceling the update."
-		rm -f "${abl_dir}/adblock-lean.latest"
-		exit 1
-	}
+			:
+		) 1>/dev/null ||
+		{
+			report_failure "Failed to source the downloaded file. Canceling the update."
+			rm -f "${abl_dir}/adblock-lean.latest"
+			exit 1
+		}
+	fi
 
 	try_mv "${abl_dir}/adblock-lean.latest" /etc/init.d/adblock-lean || exit 1
 	chmod +x /etc/init.d/adblock-lean


### PR DESCRIPTION
- download_and_process_list_part() - rename function to process_list_part()
- rm_allow_domains(): remove function - code integrated into process_list_part()
- process_list_part(): add functionality to process local list parts
- process_list_part(): limit logging dnsmasq errors to 10 first lines
- gen_list_parts(): log_process_sucess(): add function
- gen_list_parts(): handle_process_failure(): add function
- gen_list_parts(): adapt to call process_list_part() for both local and downloaded lists
- gen_list_parts(): delete downloaded allowlist parts after merging them into the main allowlist file
- init_command(): reload, restart actions: don't set cleanup_req=1 kill_req=1 lock_req=1 (requirements are handled when initializing stop() and start() functions)
- init_command(): reload, restart actions: don't detect dnsmasq dir (detection is handled when initializing stop() and start() functions)
- init_command(): reload, restart actions: don't call check_dnsmasq_instance (check is handled when initializing the start() function and shouldn't be performed before calling the stop() function)
- some improvements to console output (additional spacers, more laconic messages)

Main changes are in gen_list_parts(), process_list_part(). The init_command() changes are intended to a. avoid performing unnecessary operations when action is reload or restart, and b. to avoid calling check_dnsmasq_instance() when action is restart or reload, because otherwise that check may fail if dnsmasq crashed because of a prior issue, which would cause the restart or reload action to fail, which would be unwanted.

Needs more testing, of course.