### PR TITLE
Automated setup

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -2165,7 +2165,7 @@ status()
 	then
 		active_entries_cnt="$(get_active_entries_cnt)" || reg_failure "No entries found in the blocklist file."
 
-		luci_min_good_line_count=${active_entries_cnt}
+		luci_good_line_count=${active_entries_cnt}
 		log_msg "The dnsmasq check passed and the presently installed blocklist has entries count: $(int2human ${active_entries_cnt})."
 		log_msg -green "adblock-lean is active."
 		gen_stats -noexit

--- a/adblock-lean
+++ b/adblock-lean
@@ -716,12 +716,12 @@ load_config()
 	[ ${parse_res} = 0 ] && [ -z "${url_conv_req}" ] && return 0
 
 	# if not in interactive console, return error
-	[ "${msgs_dest}" != "/dev/tty" ] && [ "${1}" != '-f' ] && { log_msg "${tip_msg}"; return 1; }
+	{ [ "${msgs_dest}" != "/dev/tty" ] || [ -n "${luci_skip_dialogs}" ]; } && [ "${1}" != '-f' ] && { log_msg "${tip_msg}"; return 1; }
 
 	# sanity check
 	[ -z "${conf_fixes}" ] && [ -z "${url_conv_req}" ] && { reg_failure "Failed to parse config."; return 1; }
 
-	if [ "${msgs_dest}" = "/dev/tty" ] && [ "${1}" != '-f' ]
+	if [ "${msgs_dest}" = "/dev/tty" ] && [ -z "${luci_skip_dialogs}" ] && [ "${1}" != '-f' ]
 	then
 		if [ -n "${conf_fixes}" ]
 		then
@@ -816,7 +816,7 @@ fix_config()
 	if ! cp "${actual_config_file}" "${old_config_f}"
 	then
 		reg_failure "Failed to save old config file as ${old_config_f}."
-		[ "${msgs_dest}" != "/dev/tty" ] && return 1
+		[ "${msgs_dest}" != "/dev/tty" ] || [ -n "${luci_skip_dialogs}" ] && return 1
 		log_msg "Proceed with suggested config changes?"
 		pick_opt "y|n" || return 1
 		[ "${REPLY}" = n ] && return 1
@@ -1860,9 +1860,10 @@ init_command()
 # 2 - (optional) '-n' to print nothing (only assign values to vars)
 gen_preset()
 {
-	local val field mem i=1
-	eval "mem=\"\${${1}_mem}\""
-	[ "${2}" = '-d' ] && print_msg "" "Preset \"${purple}${1}${n_c}\": recommended for devices with ${mem} MB of memory."
+	local val field mem cnt i=1
+	eval "mem=\"\${${1}_mem}\" cnt=\"\${${1}_cnt}\""
+	[ "${2}" = '-d' ] && print_msg "" "${purple}${1}${n_c}: recommended for devices with ${mem} MB of memory."
+	[ "${2}" != '-n' ] && print_msg "${blue}Elements count:${n_c} ~${cnt}k"
 	for field in blocklist_urls max_file_part_size_KB max_blocklist_file_size_KB min_good_line_count
 	do
 		eval "val=\"\${${1}_${i}}\""
@@ -1898,30 +1899,36 @@ gen_config()
 {
 	init_command gen_config || exit 1
 
-	# default presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count
-	local mini_1="${hagezi_dl_url}/pro.mini-onlydomains.txt" mini_2=4000 mini_3=4000 mini_4=40000 mini_mem=64
-	local small_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" small_2=7000 small_3=10000 small_4=100000 small_mem=128
+	# quasi-arrays for default presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count, cnt - elements count/1000, mem - memory in MB
+	local mini_1="${hagezi_dl_url}/pro.mini-onlydomains.txt" \
+		mini_2=4000 mini_3=4000 mini_4=40000 mini_cnt=85 mini_mem=64
+	local small_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" \
+		small_2=7000 small_3=10000 small_4=100000 small_cnt=250 small_mem=128
 	local medium_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.medium-onlydomains.txt ${hagezi_dl_url}/popupads-onlydomains.txt" \
-		medium_2=10000 medium_3=20000 medium_4=200000 medium_mem=256
-	local large_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" large_2=30000 large_3=50000 large_4=200000 large_mem=512
-	local preset mem
+		medium_2=10000 medium_3=20000 medium_4=200000 medium_cnt=350 medium_mem=256
+	local large_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" \
+		large_2=30000 large_3=50000 large_4=200000 large_cnt=700 large_mem=512
 
+	local preset mem totalmem cnt
+
+	# determine recommended preset
 	read -r _ totalmem _ </proc/meminfo
 	for preset in large medium small mini
 	do
 		eval "mem=\"\${${preset}_mem}\""
-		[ "${totalmem}" -ge $((mem * 922)) ] && break
+		# multiplying by 900 rather than 1024 to account for some memory not available to the kernel
+		[ "${totalmem}" -ge $((mem * 900)) ] && break
 	done
 
-	if [ -z "${luci_sourced}" ] && [ -z "${luci_preset}" ]
+	if [ -z "${luci_skip_dialogs}" ] && [ -z "${luci_preset}" ]
 	then
-		print_msg "" "Based on the total memory of this device, the recommended preset is ${purple}${preset}${n_c}:"
+		print_msg "" "Based on the total usable memory of this device ($(bytes2human $((totalmem*1024)) )), the recommended preset is ${purple}${preset}${n_c}:"
 		gen_preset "${preset}"
 		print_msg "" "[C]onfirm this preset or [p]ick another preset?"
 		pick_opt "c|p"
 		if [ "${REPLY}" = p ]
 		then
-			print_msg "" "All available presets:"
+			print_msg "" "${purple}All available presets:${n_c}"
 			for preset in mini small medium large
 			do
 				gen_preset "${preset}" -d
@@ -1931,11 +1938,11 @@ gen_config()
 			preset="${REPLY}"
 		fi
 	else
-		preset="${luci_preset}"
+		[ "${luci_preset}" != auto ] && preset="${luci_preset}"
 	fi
 
 	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1
-	if [ "${msgs_dest}" = "/dev/tty" ] && [ -f "${config_file}" ]
+	if [ "${msgs_dest}" = "/dev/tty" ] && [ -z "${luci_skip_dialogs}" ] && [ -f "${config_file}" ]
 	then
 		print_msg "This will overwrite existing config with default one. Proceed?"
 		pick_opt "y|n" || exit 1

--- a/adblock-lean
+++ b/adblock-lean
@@ -372,8 +372,8 @@ mk_def_preset()
 			for preset in large medium small mini
 			do
 				eval "mem=\"\${${preset}_mem}\""
-				# multiplying by 900 rather than 1024 to account for some memory not available to the kernel
-				[ "${totalmem}" -ge $((mem * 900)) ] && break
+				# multiplying by 800 rather than 1024 to account for some memory not available to the kernel
+				[ "${totalmem}" -ge $((mem * 800)) ] && break
 			done
 	esac
 	:

--- a/adblock-lean
+++ b/adblock-lean
@@ -1218,11 +1218,26 @@ gen_list_parts()
 		for list_format in raw dnsmasq
 		do
 			local d=
+			local invalid_urls='' bad_hagezi_urls=''
 			[ "${list_format}" = dnsmasq ] && d="dnsmasq_"
+
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
-			if [ -n "${list_urls}" ]
+			[ -z "${list_urls}" ] && continue
+
+			reg_action -blue "Starting ${list_format} ${list_type} part(s) download." || return 1
+
+			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
+				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"
+
+			if [ "${list_format}" = raw ]
 			then
-				reg_action -blue "Starting ${list_format} ${list_type} part(s) download." || return 1
+				bad_hagezi_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | sed -n '/\/hagezi\/.*\/dnsmasq\//p')"
+				[ -n "${bad_hagezi_urls}" ] && log_msg -warn "" \
+					"Following Hagezi URLs are in dnsmasq format and should be either changed to raw list URLs" \
+					"or moved to one of the 'dnsmasq_' config entries:" "${bad_hagezi_urls}"
+				bad_hagezi_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | sed -n '/\/hagezi\//{/onlydomains\./d;/^$/d;p;}')"
+				[ -n "${bad_hagezi_urls}" ] && log_msg -warn "" \
+					"Following Hagezi URLs are missing the '-onlydomains' suffix in the filename:" "${bad_hagezi_urls}"
 			fi
 
 			for list_url in ${list_urls}

--- a/adblock-lean
+++ b/adblock-lean
@@ -608,7 +608,7 @@ parse_config()
 	[ ! -f "${1}" ] && { reg_failure "Config file '${1}' not found."; return 1; }
 
 	# extract entries from default config
-	def_config="$(print_def_config)"
+	def_config="$(print_def_config)" || return 1
 
 	# extract valid values from default config
 	local sed_valid_vals_expr="/^[^@]*$/d; s/=.*@[ \t]*/=/; /=[ \t]*$/d; /\"/d; s/[ \t]//g; s/^/val_/; s/=string/=*/; \

--- a/adblock-lean
+++ b/adblock-lean
@@ -373,7 +373,7 @@ mk_def_preset()
 	local mem cnt
 	read -r _ totalmem _ </proc/meminfo
 	case "${totalmem}" in
-		''|*[!0-9]*) reg_failure "Failed to determine system memory capacity." ;;
+		''|*[!0-9]*) reg_failure "Failed to determine system memory capacity."; return 1 ;;
 		*)
 			for preset in large medium small mini
 			do

--- a/adblock-lean
+++ b/adblock-lean
@@ -2631,6 +2631,7 @@ case "${action}" in
 			fi
 			load_config
 			rm_cron_job
+			stop
 			disabling=
 		fi
 esac

--- a/adblock-lean
+++ b/adblock-lean
@@ -27,19 +27,19 @@ default_IFS="${IFS}"
 
 if [ -t 0 ]
 then
-	msgs_dest="/dev/tty"
+	msgs_dest=/dev/tty
 else
-	msgs_dest="/dev/null"
+	msgs_dest=/dev/null
 fi
 
-config_dir="/etc/adblock-lean"
-PREFIX=/root/adblock-lean
+abl_service_path=/etc/init.d/adblock-lean
+config_dir=/etc/adblock-lean
+config_file=${config_dir}/config
+root_config_file=/root/adblock-lean/config # @config_migration_logic
 abl_dir=/var/run/adblock-lean
 abl_pid_dir=/tmp/adblock-lean
-config_file="${config_dir}/config"
-root_config_file="${PREFIX}/config" # @config_migration_logic
-update_log_file="/var/log/abl_update.log"
-session_log_file="/var/log/abl_session.log"
+update_log_file=/var/log/abl_update.log
+session_log_file=/var/log/abl_session.log
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export HOME=/root
@@ -716,12 +716,12 @@ load_config()
 	[ ${parse_res} = 0 ] && [ -z "${url_conv_req}" ] && return 0
 
 	# if not in interactive console, return error
-	{ [ "${msgs_dest}" != "/dev/tty" ] || [ -n "${luci_skip_dialogs}" ]; } && [ "${1}" != '-f' ] && { log_msg "${tip_msg}"; return 1; }
+	[ -z "${do_dialogs}" ] && [ "${1}" != '-f' ] && { log_msg "${tip_msg}"; return 1; }
 
 	# sanity check
 	[ -z "${conf_fixes}" ] && [ -z "${url_conv_req}" ] && { reg_failure "Failed to parse config."; return 1; }
 
-	if [ "${msgs_dest}" = "/dev/tty" ] && [ -z "${luci_skip_dialogs}" ] && [ "${1}" != '-f' ]
+	if [ -n "${do_dialogs}" ] && [ "${1}" != '-f' ]
 	then
 		if [ -n "${conf_fixes}" ]
 		then
@@ -816,7 +816,7 @@ fix_config()
 	if ! cp "${actual_config_file}" "${old_config_f}"
 	then
 		reg_failure "Failed to save old config file as ${old_config_f}."
-		[ "${msgs_dest}" != "/dev/tty" ] || [ -n "${luci_skip_dialogs}" ] && return 1
+		[ -z "${do_dialogs}" ] && return 1
 		log_msg "Proceed with suggested config changes?"
 		pick_opt "y|n" || return 1
 		[ "${REPLY}" = n ] && return 1
@@ -924,6 +924,20 @@ try_export_existing_blocklist()
 	:	
 }
 
+# return codes:
+# 0 - addnmount entry exists
+# 1 - addnmount entry doesn't exist
+# 2 - uci command not found
+check_addnmount()
+{
+	hash uci 1>/dev/null || { reg_failure "uci command was not found."; return 2; }
+	uci -q get dhcp.@dnsmasq[0].addnmount | grep -qE "(^|[ \t])/bin(/\*|/busybox)*($|[ \t])"
+}
+
+# return codes:
+# 0 - addnmount entry exists
+# 1 - addnmount entry doesn't exist
+# 2 - uci command not found
 check_blocklist_compression_support()
 {
 	if ! dnsmasq --help | grep -qe "--conf-script"
@@ -934,13 +948,8 @@ check_blocklist_compression_support()
 		return 1
 	fi
 
-	addnmount_str=$(uci get dhcp.@dnsmasq[0].addnmount 2> /dev/null)
-
-	for addnmount_path in ${addnmount_str}
-	do
-		printf "%s" "$addnmount_path" | grep -qE "^/bin(/*|/busybox)?$" && return 0
-	done
-
+	check_addnmount && return 0
+	[ ${?} = 2 ] && return 2
 	reg_failure "No appropriate 'addnmount' entry in /etc/config/dhcp was identified."
 	log_msg "This is leveraged to give dnsmasq access to busybox gunzip to extract compressed blocklist." \
 		"Add: \"list addnmount '/bin/busybox'\" to /etc/config/dhcp at the end of the dnsmasq section." \
@@ -1590,7 +1599,7 @@ check_for_updates()
 {
 	reg_action -blue "Checking for adblock-lean updates."
 	rm -f "${abl_dir}/uclient-fetch_err"
-	sha256sum_adblock_lean_local=$(sha256sum /etc/init.d/adblock-lean | sed -E 's/[ \t]+.*$//')
+	sha256sum_adblock_lean_local=$(sha256sum "${abl_service_path}" | sed -E 's/[ \t]+.*$//')
 	sha256sum_adblock_lean_remote=$(uclient-fetch https://raw.githubusercontent.com/lynxthecat/adblock-lean/master/adblock-lean -O - \
 		2> "${abl_dir}/uclient-fetch_err" |
 		tee >(cat > "${abl_dir}/remote_abl"; . "${abl_dir}/remote_abl" 1>/dev/null 2>/dev/null && print_def_config -d |
@@ -1775,13 +1784,16 @@ init_command()
 	luci_sourced=
 	command -v "abl_luci_exit" 1>/dev/null && luci_sourced=1
 
+	do_dialogs=
+	[ -z "${luci_skip_dialogs}" ] && [ "${msgs_dest}" = "/dev/tty" ] && do_dialogs=1
+
 	trap 'cleanup_and_exit 1' INT TERM
 	trap 'cleanup_and_exit ${?}' EXIT
 
 	# set requirements
 	case ${action} in
 		help|status|gen_stats|print_log|enabled|enable|disable|'') ;;
-		gen_config|pause) lock_req=1 ;;
+		setup|gen_config|pause) lock_req=1 ;;
 		boot|start|update|resume) cleanup_req=1 lock_req=1 ;;
 		stop)
 			init_action_msg="Stopping adblock-lean."
@@ -1825,7 +1837,7 @@ init_command()
 	log_file=
 	case ${init_lock_status} in 0|3)
 		case ${action} in
-			start|boot|stop|restart|reload|pause|resume) log_file="${session_log_file}" ;;
+			start|boot|stop|restart|reload|pause|resume|setup) log_file="${session_log_file}" ;;
 			update) log_file="${update_log_file}"
 		esac
 	esac
@@ -1876,6 +1888,139 @@ gen_preset()
 
 ### MAIN COMMAND FUNCTIONS
 
+setup()
+{
+	setup_failed()
+	{
+		[ -n "${1}" ] && reg_failure "${1}"
+		exit 1
+	}
+
+	init_command setup
+	[ -z "${abl_service_path}" ] && setup_failed "\${abl_service_path} variable is unset."
+	[ ! -f "${abl_service_path}" ] && setup_failed "adblock-lean service file doesn't exist at ${abl_service_path}."
+
+	# make the script executable
+	if [ ! -x "${abl_service_path}" ]
+	then
+		print_msg "" "${purple}Making ${abl_service_path} executable.${n_c}"
+		chmod +x "${abl_service_path}" || setup_failed "Failed to make '${abl_service_path}' executable."
+	else
+		print_msg "" "${green}${abl_service_path} is already executable.${n_c}"
+	fi
+
+	# make addnmount entry - enables blocklist compression to reduce RAM usage
+	check_addnmount
+	case ${?} in
+		0) print_msg "" "${green}Found existing dnsmasq addnmount UCI entry.${n_c}" ;;
+		2) exit 1 ;;
+		1)
+			print_msg "" "${purple}Creating dnsmasq addnmount UCI entry.${n_c}"
+			uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox' && uci commit || setup_failed "Failed to create addnmount entry."
+	esac
+
+	# generate config
+	gen_config
+
+	# enable the service
+	if ! service adblock-lean enabled
+	then
+		print_msg "" "${purple}Enabling the adblock-lean service.${n_c}"
+		service adblock-lean enable || setup_failed "Failed to enable the adblock-lean service."
+	else
+		print_msg "" "${green}adblock-lean service is already enabled.${n_c}"
+	fi
+
+	# install utils
+	local util package installed_utils="$(opkg list_installed | grep -E '^[ \t]*(sed|gawk|coreutils-sort)([ \t]|$)')" \
+		awk_size=460 sort_size=120 sed_size=150 util_size missing_utils='' pkgs2install='' utils_size_KB=0
+	
+	echo
+	for util in sed sort awk
+	do
+		case "${installed_utils}" in
+			*"${util}"*) print_msg "${green}GNU ${util} is already installed.${n_c}" ;;
+			*) missing_utils="${missing_utils}${util} " missing_utils_print="${missing_utils_print}${blue}GNU ${util}${n_c}, "
+		esac
+	done
+
+	if [ -n "${missing_utils}" ]
+	then
+		if [ -n "${do_dialogs}" ] 
+		then
+			print_msg "" "For improved performance while processing the lists, it is recommended to install ${blue}GNU awk${n_c}, ${blue}GNU sed${n_c} and ${blue}GNU sort${n_c}." \
+				"Corresponding opkg packages are ${blue}gawk${n_c}, ${blue}sed${n_c}, ${blue}coreutils-sort${n_c}." "" \
+				"Following utilities are currently not installed: ${missing_utils_print%, }."
+		fi
+
+		for util in ${missing_utils}
+		do
+			REPLY=n
+			if [ -n "${do_dialogs}" ]
+			then
+				eval "util_size=\"\${${util}_size}\""
+				print_msg "Would you like to install ${blue}GNU ${util}${n_c} automatically? Installed size: ${yellow}${util_size} KiB${n_c}."
+				pick_opt "y|n" || exit 1
+			elif [ -n "${luci_install_packages}" ]
+			then
+				REPLY=y
+			fi
+
+			if [ "${REPLY}" = y ]
+			then
+				case "${util}" in
+					awk) package="gawk" ;;
+					sed) package="sed" ;;
+					sort) package="coreutils-sort"
+				esac
+				pkgs2install="${pkgs2install}${package} "
+				utils_size_KB=$((utils_size_KB+util_size))
+			fi
+		done
+	fi
+
+	if [ -n "${pkgs2install}" ]
+	then
+		local free_space_B='' free_space_KB="$(df -k /usr/ | tail -n1 | sed -E 's/^[ \t]*([^ \t]+[ \t]+){3}//;s/[ \t]+.*//')" \
+			utils_size_B="$((utils_size_KB*1024))" mount_point="$(df -k /usr/ | tail -n1 | sed -E 's/.*[ \t]+//')"
+		case "${free_space_KB}" in
+			''|*[!0-9]*) reg_failure "Failed to check available free space." ;;
+			*) free_space_B=$((free_space_KB*1024))
+		esac
+		REPLY=n
+		if [ -n "${do_dialogs}" ]
+		then
+			print_msg "" "Selected packages: ${blue}${pkgs2install% }${n_c}" "Total installed size: ${yellow}$(bytes2human ${utils_size_B})${n_c}."
+			[ -n "${free_space_B}" ] && print_msg "Available free space on mount point '${mount_point}': ${yellow}$(bytes2human ${free_space_B})${n_c}."
+			print_msg "Proceed with packages installation?"
+			pick_opt "y|n"
+		elif [ -n "${luci_install_packages}" ]
+		then
+			REPLY=y
+		fi
+		if [ "${REPLY}" = y ]
+		then
+			if [ -z "${free_space_B}" ] || [ -z "${utils_size_B}" ] || [ ${free_space_B} -gt ${utils_size_B} ]
+			then
+				echo
+				opkg update && opkg install ${pkgs2install% } ||
+					reg_failure "Failed to automatically install packages. You can install them manually later."
+			else
+				reg_failure "Not enough space on mount point '${mount_point}'. Free up some space, then you can manually install the packages later."
+			fi
+		fi
+	fi
+
+	if [ -n "${do_dialogs}" ]
+	then
+		print_msg "" "${green}Setup is complete.${n_c}" "" "Start adblock-lean now?"
+		pick_opt "y|n" || exit 1
+		[ "${REPLY}" != y ] && return 0
+		start
+	fi
+	:
+}
+
 print_log()
 {
 	[ ! -s "${session_log_file}" ] && { log_msg -err "Session log file '${session_log_file}' doesn't exist or is empty."; exit 1; }
@@ -1920,7 +2065,7 @@ gen_config()
 		[ "${totalmem}" -ge $((mem * 900)) ] && break
 	done
 
-	if [ -z "${luci_skip_dialogs}" ] && [ -z "${luci_preset}" ]
+	if [ -n "${do_dialogs}" ] && [ -z "${luci_preset}" ]
 	then
 		print_msg "" "Based on the total usable memory of this device ($(bytes2human $((totalmem*1024)) )), the recommended preset is ${purple}${preset}${n_c}:"
 		gen_preset "${preset}"
@@ -1942,7 +2087,7 @@ gen_config()
 	fi
 
 	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1
-	if [ "${msgs_dest}" = "/dev/tty" ] && [ -z "${luci_skip_dialogs}" ] && [ -f "${config_file}" ]
+	if [ -n "${do_dialogs}" ] && [ -f "${config_file}" ]
 	then
 		print_msg "This will overwrite existing config with default one. Proceed?"
 		pick_opt "y|n" || exit 1
@@ -1994,7 +2139,14 @@ start()
 	fi
 
 	final_compress=
-	[ "${use_compression}" = 1 ] && check_blocklist_compression_support && final_compress=1
+	if [ "${use_compression}" = 1 ]
+	then
+		check_blocklist_compression_support
+		case ${?} in
+			0) final_compress=1 ;;
+			2) exit 1
+		esac
+	fi
 
 	if [ "${RANDOM_DELAY}" = "1" ]
 	then
@@ -2258,9 +2410,9 @@ update()
 		}
 	fi
 
-	try_mv "${abl_dir}/adblock-lean.latest" /etc/init.d/adblock-lean || exit 1
-	chmod +x /etc/init.d/adblock-lean
-	/etc/init.d/adblock-lean enable
+	try_mv "${abl_dir}/adblock-lean.latest" "${abl_service_path}" || exit 1
+	chmod +x "${abl_service_path}"
+	${abl_service_path} enable
 	log_msg -green "adblock-lean has been updated to the latest version."
 
 	rm -f "${abl_dir}/adblock-lean.latest" "${abl_dir}/uclient-fetch_err"
@@ -2269,4 +2421,5 @@ update()
 
 set_colors
 
+[ "${1}" = setup ] && setup
 :

--- a/adblock-lean
+++ b/adblock-lean
@@ -2125,8 +2125,24 @@ setup()
 	esac
 	luci_addnmount_failed=
 
-	# generate config and enable the service
-	gen_config || exit 1
+	REPLY=n
+	if [ -n "${do_dialogs}" ] && [ -s "${config_file}" ]
+	then
+		print_msg "" "Existing config file found." "Generate [n]ew config or use [e]xisting config?"
+		pick_opt 'n|e' || exit 1
+	elif [ -n "${luci_use_old_config}" ]
+	then
+		REPLY=e
+	fi
+
+	if [ "${REPLY}" = n ]
+	then
+		# generate config and enable the service
+		gen_config || exit 1
+	else
+		load_config || exit 1
+		upd_cron_job
+	fi
 
 	# determine if there are missing GNU utils
 	local pkgs2install='' missing_packages='' missing_utils='' missing_utils_print='' util package \

--- a/adblock-lean
+++ b/adblock-lean
@@ -1896,6 +1896,15 @@ setup()
 		exit 1
 	}
 
+	get_package_name()
+	{
+		case "${1}" in
+			awk) printf gawk ;;
+			sed) printf sed ;;
+			sort) printf coreutils-sort
+		esac
+	}
+
 	init_command setup
 	[ -z "${abl_service_path}" ] && setup_failed "\${abl_service_path} variable is unset."
 	[ ! -f "${abl_service_path}" ] && setup_failed "adblock-lean service file doesn't exist at ${abl_service_path}."
@@ -1931,26 +1940,39 @@ setup()
 		print_msg "" "${green}adblock-lean service is already enabled.${n_c}"
 	fi
 
-	# install utils
-	local util package installed_utils="$(opkg list_installed | grep -E '^[ \t]*(sed|gawk|coreutils-sort)([ \t]|$)')" \
-		awk_size=460 sort_size=120 sed_size=150 util_size missing_utils='' pkgs2install='' utils_size_KB=0
-	
+	# determine if there are missing GNU utils
+	local pkgs2install='' missing_packages='' missing_utils='' missing_utils_print='' util package \
+		util_size utils_size_KB=0 awk_size=460 sort_size=120 sed_size=150 \
+		installed_utils="$(opkg list_installed | grep -E '^[ \t]*(sed|gawk|coreutils-sort)([ \t]|$)')"
+
 	echo
 	for util in sed sort awk
 	do
 		case "${installed_utils}" in
 			*"${util}"*) print_msg "${green}GNU ${util} is already installed.${n_c}" ;;
-			*) missing_utils="${missing_utils}${util} " missing_utils_print="${missing_utils_print}${blue}GNU ${util}${n_c}, "
+			*)
+				missing_utils="${missing_utils}${util} "
+				missing_utils_print="${missing_utils_print}${blue}GNU ${util}${n_c}, "
+				missing_packages="${missing_packages}${blue}$(get_package_name "${util}")${n_c}, "
 		esac
 	done
 
+	# make a list of GNU utils to install
 	if [ -n "${missing_utils}" ]
 	then
+		local free_space_B='' free_space_KB="$(df -k /usr/ | tail -n1 | sed -E 's/^[ \t]*([^ \t]+[ \t]+){3}//;s/[ \t]+.*//')" \
+			mount_point="$(df -k /usr/ | tail -n1 | sed -E 's/.*[ \t]+//')"
+		case "${free_space_KB}" in
+			''|*[!0-9]*) reg_failure "Failed to check available free space." ;;
+			*) free_space_B=$((free_space_KB*1024))
+		esac
+
 		if [ -n "${do_dialogs}" ] 
 		then
-			print_msg "" "For improved performance while processing the lists, it is recommended to install ${blue}GNU awk${n_c}, ${blue}GNU sed${n_c} and ${blue}GNU sort${n_c}." \
-				"Corresponding opkg packages are ${blue}gawk${n_c}, ${blue}sed${n_c}, ${blue}coreutils-sort${n_c}." "" \
-				"Following utilities are currently not installed: ${missing_utils_print%, }."
+			print_msg "" "For improved performance while processing the lists, it is recommended to install ${missing_utils_print%, }." \
+				"Corresponding opkg packages are: ${missing_packages%, }."
+			[ -n "${free_space_B}" ] &&
+				print_msg "" "Available free space at mount point '${mount_point}': ${yellow}$(bytes2human "${free_space_B}")${n_c}." ""
 		fi
 
 		for util in ${missing_utils}
@@ -1968,31 +1990,22 @@ setup()
 
 			if [ "${REPLY}" = y ]
 			then
-				case "${util}" in
-					awk) package="gawk" ;;
-					sed) package="sed" ;;
-					sort) package="coreutils-sort"
-				esac
-				pkgs2install="${pkgs2install}${package} "
+				pkgs2install="${pkgs2install}$(get_package_name "${util}") "
 				utils_size_KB=$((utils_size_KB+util_size))
 			fi
 		done
 	fi
 
+	# install GNU utils
 	if [ -n "${pkgs2install}" ]
 	then
-		local free_space_B='' free_space_KB="$(df -k /usr/ | tail -n1 | sed -E 's/^[ \t]*([^ \t]+[ \t]+){3}//;s/[ \t]+.*//')" \
-			utils_size_B="$((utils_size_KB*1024))" mount_point="$(df -k /usr/ | tail -n1 | sed -E 's/.*[ \t]+//')"
-		case "${free_space_KB}" in
-			''|*[!0-9]*) reg_failure "Failed to check available free space." ;;
-			*) free_space_B=$((free_space_KB*1024))
-		esac
+		local utils_size_B="$((utils_size_KB*1024))"
 		REPLY=n
 		if [ -n "${do_dialogs}" ]
 		then
-			print_msg "" "Selected packages: ${blue}${pkgs2install% }${n_c}" "Total installed size: ${yellow}$(bytes2human ${utils_size_B})${n_c}."
-			[ -n "${free_space_B}" ] && print_msg "Available free space at mount point '${mount_point}': ${yellow}$(bytes2human ${free_space_B})${n_c}."
-			print_msg "Proceed with packages installation?"
+			print_msg "" "Selected packages: ${blue}${pkgs2install% }${n_c}" \
+				"Total installed size: ${yellow}$(bytes2human ${utils_size_B})${n_c}." \
+				"Proceed with packages installation?"
 			pick_opt "y|n"
 		elif [ -n "${luci_install_packages}" ]
 		then
@@ -2006,7 +2019,9 @@ setup()
 				opkg update && opkg install ${pkgs2install% } ||
 					reg_failure "Failed to automatically install packages. You can install them manually later."
 			else
-				reg_failure "Not enough free space at mount point '${mount_point}'. Free up some space, then you can manually install the packages later."
+				reg_failure "Not enough free space at mount point '${mount_point}'."
+				print_msg "Free up some space, then you can manually install the packages later by issuing the command:" \
+					"opkg update; opkg install ${pkgs2install% }"
 			fi
 		fi
 	fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -249,15 +249,8 @@ print_def_config()
 	# follow each default option with '@' and a pre-defined type: string, integer (implies unsigned integer)
 	# or custom optional values, examples: opt1, opt1|opt2, ''|opt1|opt2
 
-	local preset
 	mk_preset_arrays
-	if [ "${1}" = '-p' ]
-	then
-		preset="${2}"
-	else
-		mk_def_preset || { print_msg "Falling back to preset 'small'."; preset=small; }
-	fi
-
+	: "${preset:=small}"
 	case "${preset}" in mini|small|medium|large) ;; *) reg_failure "print_def_config: \$preset var has invalid value."; exit 1; esac
 	gen_preset "${preset}" -n
 
@@ -602,11 +595,17 @@ parse_config()
 
 	unset curr_config_format def_config_format bad_value_keys \
 		luci_curr_config_format luci_def_config_format luci_unexp_keys luci_unexp_entries luci_missing_keys luci_missing_entries \
-		luci_legacy_entries luci_bad_conf_format luci_conf_fixes
+		luci_legacy_entries luci_bad_conf_format luci_conf_fixes preset
 
 	[ -z "${1}" ] && { reg_failure "parse_config(): no file specified."; return 1; }
 
 	[ ! -f "${1}" ] && { reg_failure "Config file '${1}' not found."; return 1; }
+
+	# determine recommended preset
+	case "${luci_preset}" in
+		''|auto) mk_def_preset || { print_msg "Falling back to preset 'small'."; preset=small; } ;;
+		*) preset="${luci_preset}"
+	esac
 
 	# extract entries from default config
 	def_config="$(print_def_config)" || return 1
@@ -2197,7 +2196,7 @@ gen_config()
 {
 	init_command gen_config || return 1
 
-	local preset cnt
+	local cnt
 
 	if [ -n "${do_dialogs}" ] && [ -z "${luci_preset}" ]
 	then

--- a/adblock-lean
+++ b/adblock-lean
@@ -257,7 +257,7 @@ print_def_config()
 	cat <<-EOT | if [ "${1}" = '-d' ]; then cat; else sed 's/[ \t]*@.*//'; fi
 
 	# adblock-lean configuration options
-	# config_format=v3
+	# config_format=v4
 	#
 	# values must be enclosed in double-quotes
 	# comments must start at newline or inline after the closing double-quote

--- a/adblock-lean
+++ b/adblock-lean
@@ -2646,7 +2646,7 @@ case "${action}" in
 				/sbin/service adblock-lean enable && /sbin/service adblock-lean enabled ||
 					{ reg_failure "Failed to enable the adblock-lean service"; exit 1; }
 			else
-				log_msg -green "" "The adblock-lean service is already enabled."
+				log_msg -green "The adblock-lean service is already enabled."
 			fi
 			load_config
 			upd_cron_job && luci_cron_job_creation_failed=

--- a/adblock-lean
+++ b/adblock-lean
@@ -43,13 +43,15 @@ session_log_file="/var/log/abl_session.log"
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export HOME=/root
+hagezi_dl_url="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard"
 
 START=99
 STOP=4
 
-EXTRA_COMMANDS="status pause resume gen_stats gen_config print_log update"
+EXTRA_COMMANDS="setup status pause resume gen_stats gen_config print_log update"
 EXTRA_HELP="	
 adblock-lean custom commands:
+	setup		run automated setup for adblock-lean
 	status		check dnsmasq and entries count of existing blocklist
 	pause		pause adblock-lean
 	resume		resume adblock-lean
@@ -235,12 +237,22 @@ pick_opt()
 
 ### HELPER FUNCTIONS
 
-# 1 - (optional) -d to print with allowed value types (otherwise print without)
+# (optional) -d to print with allowed value types (otherwise print without)
+# (optional) -p to print with values from preset
 print_def_config()
 {
 	# follow each default option with '@' and a pre-defined type: string, integer (implies unsigned integer)
 	# or custom optional values, examples: opt1, opt1|opt2, ''|opt1|opt2
-	local hagezi_dl_url="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard"
+
+	local preset
+	if [ "${1}" = '-p' ]
+	then
+		preset="${2}"
+	else
+		preset=small
+	fi
+	case "${preset}" in mini|small|medium|large) ;; *) reg_failure "print_def_config: \$preset var has invalid value."; exit 1; esac
+	gen_preset "${preset}" -n
 
 	cat <<-EOT | if [ "${1}" = '-d' ]; then cat; else sed 's/[ \t]*@.*//'; fi
 
@@ -251,7 +263,7 @@ print_def_config()
 	# comments must start at newline or inline after the closing double-quote
 
 	# One or more *raw domain* format blocklist/ipv4 blocklist/allowlist urls separated by spaces
-	blocklist_urls="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" @ string
+	blocklist_urls="${blocklist_urls}" @ string
 	blocklist_ipv4_urls="" @ string
 	allowlist_urls="" @ string
 
@@ -275,13 +287,13 @@ print_def_config()
 	min_allowlist_part_line_count="1" @ integer
 
 	# Maximum size of any individual downloaded blocklist part
-	max_file_part_size_KB="20000" @ integer
+	max_file_part_size_KB="${max_file_part_size_KB}" @ integer
 
 	# Maximum total size of combined, processed blocklist
-	max_blocklist_file_size_KB="30000" @ integer
+	max_blocklist_file_size_KB="${max_blocklist_file_size_KB}" @ integer
 
 	# Minimum number of good lines in final postprocessed blocklist
-	min_good_line_count="100000" @ integer
+	min_good_line_count="${min_good_line_count}" @ integer
 
 	# compress final blocklist, intermediate blocklist parts and the backup blocklist to save memory - enable (1) or disable (0)
 	use_compression="1" @ 0|1
@@ -1843,6 +1855,24 @@ init_command()
 	:
 }
 
+# 1 - mini|small|medium|large
+# 2 - (optional) '-d' to print the description
+# 2 - (optional) '-n' to print nothing (only assign values to vars)
+gen_preset()
+{
+	local val field mem i=1
+	eval "mem=\"\${${1}_mem}\""
+	[ "${2}" = '-d' ] && print_msg "" "Preset \"${purple}${1}${n_c}\": recommended for devices with ${mem} MB of memory."
+	for field in blocklist_urls max_file_part_size_KB max_blocklist_file_size_KB min_good_line_count
+	do
+		eval "val=\"\${${1}_${i}}\""
+		eval "${field}=\"${val}\""
+		[ "${2}" != '-n' ] && print_msg "${blue}${field}${n_c}=\"${val}\""
+		i=$((i+1))
+	done
+}
+
+
 ### MAIN COMMAND FUNCTIONS
 
 print_log()
@@ -1867,14 +1897,46 @@ gen_stats()
 gen_config()
 {
 	init_command gen_config || exit 1
-	reg_action -purple "Generating new default config for adblock-lean." || exit 1
+
+	# default presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count
+	local mini_1="${hagezi_dl_url}/pro.mini-onlydomains.txt" mini_2=4000 mini_3=4000 mini_4=40000 mini_mem=64
+	local small_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" small_2=7000 small_3=10000 small_4=100000 small_mem=128
+	local medium_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.medium-onlydomains.txt ${hagezi_dl_url}/popupads-onlydomains.txt" \
+		medium_2=10000 medium_3=20000 medium_4=200000 medium_mem=256
+	local large_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" large_2=30000 large_3=50000 large_4=200000 large_mem=512
+	local preset mem
+
+	read -r _ totalmem _ </proc/meminfo
+	for preset in large medium small mini
+	do
+		eval "mem=\"\${${preset}_mem}\""
+		[ "${totalmem}" -ge $((mem * 922)) ] && break
+	done
+
+	print_msg "" "Based on the total memory of this device, the recommended preset is ${purple}${preset}${n_c}:"
+	gen_preset "${preset}"
+	print_msg "" "[C]onfirm this preset or [p]ick another preset?"
+	pick_opt "c|p"
+	if [ "${REPLY}" = p ]
+	then
+		print_msg "" "All available presets:"
+		for preset in mini small medium large
+		do
+			gen_preset "${preset}" -d
+		done
+		print_msg "" "Pick preset:"
+		pick_opt "mini|small|medium|large"
+		preset="${REPLY}"
+	fi
+
+	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1
 	if [ "${msgs_dest}" = "/dev/tty" ] && [ -f "${config_file}" ]
 	then
 		print_msg "This will overwrite existing config with default one. Proceed?"
 		pick_opt "y|n" || exit 1
 		[ "${REPLY}" = n ] && exit 1
 	fi
-	write_config "$(print_def_config)" || exit 1
+	write_config "$(print_def_config -p "${preset}")" || exit 1
 	mk_new_urls_format_flag || exit 1 # @url_conversion_logic
 	check_blocklist_compression_support
 	:

--- a/adblock-lean
+++ b/adblock-lean
@@ -1932,10 +1932,10 @@ setup()
 	gen_config
 
 	# enable the service
-	if ! service adblock-lean enabled
+	if ! /sbin/service adblock-lean enabled
 	then
 		print_msg "" "${purple}Enabling the adblock-lean service.${n_c}"
-		service adblock-lean enable || setup_failed "Failed to enable the adblock-lean service."
+		/sbin/service adblock-lean enable || setup_failed "Failed to enable the adblock-lean service."
 	else
 		print_msg "" "${green}adblock-lean service is already enabled.${n_c}"
 	fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -17,6 +17,8 @@
 
 # expects that the RPC script for luci UI is named specifically 'luci.adblock-lean'
 
+# get return value of built-in actions
+action_rv="${?}"
 
 LC_ALL=C
 IFS='	 
@@ -49,18 +51,19 @@ export HOME=/root
 START=99
 STOP=4
 
-EXTRA_COMMANDS="setup status pause resume gen_stats gen_config update_cron_job print_log update"
+EXTRA_COMMANDS="setup status pause resume gen_stats gen_config upd_cron_job print_log update"
 EXTRA_HELP="
 adblock-lean custom commands:
-	setup			run automated setup for adblock-lean
-	status			check dnsmasq and entries count of existing blocklist
-	pause			pause adblock-lean
-	resume			resume adblock-lean
-	gen_stats		generate dnsmasq stats for system log
-	gen_config		generate default config and enable the adblock-lean service
-	update_cron_job	create cron job for adblock-lean with schedule set in the config option 'cron_schedule'. if set to 'disable', remove existing cron job if any
-	print_log		print most recent session log
-	update			update adblock-lean to the latest version"
+	setup           run automated setup for adblock-lean
+	status          check dnsmasq and entries count of existing blocklist
+	pause           pause adblock-lean
+	resume          resume adblock-lean
+	gen_stats       generate dnsmasq stats for system log
+	gen_config      generate default config and enable the adblock-lean service
+	upd_cron_job    create cron job for adblock-lean with schedule set in the config option 'cron_schedule'.
+	                if config option set to 'disable', remove existing cron job if any
+	print_log       print most recent session log
+	update          update adblock-lean to the latest version"
 
 
 ### UTILITY FUNCTIONS
@@ -1908,7 +1911,7 @@ init_command()
 
 	# set requirements
 	case ${action} in
-		help|status|gen_stats|print_log|enabled|enable|disable|update_cron_job|'') ;;
+		help|status|gen_stats|print_log|enabled|enable|disable|upd_cron_job|'') ;;
 		setup|gen_config|pause) lock_req=1 ;;
 		boot|start|update|resume) cleanup_req=1 lock_req=1 ;;
 		stop)
@@ -1965,10 +1968,10 @@ init_command()
 
 	# create work dir, check dnsmasq, load config, source custom script
 	case ${action} in
-		status)
+		status|boot)
 			try_mkdir -p "${abl_dir}" || exit 1
 			load_config || { reg_failure "Failed to load config."; exit 1; } ;;
-		start|boot|pause|resume|update)
+		start|pause|resume|update)
 			check_dnsmasq_instance || { [ ${?} = 1 ] && reg_failure "No running instance of dnsmasq detected."; exit 1; }
 			try_mkdir -p "${abl_dir}" || exit 1
 			load_config || { reg_failure "Failed to load config."; exit 1; }
@@ -1986,13 +1989,13 @@ init_command()
 
 ### MAIN COMMAND FUNCTIONS
 
-update_cron_job()
+upd_cron_job()
 {
-	local me="update_cron_job" curr_cron cron_line
+	local me="upd_cron_job" curr_cron cron_line
 
 	log_msg -purple "" "Updating cron job for adblock-lean."
 
-	if [ "${action}" = update_cron_job ]
+	if [ "${action}" = upd_cron_job ]
 	then
 		load_config || return 1
 	fi
@@ -2163,6 +2166,7 @@ setup()
 		print_msg "" "${green}Setup is complete.${n_c}" "" "Start adblock-lean now?"
 		pick_opt "y|n" || exit 1
 		[ "${REPLY}" != y ] && return 0
+		echo
 		start
 	fi
 	:
@@ -2237,15 +2241,15 @@ gen_config()
 			"The default schedule is '${blue}${def_schedule}${n_c}': ${def_schedule_desc}" \
 			"The cron job will run with an added random number of minutes." \
 			"" "Create cron job with default schedule for automatic list updates?" \
-			"If you enter 'n', you can later create a cron job with a custom schedule as described in:" \
+			"'n' will set the 'cron_schedule' setting to 'disable'. You can later create a cron job with a custom schedule as described in:" \
 			"https://github.com/lynxthecat/adblock-lean/blob/master/README.md"
 		pick_opt "y|n" || return 1
 		cron_schedule="${def_schedule}"
-	elif [ -n "${luci_update_cron_job}" ] && [ -n "${luci_cron_schedule}" ]
+	elif [ -n "${luci_upd_cron_job}" ] && [ -n "${luci_cron_schedule}" ]
 	then
 		REPLY=y
 		cron_schedule="${luci_cron_schedule}"
-	elif  [ -n "${luci_update_cron_job}" ]
+	elif  [ -n "${luci_upd_cron_job}" ]
 	then
 		reg_failure "Can not create cron job for luci because the \${luci_cron_schedule} var is empty."
 	fi
@@ -2260,17 +2264,13 @@ gen_config()
 	fi
 	write_config "$(print_def_config -p "${preset}")" || return 1
 
+	mk_new_urls_format_flag || return 1 # @url_conversion_logic
+
 	# enable the service
-	if ! /sbin/service adblock-lean enabled
-	then
-		print_msg "" "${purple}Enabling the adblock-lean service.${n_c}"
-		/sbin/service adblock-lean enable || { reg_failure "Failed to enable the adblock-lean service."; return 1; }
-	else
-		print_msg "" "The ${green}adblock-lean service is already enabled.${n_c}"
-	fi
+	echo
+	/sbin/service adblock-lean enable || { reg_failure "Failed to enable the adblock-lean service."; return 1; }
 	luci_service_enable_failed=
 
-	mk_new_urls_format_flag || return 1 # @url_conversion_logic
 	check_blocklist_compression_support
 	:
 }
@@ -2278,7 +2278,7 @@ gen_config()
 boot()
 {
 	init_command boot || exit 1
-	reg_action -purple "Sleeping for ${boot_start_delay_s} seconds." || exit 1
+	log_msg -purple "Sleeping for ${boot_start_delay_s} seconds." || exit 1
 	sleep "${boot_start_delay_s}"
 	start "$@"
 }
@@ -2599,15 +2599,40 @@ set_colors
 
 [ "${1}" = setup ] && { setup; exit 0; }
 
+# handle enable/disable actions
 case "${action}" in
 	enable)
-		log_msg -purple "Enabling adblock-lean."
-		load_config
-		update_cron_job ;;
+		if ! [ "${enabling}" ]
+		then
+			export enabling=1
+			log_msg -purple "Enabling adblock-lean."
+			if ! /sbin/service adblock-lean enabled
+			then
+				/sbin/service adblock-lean enable && /sbin/service adblock-lean enabled ||
+					{ reg_failure "Failed to enable the adblock-lean service"; return 1; }
+			else
+				log_msg "The adblock-lean service is already enabled."
+			fi
+			load_config
+			upd_cron_job
+			enabling=
+		fi ;;
 	disable)
-		log_msg -purple "Disabling adblock-lean."
-		load_config
-		rm_cron_job
+		if ! [ "${disabling}" ]
+		then
+			export disabling=1
+			log_msg -purple "Disabling adblock-lean."
+			if /sbin/service adblock-lean enabled
+			then
+				/sbin/service adblock-lean disable && ! /sbin/service adblock-lean enabled ||
+					{ reg_failure "Failed to disable the adblock-lean service"; return 1; }
+			else
+				log_msg "The adblock-lean service is already disabled."
+			fi
+			load_config
+			rm_cron_job
+			disabling=
+		fi
 esac
 
 :

--- a/adblock-lean
+++ b/adblock-lean
@@ -366,7 +366,7 @@ mk_preset_arrays()
 		large_2=30000 large_3=50000 large_4=200000 large_cnt=700 large_mem=512
 }
 
-# determine recommended preset
+# sets ${preset} to recommended preset, depending on system memory capacity
 mk_def_preset()
 {
 	unset preset totalmem

--- a/adblock-lean
+++ b/adblock-lean
@@ -366,12 +366,13 @@ mk_preset_arrays()
 		large_2=30000 large_3=50000 large_4=200000 large_cnt=700 large_mem=512
 }
 
-# determine recommended preset and set quasi-array variables
+# determine recommended preset
 mk_def_preset()
 {
 	unset preset totalmem
 	local mem cnt
-	read -r _ totalmem _ </proc/meminfo
+	local IFS="${default_IFS}"
+	read -r _ totalmem _ < /proc/meminfo
 	case "${totalmem}" in
 		''|*[!0-9]*) reg_failure "\$totalmem has invalid value '${totalmem}'. Failed to determine system memory capacity."; return 1 ;;
 		*)

--- a/adblock-lean
+++ b/adblock-lean
@@ -1913,20 +1913,25 @@ gen_config()
 		[ "${totalmem}" -ge $((mem * 922)) ] && break
 	done
 
-	print_msg "" "Based on the total memory of this device, the recommended preset is ${purple}${preset}${n_c}:"
-	gen_preset "${preset}"
-	print_msg "" "[C]onfirm this preset or [p]ick another preset?"
-	pick_opt "c|p"
-	if [ "${REPLY}" = p ]
+	if [ -z "${luci_sourced}" ] && [ -z "${luci_preset}" ]
 	then
-		print_msg "" "All available presets:"
-		for preset in mini small medium large
-		do
-			gen_preset "${preset}" -d
-		done
-		print_msg "" "Pick preset:"
-		pick_opt "mini|small|medium|large"
-		preset="${REPLY}"
+		print_msg "" "Based on the total memory of this device, the recommended preset is ${purple}${preset}${n_c}:"
+		gen_preset "${preset}"
+		print_msg "" "[C]onfirm this preset or [p]ick another preset?"
+		pick_opt "c|p"
+		if [ "${REPLY}" = p ]
+		then
+			print_msg "" "All available presets:"
+			for preset in mini small medium large
+			do
+				gen_preset "${preset}" -d
+			done
+			print_msg "" "Pick preset:"
+			pick_opt "mini|small|medium|large"
+			preset="${REPLY}"
+		fi
+	else
+		preset="${luci_preset}"
 	fi
 
 	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1

--- a/adblock-lean
+++ b/adblock-lean
@@ -2126,7 +2126,7 @@ setup()
 	luci_addnmount_failed=
 
 	REPLY=n
-	if [ -n "${do_dialogs}" ] && [ -s "${config_file}" ]
+	if [ -n "${do_dialogs}" ] && { [ -s "${config_file}" ] || [ -s "${root_config_file}" ]; }
 	then
 		print_msg "" "Existing config file found." "Generate [n]ew config or use [e]xisting config?"
 		pick_opt 'n|e' || exit 1
@@ -2137,12 +2137,15 @@ setup()
 
 	if [ "${REPLY}" = n ]
 	then
-		# generate config and enable the service
+		# generate config
 		gen_config || exit 1
 	else
 		load_config || exit 1
-		upd_cron_job
 	fi
+
+	# enable the service, update the cron job
+	/sbin/service adblock-lean enable || setup_failed
+	luci_service_enable_failed=
 
 	# determine if there are missing GNU utils
 	local pkgs2install='' missing_packages='' missing_utils='' missing_utils_print='' util package \
@@ -2234,7 +2237,7 @@ setup()
 
 	if [ -n "${do_dialogs}" ]
 	then
-		print_msg "" "${green}Setup is complete.${n_c}" "" "Start adblock-lean now?"
+		print_msg "" "${purple}Setup is complete.${n_c}" "" "Start adblock-lean now?"
 		pick_opt "y|n" || exit 1
 		[ "${REPLY}" != y ] && return 0
 		echo
@@ -2336,11 +2339,6 @@ gen_config()
 	write_config "$(print_def_config -p "${preset}")" || return 1
 
 	mk_new_urls_format_flag || return 1 # @url_conversion_logic
-
-	# enable the service
-	echo
-	/sbin/service adblock-lean enable || { reg_failure "Failed to enable the adblock-lean service."; return 1; }
-	luci_service_enable_failed=
 
 	check_blocklist_compression_support
 	:
@@ -2642,16 +2640,16 @@ case "${action}" in
 		if ! [ "${enabling}" ]
 		then
 			export enabling=1
-			log_msg -purple "Enabling adblock-lean."
+			log_msg -purple "" "Enabling the adblock-lean service."
 			if ! /sbin/service adblock-lean enabled
 			then
 				/sbin/service adblock-lean enable && /sbin/service adblock-lean enabled ||
-					{ reg_failure "Failed to enable the adblock-lean service"; return 1; }
+					{ reg_failure "Failed to enable the adblock-lean service"; exit 1; }
 			else
-				log_msg "The adblock-lean service is already enabled."
+				log_msg -green "" "The adblock-lean service is already enabled."
 			fi
 			load_config
-			upd_cron_job
+			upd_cron_job && luci_cron_job_creation_failed=
 			enabling=
 		fi ;;
 	disable)
@@ -2662,7 +2660,7 @@ case "${action}" in
 			if /sbin/service adblock-lean enabled
 			then
 				/sbin/service adblock-lean disable && ! /sbin/service adblock-lean enabled ||
-					{ reg_failure "Failed to disable the adblock-lean service"; return 1; }
+					{ reg_failure "Failed to disable the adblock-lean service"; exit 1; }
 			else
 				log_msg "The adblock-lean service is already disabled."
 			fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -1991,7 +1991,7 @@ setup()
 		if [ -n "${do_dialogs}" ]
 		then
 			print_msg "" "Selected packages: ${blue}${pkgs2install% }${n_c}" "Total installed size: ${yellow}$(bytes2human ${utils_size_B})${n_c}."
-			[ -n "${free_space_B}" ] && print_msg "Available free space on mount point '${mount_point}': ${yellow}$(bytes2human ${free_space_B})${n_c}."
+			[ -n "${free_space_B}" ] && print_msg "Available free space at mount point '${mount_point}': ${yellow}$(bytes2human ${free_space_B})${n_c}."
 			print_msg "Proceed with packages installation?"
 			pick_opt "y|n"
 		elif [ -n "${luci_install_packages}" ]
@@ -2006,7 +2006,7 @@ setup()
 				opkg update && opkg install ${pkgs2install% } ||
 					reg_failure "Failed to automatically install packages. You can install them manually later."
 			else
-				reg_failure "Not enough space on mount point '${mount_point}'. Free up some space, then you can manually install the packages later."
+				reg_failure "Not enough free space at mount point '${mount_point}'. Free up some space, then you can manually install the packages later."
 			fi
 		fi
 	fi
@@ -2044,7 +2044,8 @@ gen_config()
 {
 	init_command gen_config || exit 1
 
-	# quasi-arrays for default presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count, cnt - elements count/1000, mem - memory in MB
+	# quasi-arrays for default presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count,
+	# cnt - elements count/1000, mem - memory in MB
 	local mini_1="${hagezi_dl_url}/pro.mini-onlydomains.txt" \
 		mini_2=4000 mini_3=4000 mini_4=40000 mini_cnt=85 mini_mem=64
 	local small_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" \
@@ -2054,23 +2055,35 @@ gen_config()
 	local large_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" \
 		large_2=30000 large_3=50000 large_4=200000 large_cnt=700 large_mem=512
 
-	local preset mem totalmem cnt
+	local preset='' mem totalmem cnt
 
 	# determine recommended preset
 	read -r _ totalmem _ </proc/meminfo
-	for preset in large medium small mini
-	do
-		eval "mem=\"\${${preset}_mem}\""
-		# multiplying by 900 rather than 1024 to account for some memory not available to the kernel
-		[ "${totalmem}" -ge $((mem * 900)) ] && break
-	done
+	case "${totalmem}" in
+		''|*[!0-9]*)
+			reg_failure "Failed to determine system memory capacity."
+			print_msg "Skipping automatic preset recommendation." ;;
+		*)
+			for preset in large medium small mini
+			do
+				eval "mem=\"\${${preset}_mem}\""
+				# multiplying by 900 rather than 1024 to account for some memory not available to the kernel
+				[ "${totalmem}" -ge $((mem * 900)) ] && break
+			done
+	esac
 
 	if [ -n "${do_dialogs}" ] && [ -z "${luci_preset}" ]
 	then
-		print_msg "" "Based on the total usable memory of this device ($(bytes2human $((totalmem*1024)) )), the recommended preset is ${purple}${preset}${n_c}:"
-		gen_preset "${preset}"
-		print_msg "" "[C]onfirm this preset or [p]ick another preset?"
-		pick_opt "c|p"
+		if [ -n "${preset}" ]
+		then
+			print_msg "" "Based on the total usable memory of this device ($(bytes2human $((totalmem*1024)) )), the recommended preset is ${purple}${preset}${n_c}:"
+			gen_preset "${preset}"
+			print_msg "" "[C]onfirm this preset or [p]ick another preset?"
+			pick_opt "c|p"
+		else
+			REPLY=p
+		fi
+
 		if [ "${REPLY}" = p ]
 		then
 			print_msg "" "${purple}All available presets:${n_c}"
@@ -2085,6 +2098,8 @@ gen_config()
 	else
 		[ "${luci_preset}" != auto ] && preset="${luci_preset}"
 	fi
+
+	[ -z "${preset}" ] && { reg_failure "No config preset was selected."; exit 1; }
 
 	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1
 	if [ -n "${do_dialogs}" ] && [ -f "${config_file}" ]

--- a/adblock-lean
+++ b/adblock-lean
@@ -1835,7 +1835,61 @@ report_pid_action()
 	:
 }
 
+get_active_entries_cnt()
+{
+	local cnt entry_type allow_opt='' list_prefix list_prefixes=
+
+	# 'blocklist_ipv4' prefix doesn't need to be added for counting
+	for entry_type in blocklist allowlist
+	do
+		eval "[ ! \"\${${entry_type}_urls}\" ] && [ ! -s \"\${local_${entry_type}_path}\" ]" && continue
+		case ${entry_type} in
+			blocklist) list_prefix=local ;;
+			allowlist) list_prefix=server allow_opt="|#"
+		esac
+		list_prefixes="${list_prefixes}${list_prefix}|"
+	done
+
+	if [ -f "${dnsmasq_tmp_d}"/.blocklist.gz ]
+	then
+		gunzip -c "${dnsmasq_tmp_d}"/.blocklist.gz
+	elif [ -f "${dnsmasq_tmp_d}"/blocklist ]
+	then
+		cat "${dnsmasq_tmp_d}/blocklist"
+	else
+		printf ''
+	fi |
+	sed -E "s~^(${list_prefixes%|})\=/~~;" | tr "[/${allow_opt}]" '\n' | wc -w > "/tmp/abl_entries_cnt"
+
+	read -r cnt _ < "/tmp/abl_entries_cnt" || cnt=0
+	case ${cnt} in
+		[0-2]|'') printf 0; return 1 ;;
+		*) printf %s "$((cnt-3))" # to account for the blocklist test entry
+	esac
+	:
+}
+
 ### Cron-related functions
+
+# args: 1 - (optional) schedule
+# return codes:
+# 0 - cron job with same schedule exists
+# 1 - error
+# 2 - cron job with a different schedule exists
+# 3 - cron job doesn't exist
+get_curr_crontab()
+{
+	local curr_cron
+	curr_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "${me}: Failed to read crontab."; return 1; }
+	printf '%s\n' "${curr_cron}"
+
+	# check if adblock-lean cron job with same schedule exists
+	case "${curr_cron}" in
+		*"${cron_schedule}"*"${abl_cron_cmd}"*) return 0 ;;
+		*"${abl_cron_cmd}"*) return 2 ;;
+		*) return 3 ;;
+	esac
+}
 
 rm_cron_job()
 {
@@ -1988,26 +2042,6 @@ init_command()
 
 
 ### MAIN COMMAND FUNCTIONS
-
-# args: 1 - (optional) schedule
-# return codes:
-# 0 - cron job with same schedule exists
-# 1 - error
-# 2 - cron job with a different schedule exists
-# 3 - cron job doesn't exist
-get_curr_crontab()
-{
-	local curr_cron
-	curr_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "${me}: Failed to read crontab."; return 1; }
-	printf '%s\n' "${curr_cron}"
-
-	# check if adblock-lean cron job with same schedule exists
-	case "${curr_cron}" in
-		*"${cron_schedule}"*"${abl_cron_cmd}"*) return 0 ;;
-		*"${abl_cron_cmd}"*) return 2 ;;
-		*) return 3 ;;
-	esac
-}
 
 upd_cron_job()
 {
@@ -2447,40 +2481,6 @@ restart()
 reload()
 {
 	restart
-}
-
-get_active_entries_cnt()
-{
-	local cnt entry_type allow_opt='' list_prefix list_prefixes=
-
-	# 'blocklist_ipv4' prefix doesn't need to be added for counting
-	for entry_type in blocklist allowlist
-	do
-		eval "[ ! \"\${${entry_type}_urls}\" ] && [ ! -s \"\${local_${entry_type}_path}\" ]" && continue
-		case ${entry_type} in
-			blocklist) list_prefix=local ;;
-			allowlist) list_prefix=server allow_opt="|#"
-		esac
-		list_prefixes="${list_prefixes}${list_prefix}|"
-	done
-
-	if [ -f "${dnsmasq_tmp_d}"/.blocklist.gz ]
-	then
-		gunzip -c "${dnsmasq_tmp_d}"/.blocklist.gz
-	elif [ -f "${dnsmasq_tmp_d}"/blocklist ]
-	then
-		cat "${dnsmasq_tmp_d}/blocklist"
-	else
-		printf ''
-	fi |
-	sed -E "s~^(${list_prefixes%|})\=/~~;" | tr "[/${allow_opt}]" '\n' | wc -w > "/tmp/abl_entries_cnt"
-
-	read -r cnt _ < "/tmp/abl_entries_cnt" || cnt=0
-	case ${cnt} in
-		[0-2]|'') printf 0; return 1 ;;
-		*) printf %s "$((cnt-3))" # to account for the blocklist test entry
-	esac
-	:
 }
 
 # return codes:

--- a/adblock-lean
+++ b/adblock-lean
@@ -40,25 +40,27 @@ abl_dir=/var/run/adblock-lean
 abl_pid_dir=/tmp/adblock-lean
 update_log_file=/var/log/abl_update.log
 session_log_file=/var/log/abl_session.log
+hagezi_dl_url="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard"
+abl_cron_cmd="/etc/init.d/adblock-lean start"
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export HOME=/root
-hagezi_dl_url="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard"
 
 START=99
 STOP=4
 
-EXTRA_COMMANDS="setup status pause resume gen_stats gen_config print_log update"
-EXTRA_HELP="	
+EXTRA_COMMANDS="setup status pause resume gen_stats gen_config update_cron_job print_log update"
+EXTRA_HELP="
 adblock-lean custom commands:
-	setup		run automated setup for adblock-lean
-	status		check dnsmasq and entries count of existing blocklist
-	pause		pause adblock-lean
-	resume		resume adblock-lean
-	gen_stats	generate dnsmasq stats for system log
-	gen_config	generate default config
-	print_log	print most recent session log
-	update		update adblock-lean to the latest version"
+	setup			run automated setup for adblock-lean
+	status			check dnsmasq and entries count of existing blocklist
+	pause			pause adblock-lean
+	resume			resume adblock-lean
+	gen_stats		generate dnsmasq stats for system log
+	gen_config		generate default config
+	update_cron_job	create cron job for adblock-lean with schedule set in the config option 'cron_schedule' 
+	print_log		print most recent session log
+	update			update adblock-lean to the latest version"
 
 
 ### UTILITY FUNCTIONS
@@ -245,12 +247,14 @@ print_def_config()
 	# or custom optional values, examples: opt1, opt1|opt2, ''|opt1|opt2
 
 	local preset
+	mk_preset_arrays
 	if [ "${1}" = '-p' ]
 	then
 		preset="${2}"
 	else
-		preset=small
+		mk_def_preset || { print_msg "Falling back to preset 'small'."; preset=small; }
 	fi
+
 	case "${preset}" in mini|small|medium|large) ;; *) reg_failure "print_def_config: \$preset var has invalid value."; exit 1; esac
 	gen_preset "${preset}" -n
 
@@ -321,7 +325,61 @@ print_def_config()
 	# Start delay in seconds when service is started from system boot
 	boot_start_delay_s="120" @ integer
 
+	# Crontab schedule expression for periodic list updates
+	cron_schedule="${cron_schedule:-"0 5 * * *"}" @ string
+
 	EOT
+}
+
+# 1 - mini|small|medium|large
+# 2 - (optional) '-d' to print the description
+# 2 - (optional) '-n' to print nothing (only assign values to vars)
+gen_preset()
+{
+	local val field mem cnt i=1
+	eval "mem=\"\${${1}_mem}\" cnt=\"\${${1}_cnt}\""
+	[ "${2}" = '-d' ] && print_msg "" "${purple}${1}${n_c}: recommended for devices with ${mem} MB of memory."
+	[ "${2}" != '-n' ] && print_msg "${blue}Elements count:${n_c} ~${cnt}k"
+	for field in blocklist_urls max_file_part_size_KB max_blocklist_file_size_KB min_good_line_count
+	do
+		eval "val=\"\${${1}_${i}}\""
+		eval "${field}=\"${val}\""
+		[ "${2}" != '-n' ] && print_msg "${blue}${field}${n_c}=\"${val}\""
+		i=$((i+1))
+	done
+}
+
+mk_preset_arrays()
+{
+	# quasi-arrays for presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count,
+	# cnt - elements count/1000, mem - memory in MB
+	mini_1="${hagezi_dl_url}/pro.mini-onlydomains.txt" \
+		mini_2=4000 mini_3=4000 mini_4=40000 mini_cnt=85 mini_mem=64
+	small_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" \
+		small_2=7000 small_3=10000 small_4=100000 small_cnt=250 small_mem=128
+	medium_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.medium-onlydomains.txt ${hagezi_dl_url}/popupads-onlydomains.txt" \
+		medium_2=10000 medium_3=20000 medium_4=200000 medium_cnt=350 medium_mem=256
+	large_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" \
+		large_2=30000 large_3=50000 large_4=200000 large_cnt=700 large_mem=512
+}
+
+# determine recommended preset and set quasi-array variables
+mk_def_preset()
+{
+	unset preset totalmem
+	local mem cnt
+	read -r _ totalmem _ </proc/meminfo
+	case "${totalmem}" in
+		''|*[!0-9]*) reg_failure "Failed to determine system memory capacity." ;;
+		*)
+			for preset in large medium small mini
+			do
+				eval "mem=\"\${${preset}_mem}\""
+				# multiplying by 900 rather than 1024 to account for some memory not available to the kernel
+				[ "${totalmem}" -ge $((mem * 900)) ] && break
+			done
+	esac
+	:
 }
 
 # get config format from config file contents
@@ -976,8 +1034,8 @@ cleanup_dl_status_files()
 # 3 - Download Failure (retry makes sense)
 process_list_part()
 {
-	local list_id="${1}" list_type="${2}" list_origin="${3}" list_format="${4}" list_path="${5}" me="process_list_part"
-	local dest_file="${abl_dir}/${list_type}.${list_id}" compress_part='' \
+	local list_id="${1}" list_type="${2}" list_origin="${3}" list_format="${4}" list_path="${5}" me="process_list_part" \
+		dest_file="${abl_dir}/${list_type}.${list_id}" compress_part='' \
 		min_list_part_line_count='' list_part_size_B='' list_part_size_KB='' val_entry_regex
 
 	for v in 1 2 3 4 5; do
@@ -1774,6 +1832,64 @@ report_pid_action()
 	:
 }
 
+### Cron-related functions
+
+rm_cron_job()
+{
+	local curr_cron
+	log_msg -yellow "Removing cron job for adblock-lean."
+	curr_cron="$(crontab -u root -l 2>/dev/null)" || return 1
+	case "${curr_cron}" in
+		*"adblock-lean start"*) ;;
+		*) log_msg "Cron job for adblock-lean is not present."; return 0
+	esac
+
+	printf '%s\n' "${curr_cron}" | sed '/adblock-lean start/d;/^$/d' | crontab -u root - ||
+		{ reg_failure "Failed to update crontab."; return 1; }
+	:
+}
+
+# checks if the cron service is enabled and running
+# if not enabled or not running or if crontab doesn't exist, implements automatic correction
+# return codes: 0 - success, 1 - failure
+enable_cron_service()
+{
+	# returns 0 if crontab is readable and the crond process is running, 1 otherwise
+	# sets $cron_reboot if above conditions are satisfied and cron is not implemented via the busybox binary
+	check_cron_service()
+	{
+		# check if service is enabled
+		${cron_service_path} enabled || return 1
+		# check reading crontab
+		crontab -u root -l &>/dev/null || return 1
+		# check for crond in running processes
+		pidof crond 1>/dev/null || return 1
+		:
+	}
+
+	local cron_service_path="/etc/init.d/cron" enable_failed="Failed to enable and start the cron service"
+
+	hash crontab || { reg_failure "${enable_failed}: 'crontab' utility is inaccessible."; return 1; }
+	[ -f "${cron_service_path}" ] || { reg_failure "${enable_failed}: the cron service was not found at path '${cron_service_path}'."; return 1; }
+
+	check_cron_service && return 0
+	log_msg -warn "The cron service is not enabled or not running."
+
+	printf '\n%s' "${purple}Attempting to enable and start the cron service...${n_c} " > "${msgs_dest}"
+
+	# if crontab doesn't exist yet, try to create an empty crontab
+	crontab -u root -l &>/dev/null || printf '' | crontab -u root -
+
+	# try to enable and start the cron service
+	${cron_service_path} enabled 1>/dev/null || ${cron_service_path} enable && { ${cron_service_path} start; sleep 2; }
+
+	check_cron_service || { printf '%s\n' "${red}Failed.${n_c}"; reg_failure "${enable_failed}."; return 1; }
+	printf '%s\n' "${green}OK${n_c}" > "${msgs_dest}"
+	:
+}
+
+### Commands init
+
 init_command()
 {
 	action="${1}"
@@ -1792,7 +1908,7 @@ init_command()
 
 	# set requirements
 	case ${action} in
-		help|status|gen_stats|print_log|enabled|enable|disable|'') ;;
+		help|status|gen_stats|print_log|enabled|enable|disable|update_cron_job|'') ;;
 		setup|gen_config|pause) lock_req=1 ;;
 		boot|start|update|resume) cleanup_req=1 lock_req=1 ;;
 		stop)
@@ -1867,26 +1983,45 @@ init_command()
 	:
 }
 
-# 1 - mini|small|medium|large
-# 2 - (optional) '-d' to print the description
-# 2 - (optional) '-n' to print nothing (only assign values to vars)
-gen_preset()
-{
-	local val field mem cnt i=1
-	eval "mem=\"\${${1}_mem}\" cnt=\"\${${1}_cnt}\""
-	[ "${2}" = '-d' ] && print_msg "" "${purple}${1}${n_c}: recommended for devices with ${mem} MB of memory."
-	[ "${2}" != '-n' ] && print_msg "${blue}Elements count:${n_c} ~${cnt}k"
-	for field in blocklist_urls max_file_part_size_KB max_blocklist_file_size_KB min_good_line_count
-	do
-		eval "val=\"\${${1}_${i}}\""
-		eval "${field}=\"${val}\""
-		[ "${2}" != '-n' ] && print_msg "${blue}${field}${n_c}=\"${val}\""
-		i=$((i+1))
-	done
-}
-
 
 ### MAIN COMMAND FUNCTIONS
+
+update_cron_job()
+{
+	local me="update_cron_job" curr_cron cron_line
+
+	log_msg -purple "" "Updating cron job for adblock-lean."
+
+	if [ "${action}" = update_cron_job ]
+	then
+		load_config || return 1
+	fi
+
+	[ -z "${cron_schedule}" ] && { reg_failure "${me}: the \$cron_schedule variable is unset."; return 1; }
+	case "${cron_schedule}" in disable) rm_cron_job; return 0; esac
+
+	enable_cron_service || return 1
+
+	curr_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "${me}: Failed to read crontab."; return 1; }
+
+	# check if adblock-lean cron job with same schedule exists
+	case "${curr_cron}" in
+		*"${cron_schedule}"*"${abl_cron_cmd}"*)
+			print_msg "${green}Cron job for adblock-lean with schedule '${cron_schedule}' aldready exists.${n_c}"; return 0 ;;
+		*"${abl_cron_cmd}"*)
+			# remove existing cron job with a different schedule from $curr_cron
+			curr_cron="$(printf %s "${curr_cron}" | sed "s~^.*${abl_cron_cmd}.*\$~~")" ;;
+		*) ;; # no adblock-lean cron job exists
+	esac
+
+	cron_line="${cron_schedule} RANDOM_DELAY=1 ${abl_cron_cmd} 1>/dev/null"
+
+	#### Create new cron job
+	printf '%s\n' "${curr_cron}${nl}${cron_line}" | sed '/^$/d' | crontab -u root - ||
+		{ reg_failure "Failed to update crontab."; return 1; }
+	log_msg "Creating cron job with schedule '${blue}${cron_schedule}${n_c}'."
+	:
+}
 
 setup()
 {
@@ -1904,6 +2039,9 @@ setup()
 			sort) printf coreutils-sort
 		esac
 	}
+
+	# set all luci feedback vars to failed, unset later upon success
+	luci_addnmount_failed=1 luci_service_enable_failed=1 luci_pkgs_install_failed=1 luci_cron_job_creation_failed=1
 
 	init_command setup
 	[ -z "${abl_service_path}" ] && setup_failed "\${abl_service_path} variable is unset."
@@ -1927,6 +2065,7 @@ setup()
 			print_msg "" "${purple}Creating dnsmasq addnmount UCI entry.${n_c}"
 			uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox' && uci commit || setup_failed "Failed to create addnmount entry."
 	esac
+	luci_addnmount_failed=
 
 	# generate config
 	gen_config
@@ -1937,12 +2076,13 @@ setup()
 		print_msg "" "${purple}Enabling the adblock-lean service.${n_c}"
 		/sbin/service adblock-lean enable || setup_failed "Failed to enable the adblock-lean service."
 	else
-		print_msg "" "${green}adblock-lean service is already enabled.${n_c}"
+		print_msg "" "The ${green}adblock-lean service is already enabled.${n_c}"
 	fi
+	luci_service_enable_failed=
 
 	# determine if there are missing GNU utils
 	local pkgs2install='' missing_packages='' missing_utils='' missing_utils_print='' util package \
-		util_size utils_size_KB=0 awk_size=460 sort_size=120 sed_size=150 \
+		util_size_B utils_size_B=0 awk_size_B=1048576 sort_size_B=122880 sed_size_B=153600 \
 		installed_utils="$(opkg list_installed | grep -E '^[ \t]*(sed|gawk|coreutils-sort)([ \t]|$)')"
 
 	echo
@@ -1980,8 +2120,8 @@ setup()
 			REPLY=n
 			if [ -n "${do_dialogs}" ]
 			then
-				eval "util_size=\"\${${util}_size}\""
-				print_msg "Would you like to install ${blue}GNU ${util}${n_c} automatically? Installed size: ${yellow}${util_size} KiB${n_c}."
+				eval "util_size_B=\"\${${util}_size_B}\""
+				print_msg "Would you like to install ${blue}GNU ${util}${n_c} automatically? Installed size: ${yellow}$(bytes2human "${util_size_B}")${n_c}."
 				pick_opt "y|n" || exit 1
 			elif [ -n "${luci_install_packages}" ]
 			then
@@ -1991,7 +2131,7 @@ setup()
 			if [ "${REPLY}" = y ]
 			then
 				pkgs2install="${pkgs2install}$(get_package_name "${util}") "
-				utils_size_KB=$((utils_size_KB+util_size))
+				utils_size_B=$((utils_size_B+util_size_B))
 			fi
 		done
 	fi
@@ -1999,7 +2139,6 @@ setup()
 	# install GNU utils
 	if [ -n "${pkgs2install}" ]
 	then
-		local utils_size_B="$((utils_size_KB*1024))"
 		REPLY=n
 		if [ -n "${do_dialogs}" ]
 		then
@@ -2011,12 +2150,13 @@ setup()
 		then
 			REPLY=y
 		fi
+
 		if [ "${REPLY}" = y ]
 		then
 			if [ -z "${free_space_B}" ] || [ -z "${utils_size_B}" ] || [ ${free_space_B} -gt ${utils_size_B} ]
 			then
 				echo
-				opkg update && opkg install ${pkgs2install% } ||
+				opkg update && opkg install ${pkgs2install% } && luci_pkgs_install_failed='' ||
 					reg_failure "Failed to automatically install packages. You can install them manually later."
 			else
 				reg_failure "Not enough free space at mount point '${mount_point}'."
@@ -2024,6 +2164,8 @@ setup()
 					"opkg update; opkg install ${pkgs2install% }"
 			fi
 		fi
+	else
+		luci_pkgs_install_failed=
 	fi
 
 	if [ -n "${do_dialogs}" ]
@@ -2059,39 +2201,15 @@ gen_config()
 {
 	init_command gen_config || exit 1
 
-	# quasi-arrays for default presets: 1 - url, 2 - max part size, 3 - max blocklist size, 4 - min line count,
-	# cnt - elements count/1000, mem - memory in MB
-	local mini_1="${hagezi_dl_url}/pro.mini-onlydomains.txt" \
-		mini_2=4000 mini_3=4000 mini_4=40000 mini_cnt=85 mini_mem=64
-	local small_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.mini-onlydomains.txt" \
-		small_2=7000 small_3=10000 small_4=100000 small_cnt=250 small_mem=128
-	local medium_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.medium-onlydomains.txt ${hagezi_dl_url}/popupads-onlydomains.txt" \
-		medium_2=10000 medium_3=20000 medium_4=200000 medium_cnt=350 medium_mem=256
-	local large_1="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" \
-		large_2=30000 large_3=50000 large_4=200000 large_cnt=700 large_mem=512
-
-	local preset='' mem totalmem cnt
-
-	# determine recommended preset
-	read -r _ totalmem _ </proc/meminfo
-	case "${totalmem}" in
-		''|*[!0-9]*)
-			reg_failure "Failed to determine system memory capacity."
-			print_msg "Skipping automatic preset recommendation." ;;
-		*)
-			for preset in large medium small mini
-			do
-				eval "mem=\"\${${preset}_mem}\""
-				# multiplying by 900 rather than 1024 to account for some memory not available to the kernel
-				[ "${totalmem}" -ge $((mem * 900)) ] && break
-			done
-	esac
+	local preset cnt
 
 	if [ -n "${do_dialogs}" ] && [ -z "${luci_preset}" ]
 	then
+		mk_preset_arrays
+		mk_def_preset || print_msg "Skipping automatic preset recommendation."
 		if [ -n "${preset}" ]
 		then
-			print_msg "" "Based on the total usable memory of this device ($(bytes2human $((totalmem*1024)) )), the recommended preset is ${purple}${preset}${n_c}:"
+			print_msg "" "Based on the total usable memory of this device ($(bytes2human $((totalmem*1024)) )), the recommended preset is '${purple}${preset}${n_c}':"
 			gen_preset "${preset}"
 			print_msg "" "[C]onfirm this preset or [p]ick another preset?"
 			pick_opt "c|p"
@@ -2116,14 +2234,43 @@ gen_config()
 
 	[ -z "${preset}" ] && { reg_failure "No config preset was selected."; exit 1; }
 
+	# create cron job
+	cron_schedule=
+	local def_schedule="0 5 * * *" def_schedule_desc="daily at 5am (5 o'clock at night)"
+
+	REPLY=n
+	if [ -n "${do_dialogs}" ]
+	then
+		print_msg "" "${purple}Cron job configuration:${n_c}" \
+			"A cron job can be created to enable automatic list updates." \
+			"The default schedule is '${blue}${def_schedule}${n_c}': ${def_schedule_desc}" \
+			"The cron job will run with an added random number of minutes." \
+			"" "Create cron job with default schedule for automatic list updates?" \
+			"If you enter 'n', you can later create a cron job with a custom schedule as described in:" \
+			"https://github.com/lynxthecat/adblock-lean/blob/master/README.md"
+		pick_opt "y|n" || exit 1
+		cron_schedule="${def_schedule}"
+	elif [ -n "${luci_update_cron_job}" ] && [ -n "${luci_cron_schedule}" ]
+	then
+		REPLY=y
+		cron_schedule="${luci_cron_schedule}"
+	elif  [ -n "${luci_update_cron_job}" ]
+	then
+		reg_failure "Can not create cron job for luci because the \${luci_cron_schedule} var is empty."
+	fi
+	[ "${REPLY}" = n ] && cron_schedule=disable
+
 	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1
 	if [ -n "${do_dialogs}" ] && [ -f "${config_file}" ]
 	then
-		print_msg "This will overwrite existing config with default one. Proceed?"
+		print_msg "This will overwrite existing config. Proceed?"
 		pick_opt "y|n" || exit 1
 		[ "${REPLY}" = n ] && exit 1
 	fi
 	write_config "$(print_def_config -p "${preset}")" || exit 1
+
+	update_cron_job && luci_cron_job_creation_failed=''
+
 	mk_new_urls_format_flag || exit 1 # @url_conversion_logic
 	check_blocklist_compression_support
 	:
@@ -2451,5 +2598,20 @@ update()
 
 set_colors
 
-[ "${1}" = setup ] && setup
+[ "${1}" = setup ] && { setup; exit 0; }
+
+case "${action}" in
+	enable)
+		log_msg -purple "Enabling adblock-lean."
+		load_config
+		update_cron_job ;;
+	disable)
+		log_msg -purple "Disabling adblock-lean."
+		load_config
+		case "${cron_schedule}" in
+			''|disable) ;;
+			*) rm_cron_job
+		esac
+esac
+
 :

--- a/adblock-lean
+++ b/adblock-lean
@@ -373,7 +373,7 @@ mk_def_preset()
 	local mem cnt
 	read -r _ totalmem _ </proc/meminfo
 	case "${totalmem}" in
-		''|*[!0-9]*) reg_failure "Failed to determine system memory capacity."; return 1 ;;
+		''|*[!0-9]*) reg_failure "\$totalmem has invalid value '${totalmem}'. Failed to determine system memory capacity."; return 1 ;;
 		*)
 			for preset in large medium small mini
 			do

--- a/adblock-lean
+++ b/adblock-lean
@@ -1840,13 +1840,13 @@ report_pid_action()
 rm_cron_job()
 {
 	local curr_cron
-	log_msg -yellow "Removing cron job for adblock-lean."
-	curr_cron="$(crontab -u root -l 2>/dev/null)" || return 1
-	case "${curr_cron}" in
-		*"adblock-lean start"*) ;;
-		*) log_msg "Cron job for adblock-lean is not present."; return 0
+	curr_cron="$(get_curr_crontab)"
+	case ${?} in
+		1) return 1 ;;
+		3) return 0
 	esac
 
+	log_msg -purple "" "Removing cron job for adblock-lean."
 	printf '%s\n' "${curr_cron}" | sed '/adblock-lean start/d;/^$/d' | crontab -u root - ||
 		{ reg_failure "Failed to update crontab."; return 1; }
 	:
@@ -1989,6 +1989,26 @@ init_command()
 
 ### MAIN COMMAND FUNCTIONS
 
+# args: 1 - (optional) schedule
+# return codes:
+# 0 - cron job with same schedule exists
+# 1 - error
+# 2 - cron job with a different schedule exists
+# 3 - cron job doesn't exist
+get_curr_crontab()
+{
+	local curr_cron
+	curr_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "${me}: Failed to read crontab."; return 1; }
+	printf '%s\n' "${curr_cron}"
+
+	# check if adblock-lean cron job with same schedule exists
+	case "${curr_cron}" in
+		*"${cron_schedule}"*"${abl_cron_cmd}"*) return 0 ;;
+		*"${abl_cron_cmd}"*) return 2 ;;
+		*) return 3 ;;
+	esac
+}
+
 upd_cron_job()
 {
 	local me="upd_cron_job" curr_cron cron_line
@@ -2001,20 +2021,21 @@ upd_cron_job()
 	fi
 
 	[ -z "${cron_schedule}" ] && { reg_failure "${me}: the \$cron_schedule variable is unset."; return 1; }
-	case "${cron_schedule}" in disable) log_msg -yellow "cron_schedule is set to 'disable' in config."; rm_cron_job; return 0; esac
+
+	if [ "${cron_schedule}" = disable ]
+	then
+		log_msg -yellow "cron_schedule is set to 'disable' in config."
+		rm_cron_job
+		return 0
+	fi
 
 	enable_cron_service || return 1
-
-	curr_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "${me}: Failed to read crontab."; return 1; }
-
-	# check if adblock-lean cron job with same schedule exists
-	case "${curr_cron}" in
-		*"${cron_schedule}"*"${abl_cron_cmd}"*)
-			print_msg "${green}Cron job for adblock-lean with schedule '${cron_schedule}' aldready exists.${n_c}"; return 0 ;;
-		*"${abl_cron_cmd}"*)
-			# remove existing cron job with a different schedule from $curr_cron
-			curr_cron="$(printf %s "${curr_cron}" | sed "s~^.*${abl_cron_cmd}.*\$~~")" ;;
-		*) ;; # no adblock-lean cron job exists
+	curr_cron="$(get_curr_crontab)"
+	case ${?} in
+		0) print_msg "${green}Cron job for adblock-lean with schedule '${cron_schedule}' aldready exists.${n_c}"; return 0 ;;
+		1) return 1 ;;
+		2) curr_cron="$(printf %s "${curr_cron}" | sed "s~^.*${abl_cron_cmd}.*\$~~")" ;; # remove cron job with a different schedule
+		3) ;; # no adblock-lean cron job exists
 	esac
 
 	cron_line="${cron_schedule} RANDOM_DELAY=1 ${abl_cron_cmd} 1>/dev/null"

--- a/adblock-lean
+++ b/adblock-lean
@@ -57,8 +57,8 @@ adblock-lean custom commands:
 	pause			pause adblock-lean
 	resume			resume adblock-lean
 	gen_stats		generate dnsmasq stats for system log
-	gen_config		generate default config
-	update_cron_job	create cron job for adblock-lean with schedule set in the config option 'cron_schedule' 
+	gen_config		generate default config and enable the adblock-lean service
+	update_cron_job	create cron job for adblock-lean with schedule set in the config option 'cron_schedule'. if set to 'disable', remove existing cron job if any
 	print_log		print most recent session log
 	update			update adblock-lean to the latest version"
 
@@ -1998,7 +1998,7 @@ update_cron_job()
 	fi
 
 	[ -z "${cron_schedule}" ] && { reg_failure "${me}: the \$cron_schedule variable is unset."; return 1; }
-	case "${cron_schedule}" in disable) rm_cron_job; return 0; esac
+	case "${cron_schedule}" in disable) log_msg -yellow "cron_schedule is set to 'disable' in config."; rm_cron_job; return 0; esac
 
 	enable_cron_service || return 1
 
@@ -2067,18 +2067,8 @@ setup()
 	esac
 	luci_addnmount_failed=
 
-	# generate config
-	gen_config
-
-	# enable the service
-	if ! /sbin/service adblock-lean enabled
-	then
-		print_msg "" "${purple}Enabling the adblock-lean service.${n_c}"
-		/sbin/service adblock-lean enable || setup_failed "Failed to enable the adblock-lean service."
-	else
-		print_msg "" "The ${green}adblock-lean service is already enabled.${n_c}"
-	fi
-	luci_service_enable_failed=
+	# generate config and enable the service
+	gen_config || exit 1
 
 	# determine if there are missing GNU utils
 	local pkgs2install='' missing_packages='' missing_utils='' missing_utils_print='' util package \
@@ -2197,9 +2187,10 @@ gen_stats()
 	[ "${1}" != '-noexit' ] && exit 0
 }
 
+# generates config and enables the service
 gen_config()
 {
-	init_command gen_config || exit 1
+	init_command gen_config || return 1
 
 	local preset cnt
 
@@ -2232,7 +2223,7 @@ gen_config()
 		[ "${luci_preset}" != auto ] && preset="${luci_preset}"
 	fi
 
-	[ -z "${preset}" ] && { reg_failure "No config preset was selected."; exit 1; }
+	[ -z "${preset}" ] && { reg_failure "No config preset was selected."; return 1; }
 
 	# create cron job
 	cron_schedule=
@@ -2248,7 +2239,7 @@ gen_config()
 			"" "Create cron job with default schedule for automatic list updates?" \
 			"If you enter 'n', you can later create a cron job with a custom schedule as described in:" \
 			"https://github.com/lynxthecat/adblock-lean/blob/master/README.md"
-		pick_opt "y|n" || exit 1
+		pick_opt "y|n" || return 1
 		cron_schedule="${def_schedule}"
 	elif [ -n "${luci_update_cron_job}" ] && [ -n "${luci_cron_schedule}" ]
 	then
@@ -2260,18 +2251,26 @@ gen_config()
 	fi
 	[ "${REPLY}" = n ] && cron_schedule=disable
 
-	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || exit 1
+	reg_action -purple "Generating new default config for adblock-lean from preset '${preset}'." || return 1
 	if [ -n "${do_dialogs}" ] && [ -f "${config_file}" ]
 	then
 		print_msg "This will overwrite existing config. Proceed?"
-		pick_opt "y|n" || exit 1
-		[ "${REPLY}" = n ] && exit 1
+		pick_opt "y|n" || return 1
+		[ "${REPLY}" = n ] && return 1
 	fi
-	write_config "$(print_def_config -p "${preset}")" || exit 1
+	write_config "$(print_def_config -p "${preset}")" || return 1
 
-	update_cron_job && luci_cron_job_creation_failed=''
+	# enable the service
+	if ! /sbin/service adblock-lean enabled
+	then
+		print_msg "" "${purple}Enabling the adblock-lean service.${n_c}"
+		/sbin/service adblock-lean enable || { reg_failure "Failed to enable the adblock-lean service."; return 1; }
+	else
+		print_msg "" "The ${green}adblock-lean service is already enabled.${n_c}"
+	fi
+	luci_service_enable_failed=
 
-	mk_new_urls_format_flag || exit 1 # @url_conversion_logic
+	mk_new_urls_format_flag || return 1 # @url_conversion_logic
 	check_blocklist_compression_support
 	:
 }
@@ -2608,10 +2607,7 @@ case "${action}" in
 	disable)
 		log_msg -purple "Disabling adblock-lean."
 		load_config
-		case "${cron_schedule}" in
-			''|disable) ;;
-			*) rm_cron_job
-		esac
+		rm_cron_job
 esac
 
 :

--- a/adblock-lean
+++ b/adblock-lean
@@ -2661,12 +2661,11 @@ case "${action}" in
 			then
 				/sbin/service adblock-lean disable && ! /sbin/service adblock-lean enabled ||
 					{ reg_failure "Failed to disable the adblock-lean service"; exit 1; }
+				stop
+				load_config && rm_cron_job
 			else
 				log_msg "The adblock-lean service is already disabled."
 			fi
-			load_config
-			rm_cron_job
-			stop
 			disabling=
 		fi
 esac


### PR DESCRIPTION
Implements automated setup command, called when running `sh /etc/init.d/adblock-lean setup` or `service adblock-lean setup`:
- Make the script executable (if not executable yet)
- Create addnmount entry (if doesn't exist yet)
- Call gen_config() if config file doesn't exist yet, or if the user chooses to recreate the config
- If config file exists and the user chooses to keep it, call `load_config()` and `upd_cron_job()`
- Enable the service (if not enabled yet)
- Offer to install GNU utils if not installed yet (GNU awk, GNU sed, GNU sort)
- Offer to start adblock-lean

gen_config():
- New option `cron_schedule` (syntax: `<cron_schedule_expression>|disable`)
- Offer to create a cron job with default schedule

Action enable: call upd_cron_job().
Action disable: call rm_cron_job().
Action disable: call stop().

Detect and report 3 types of wrong URLs:
- 'github.com' URLs
- Hagezi dnsmasq-formatted URLs in the raw-domains URLs options
- Hagezi raw-domains URLs without the `-onlydomains` suffix

Updates README.md