### PR TITLE
Add whitelist mode and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Each configuration option is internally documented with comments in `/etc/adbloc
 |             `dnsmasq_allowlist_urls` | One or more dnsmasq format allowlist URLs to download and process              |
 |               `local_allowlist_path` | Path to local allowlist (domain will not be blocked)                           |
 |               `local_blocklist_path` | Path to local blocklist (domain will be blocked)                               |
+|                       `test_domains` | Domains used to test DNS resolution after loading the final blocklist          |
 |            `list_part_failed_action` | Governs failed lists handling: 'SKIP' or 'STOP'                                |
 |               `max_download_retries` | Maximum number of download retries for allowlist/blocklist parts               |
 |                `min_good_line_count` | Minimum number of good lines in final postprocessed blocklist                  |
@@ -208,6 +209,10 @@ https://github.com/hagezi/dns-blocklists
 This mode can be used to implement parental control or similar functionality while also adblocking inside the allowed domains. It can be enabled by setting the config option `whitelist_mode` to `1`. In this mode all domain names will be resolved to 127.0.0.1, except for domains (and their subdomains) included in local and/or downloaded allowlists. In this mode, if blocklists are used in addition to allowlists, subdomains which are included in the blocklists and which are subdomains of allowed domains - will be blocked (with the 'nx domain' response).
 
 For example, if the an allowlist has this entry: `google.com` and a blocklist has this entry: `ads.google.com`, and `whitelist_mode` is set to `1`, then `ads.google.com` will be blocked, while `google.com` and `mail.google.com` (and any other subdomain of `google.com` which is not included in the blocklist) will work.
+
+Note that in this mode, the test domains (specified via the option `test_domains`) will be automatically added to the allowlist in order for the checks to pass. You can use empty string in that option - this will bypass that check and block the default domains (google.com, microsoft.com, amazon.com).
+
+Also note that in this mode by default the Github domains will be blocked, so the automatic update functionality will not work - unless you add github.com to the allowlist.
 
 ## User-configurable calls on success or failure
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The default Hagezi dnsmasq format lists [hagezi](https://github.com/hagezi/dns-b
 
 ## Installation on OpenWrt
 
-adblock-lean is written as a service script and can be installed via terminal.
+Connect to your OpenWrt router [via SSH](https://openwrt.org/docs/guide-quick-start/sshadministration) and then follow the guide below.
 
-To download it, use the following command:
+To download adblock-lean, use the following command:
 ```bash
 uclient-fetch https://raw.githubusercontent.com/lynxthecat/adblock-lean/main/adblock-lean -O /etc/init.d/adblock-lean
 ```
@@ -58,7 +58,7 @@ adblock-lean includes the following features:
 - support multiple blocklist files downloaded from user-specified urls
 - support local blocklist
 - same for downloaded and local allowlists
-- support allowlist-only mode
+- support whitelist mode
 - removal of domains found in the allowlist form the blocklist files
 - combining all downloaded and local lists into one final blocklist file
 - check that each individual blocklist and allowlist file does not exceed configurable maximum size

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ If you like adblock-lean and can benefit from it, then please leave a ⭐ (top r
 adblock-lean is **highly optimized for RAM & CPU efficiency** during blocklist download & processing, and does not remain running in memory after execution.  adblock-lean is designed to leverage the [major rewrite of the DNS server and domain handling code](https://thekelleys.org.uk/dnsmasq/CHANGELOG) associated with dnsmasq 2.86, which drastically improves dnsmasq performance and reduces memory footprint. This facilitates the use of very large blocklists even for low spec, low performance devices.
 
 ## Features
-adblock-lean is written as a service and 'service adblock-lean start' will process any local blocklist/allowlist, download blocklist/allowlist parts, generate a new merged blocklist file and set up dnsmasq with it. Various checks are performed and, depending on the outcome of those checks, the script will either: accept the new blocklist file; reject the blocklist file if it didn't pass the checks and fallback to a previous blocklist file if available; or as a last resort restart dnsmasq with no blocklist file.
 
 adblock-lean includes the following features:
 
@@ -63,6 +62,26 @@ service adblock-lean enable
 opkg update
 opkg install gawk sed coreutils-sort
 ```
+
+## Usage
+
+adblock-lean is written as a service and `service adblock-lean start` will process any local blocklist/allowlist, download blocklist/allowlist parts, generate a new merged blocklist file and set up dnsmasq with it. Various checks are performed and, depending on the outcome of those checks, the script will either: accept the new blocklist file; reject the blocklist file if it didn't pass the checks and fallback to a previous blocklist file if available; or as a last resort restart dnsmasq with no blocklist file.
+
+Additional available commands:
+- `stop`: stops any running adblock-lean instances, unloads the blocklist and removes it from memory
+- `restart`: runs the `stop`, then `start` commands
+- `pause`: unloads the blocklist and creates a compressed copy of it
+- `resume`: decompresses the blocklist and loads it into dnsmasq
+- `update`: pulls an update for adblock-lean from Github (if available) and installs the updated version
+- `uninstall`: removes the adblock-lean service and optionally adblock-lean settings, and undoes any other changes adblock-lean made to the system
+- `gen_config`: generate default config based on one of the pre-defined presets
+- `setup`: run automated setup for adblock-lean
+- `status`: check dnsmasq and entries count of the active blocklist.
+            If adblock-lean is doing something in the background, `status` will print which operation is currently performed.
+- `gen_stats`: generate dnsmasq stats (prints to system log)
+- `print_log`: print most recent session log
+- `upd_cron_job`: create cron job for adblock-lean with schedule set in the config option 'cron_schedule'.
+	              if config option set to 'disable', remove existing cron job if any
 
 ## Basic configuration
 The config file for adblock-lean is located in `/etc/adblock-lean/config`.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,30 @@ If you like adblock-lean and can benefit from it, then please leave a ⭐ (top r
 
 adblock-lean is **highly optimized for RAM & CPU efficiency** during blocklist download & processing, and does not remain running in memory after execution.  adblock-lean is designed to leverage the [major rewrite of the DNS server and domain handling code](https://thekelleys.org.uk/dnsmasq/CHANGELOG) associated with dnsmasq 2.86, which drastically improves dnsmasq performance and reduces memory footprint. This facilitates the use of very large blocklists even for low spec, low performance devices.
 
-**USER NOTICE:**  Current versions September 19, 2024 and onwards switch to using raw formatted blocklists by default (the default lists are still Hagezi).  Dnsmasq formatted lists are still supported.  Raw lists have the benefit of smaller file size dowload, improvements in processing speed and reduced ram usage.  On the first run after updating, adblock-lean will prompt you (y/n) to automatically change URLs for Hagezi & OISD lists from dnsmasq format to raw format.  For other lists, you can choose to find a raw formatted list or continue using dnsmasq formatted lists.  You can always use ```service adblock-lean gen_config``` to generate a fresh configuration file if required.
+## Features
+adblock-lean is written as a service and 'service adblock-lean start' will process any local blocklist/allowlist, download blocklist/allowlist parts, generate a new merged blocklist file and set up dnsmasq with it. Various checks are performed and, depending on the outcome of those checks, the script will either: accept the new blocklist file; reject the blocklist file if it didn't pass the checks and fallback to a previous blocklist file if available; or as a last resort restart dnsmasq with no blocklist file.
 
-Hagezi raw lists can be found [here](https://github.com/hagezi/dns-blocklists/tree/main/wildcard). **NOTE** that the file names of correct lists have the `-onlydomains` suffix.
-Visual example of raw ```blocklist_urls``` [Hagezi light raw](https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light-onlydomains.txt).  
-Visual example of dnsmasq formmatted ```dnsmasq_blocklist_urls``` [Hagezi light dnsmasq](https://raw.githubusercontent.com/hagezi/dns-blocklists/main/dnsmasq/light.txt).
+adblock-lean includes the following features:
 
-oisd raw domains-formatted lists can be found [here](https://oisd.nl/setup). **NOTE** that the correct lists are **only** the ones named `domainswild2` (note the `2`).
-oisd dnsmasq-formatted lists can be found at the same URL, except you would be looking for lists named `dnsmasq2`.
-
-The default Hagezi dnsmasq format lists [hagezi](https://github.com/hagezi/dns-blocklists) are recommended to block as many _ads, affiliate, tracking, metrics, telemetry, fake, phishing, malware, scam, coins and other "crap"_ as possible, all while breaking as few websites as possible. Any other raw or dnsmasq format lists of your choice can also be configured and used.
+- support multiple blocklist files downloaded from user-specified urls
+- support local blocklist
+- same for downloaded and local allowlists
+- support whitelist mode
+- removal of domains found in the allowlist form the blocklist files
+- combining all downloaded and local lists into one final blocklist file
+- check that each individual blocklist and allowlist file does not exceed configurable maximum size
+- check that the total blocklist size does not exceeed configurable maximum file size
+- check for rogue entries in blocklist file parts (e.g. check for redirection to specific IP)
+- check that line count in blocklist file does not exceed configurable minimum (default: 100,000)
+- save a compressed copy of the previous blocklist file, then load the new combined blocklist file into dnsmasq
+- supports blocklist compression by leveraging the new conf-script functionality of dnsmasq
+- perform checks on restarted dnsmasq with new blocklist file
+- revert to previous blocklist file if checks fail
+- if checks on previous blocklist file also fail then revert to not using any blocklist file
+- implements optional calls to user-configurable script on success or failure (for example to send an email report)
+- automatically check for application updates and self update functionality
+- config keys and values validation and optional automatic config repair when problems are detected
+- automated interactive setup
 
 ## Installation on OpenWrt
 
@@ -49,31 +63,6 @@ service adblock-lean enable
 opkg update
 opkg install gawk sed coreutils-sort
 ```
-
-## Features
-adblock-lean is written as a service and 'service adblock-lean start' will process any local blocklist/allowlist, download blocklist/allowlist parts, generate a new merged blocklist file and set up dnsmasq with it. Various checks are performed and, depending on the outcome of those checks, the script will either: accept the new blocklist file; reject the blocklist file if it didn't pass the checks and fallback to a previous blocklist file if available; or as a last resort restart dnsmasq with no blocklist file.
-
-adblock-lean includes the following features:
-
-- support multiple blocklist files downloaded from user-specified urls
-- support local blocklist
-- same for downloaded and local allowlists
-- support whitelist mode
-- removal of domains found in the allowlist form the blocklist files
-- combining all downloaded and local lists into one final blocklist file
-- check that each individual blocklist and allowlist file does not exceed configurable maximum size
-- check that the total blocklist size does not exceeed configurable maximum file size
-- check for rogue entries in blocklist file parts (e.g. check for redirection to specific IP)
-- check that line count in blocklist file does not exceed configurable minimum (default: 100,000)
-- save a compressed copy of the previous blocklist file, then load the new combined blocklist file into dnsmasq
-- supports blocklist compression by leveraging the new conf-script functionality of dnsmasq
-- perform checks on restarted dnsmasq with new blocklist file
-- revert to previous blocklist file if checks fail
-- if checks on previous blocklist file also fail then revert to not using any blocklist file
-- implements optional calls to user-configurable script on success or failure (for example to send an email report)
-- automatically check for application updates and self update functionality
-- config keys and values validation and optional automatic config repair when problems are detected
-- automated interactive setup
 
 ## Basic configuration
 The config file for adblock-lean is located in `/etc/adblock-lean/config`.
@@ -116,6 +105,18 @@ cron_schedule="disable"
 **Important:** After changing the schedule in the config, run the following command to have adblock-lean create/update/remove the cron job:
 `service adblock-lean upd_cron_job`
 
+## Supported formats
+
+**USER NOTICE:**  Current versions September 19, 2024 and onwards switch to using raw formatted blocklists by default (the default lists are still Hagezi).  Dnsmasq formatted lists are still supported.  Raw lists have the benefit of smaller file size dowload, improvements in processing speed and reduced ram usage.  On the first run after updating, adblock-lean will prompt you (y/n) to automatically change URLs for Hagezi & OISD lists from dnsmasq format to raw format.  For other lists, you can choose to find a raw formatted list or continue using dnsmasq formatted lists.  You can always use ```service adblock-lean gen_config``` to generate a fresh configuration file if required.
+
+Hagezi raw lists can be found [here](https://github.com/hagezi/dns-blocklists/tree/main/wildcard). **NOTE** that the file names of correct lists have the `-onlydomains` suffix.
+Visual example of raw ```blocklist_urls``` [Hagezi light raw](https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light-onlydomains.txt).  
+Visual example of dnsmasq formmatted ```dnsmasq_blocklist_urls``` [Hagezi light dnsmasq](https://raw.githubusercontent.com/hagezi/dns-blocklists/main/dnsmasq/light.txt).
+
+oisd raw domains-formatted lists can be found [here](https://oisd.nl/setup). **NOTE** that the correct lists are **only** the ones named `domainswild2` (note the `2`).
+oisd dnsmasq-formatted lists can be found at the same URL, except you would be looking for lists named `dnsmasq2`.
+
+The default Hagezi dnsmasq format lists [hagezi](https://github.com/hagezi/dns-blocklists) are recommended to block as many _ads, affiliate, tracking, metrics, telemetry, fake, phishing, malware, scam, coins and other "crap"_ as possible, all while breaking as few websites as possible. Any other raw or dnsmasq format lists of your choice can also be configured and used.
 
 ## Advanced configuration
 
@@ -166,7 +167,7 @@ adblock-lean includes 4 pre-defined presets (mini, small, medium, large), each o
 
 The pre-defined presets are:
 
-- **Mini**: for devices with 64MB of RAM. Aim for <100k entries. Example below: circa 85k entries
+- **Mini**: for devices with 64MB of RAM. Aim for <100k entries. This preset includes circa 85k entries
 ```bash
 blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.mini-onlydomains.txt"
 min_blocklist_part_line_count=1
@@ -175,7 +176,7 @@ max_blocklist_file_size_KB=4000
 min_good_line_count=40000
 ```
 
-- **Small**: for devices with 128MB of RAM. Aim for <300k entries. Example below: circa 250k entries
+- **Small**: for devices with 128MB of RAM. Aim for <300k entries. This preset includes circa 250k entries
 ```bash
 blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.mini-onlydomains.txt"
 min_blocklist_part_line_count=1
@@ -184,7 +185,7 @@ max_blocklist_file_size_KB=10000
 min_good_line_count=100000
 ```
 
-- **Medium**: for devices with 256MB of RAM. Aim for <600k entries. Example below: circa 350k entries
+- **Medium**: for devices with 256MB of RAM. Aim for <600k entries. This preset includes circa 350k entries
 ```bash
 blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.medium-onlydomains.txt"
 min_blocklist_part_line_count=1
@@ -193,7 +194,7 @@ max_blocklist_file_size_KB=20000
 min_good_line_count=200000
 ```
 
-- **Large**: for devices with 512MB of RAM or more. Example below: circa 700k entries
+- **Large**: for devices with 512MB of RAM or more. This preset includes circa 700k entries
 ```bash
 blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro-onlydomains.txt https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif-onlydomains.txt"
 min_blocklist_part_line_count=1
@@ -210,9 +211,11 @@ This mode can be used to implement parental control or similar functionality whi
 
 For example, if the an allowlist has this entry: `google.com` and a blocklist has this entry: `ads.google.com`, and `whitelist_mode` is set to `1`, then `ads.google.com` will be blocked, while `google.com` and `mail.google.com` (and any other subdomain of `google.com` which is not included in the blocklist) will work.
 
-Note that in this mode, the test domains (specified via the option `test_domains`) will be automatically added to the allowlist in order for the checks to pass. You can use empty string in that option - this will bypass that check and block the default domains (google.com, microsoft.com, amazon.com).
+Note that in this mode, the test domains (specified via the option `test_domains`) will be automatically added to the allowlist in order for the checks to pass. You can use empty string in that option - this will bypass that check and block the default domains (google.com, microsoft.com, amazon.com). Alternatively, you can specify preferred test domains instead of the default ones.
 
 Also note that in this mode by default the Github domains will be blocked, so the automatic update functionality will not work - unless you add github.com to the allowlist.
+
+The resulting blocklist generated in whitelist mode will be typically much smaller than otherwise, so you may need to reduce the value of the `min_good_line_count` option in order for the list to be accepted by adblock-lean.
 
 ## User-configurable calls on success or failure
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Each configuration option is internally documented with comments in `/etc/adbloc
 
 For devices with low free memory, consider enabling the `initial_dnsmasq_restart` option to free up memory for use during the memory-intensive blocklist generation process by additionally restarting dnsmasq with no blocklist prior to the generation of the new blocklist. This option is disabled by default to prevent both the associated: dnsmasq downtime; and the temporary running of dnsmasq with no blocklist.
 
-## Selection of blocklist(s) and download and processing parameters
+## Selection of blocklists and associated parameters
 
 An important factor in selecting blocklist(s) is how much free memory is available for blocklist use. It is the responsibility of the user to ensure that there is sufficient free memory to prevent an out of memory situation.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ An excellent breakdown of highly suitable lists and their merits is provided at:
 https://github.com/hagezi/dns-blocklists
 
 ## Whitelist mode
-This mode can be used to implement parental control or similar functionality while also adblocking inside the allowed domains. It can be enabled by setting the config option `whitelist_mode` to `1`. In this mode all domain names will be resolved to 127.0.0.1, except for domains (and their subdomains) included in local and/or downloaded allowlists. In this mode, if blocklists are used in addition to allowlists, subdomains which are included in the blocklists and which are subdomains of allowed domains - will be blocked (with the 'nx domain' response).
+This mode can be used to implement parental control or similar functionality while also adblocking inside the allowed domains. It can be enabled by setting the config option `whitelist_mode` to `1`. In this mode all domain names will be blocked, except for domains (and their subdomains) included in local and/or downloaded allowlists. In this mode, if blocklists are used in addition to allowlists, addresses which are included in the blocklists and which are subdomains of allowed domains - will be blocked as well.
 
 For example, if the an allowlist has this entry: `google.com` and a blocklist has this entry: `ads.google.com`, and `whitelist_mode` is set to `1`, then `ads.google.com` will be blocked, while `google.com` and `mail.google.com` (and any other subdomain of `google.com` which is not included in the blocklist) will work.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,18 @@ This will ask you several questions and make all important changes automatically
 
 ### Manual setup
 ```bash
-chmod +x /etc/init.d/adblock-lean
-service adblock-lean gen_config   # generates default config in /root/adblock-lean/config and sets up blocklist updates
-uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox' && uci commit   # Optional/recommended. Enables blocklist compression to reduce RAM usage
-service adblock-lean enable   # this will allow the script to automatically run on boot
-opkg install update
-opkg install gawk sed coreutils-sort # Optional/recommended. Makes list processing significantly faster (doesn't affect DNS resolution speed). gawk including dependencies may consume around 1MB. If flash space is an issue, consider skipping gawk installation.
+chmod +x /etc/init.d/adblock-lean # Makes the script executable
+service adblock-lean gen_config   # Generates default config in /root/adblock-lean/config and sets up blocklist updates
+
+# Optional/recommended. Enables blocklist compression to reduce RAM usage
+uci set dhcp.adblock_lean=dnsmasq && uci add_list dhcp.adblock_lean.addnmount='/bin/busybox' && uci commit
+
+# This will allow adblock-lean to automatically run on boot
+service adblock-lean enable
+
+# Optional/recommended. Makes list processing significantly faster (doesn't affect DNS resolution speed). gawk including dependencies may consume around 1MB. If flash space is an issue, consider skipping gawk installation.
+opkg update
+opkg install gawk sed coreutils-sort
 ```
 
 ## Features
@@ -298,6 +304,13 @@ After updating adblock-lean, run the command:
 ```bash
 service adblock-lean start
 ```
+
+## Uninstalling
+
+To uninstall adblock-lean, run:
+`service adblock-lean uninstall`
+or
+`sh /etc/init.d/adblock-lean uninstall`
 
 ## :stars: Stargazers <a name="stargazers"></a>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ⚔ adblock-lean
 
-If you like adblock-lean and can benefit from it, then please leave a ⭐ (top right) and become a [stargazer](https://github.com/lynxthecat/adblock-lean/stargazers)! And feel free to post any feedback on the official OpenWrt thread [here](https://forum.openwrt.org/t/adblock-lean-set-up-adblock-using-dnsmasq-blocklist/157076). Thank you for your support.
+adblock-lean provides powerful and ultra-efficient adblocking on OpenWrt. It is  **highly optimized for RAM & CPU efficiency** during blocklist download & processing, and does not remain running in memory after execution.  adblock-lean is designed to leverage the [major rewrite of the DNS server and domain handling code](https://thekelleys.org.uk/dnsmasq/CHANGELOG) associated with dnsmasq 2.86, which drastically improves dnsmasq performance and reduces memory footprint. This facilitates the use of very large blocklists even for low spec, low performance devices.
 
-adblock-lean is **highly optimized for RAM & CPU efficiency** during blocklist download & processing, and does not remain running in memory after execution.  adblock-lean is designed to leverage the [major rewrite of the DNS server and domain handling code](https://thekelleys.org.uk/dnsmasq/CHANGELOG) associated with dnsmasq 2.86, which drastically improves dnsmasq performance and reduces memory footprint. This facilitates the use of very large blocklists even for low spec, low performance devices.
+If you like adblock-lean and can benefit from it, then please leave a ⭐ (top right) and become a [stargazer](https://github.com/lynxthecat/adblock-lean/stargazers)! And feel free to post any feedback on the official OpenWrt thread [here](https://forum.openwrt.org/t/adblock-lean-set-up-adblock-using-dnsmasq-blocklist/157076). Thank you for your support.
 
 ## Features
 
@@ -12,7 +12,7 @@ adblock-lean includes the following features:
 - support local blocklist
 - same for downloaded and local allowlists
 - support whitelist mode
-- removal of domains found in the allowlist form the blocklist files
+- removal of domains found in the allowlist from the blocklist files
 - combining all downloaded and local lists into one final blocklist file
 - check that each individual blocklist and allowlist file does not exceed configurable maximum size
 - check that the total blocklist size does not exceeed configurable maximum file size
@@ -154,22 +154,22 @@ Each configuration option is internally documented with comments in `/etc/adbloc
 |`dnsmasq_blocklist_urls`             | One or more dnsmasq format blocklist URLs to download and process                             |
 |`dnsmasq_blocklist_ipv4_urls`        | One or more dnsmasq format ipv4 blocklist URLs to download and process                        |
 |`dnsmasq_allowlist_urls`             | One or more dnsmasq format allowlist URLs to download and process                             |
-|`local_allowlist_path`               | Path to local allowlist (domain will not be blocked)                                          |
-|`local_blocklist_path`               | Path to local blocklist (domain will be blocked)                                              |
+|`local_allowlist_path`               | Path to local allowlist (included domains will not be blocked)                                |
+|`local_blocklist_path`               | Path to local blocklist (included domains will be blocked)                                    |
 |`test_domains`                       | Domains used to test DNS resolution after loading the final blocklist                         |
 |`list_part_failed_action`            | Governs failed lists handling: 'SKIP' or 'STOP'                                               |
 |`max_download_retries`               | Maximum number of download retries for allowlist/blocklist parts                              |
 |`min_good_line_count`                | Minimum number of good lines in final postprocessed blocklist                                 |
 |`min_blocklist_part_line_count`      | Minimum number of lines of individual downloaded blocklist part                               |
 |`min_blocklist_ipv4_part_line_count` | Minimum number of lines of individual downloaded ipv4 blocklist part                          |
-|`min_allowlist_part_line_count`      | Minimum number of lines of individual downloaded blocklist part                               |
+|`min_allowlist_part_line_count`      | Minimum number of lines of individual downloaded allowlist part                               |
 |`max_file_part_size_KB`              | Maximum size in KB of any individual downloaded blocklist part                                |
 |`max_blocklist_file_size_KB`         | Maximim size in KB of combined, processed blocklist                                           |
 |`deduplication`                      | Whether to perform sorting and deduplication of entries                                       |
 |`use_compression`                    | Compress while processing, and final blocklists. Reduces memory usage. 1/0 to enable/disable  |
-|`initial_dnsmasq_restart`            | Enable (1) or disable (0) initial dnsmasq restart to free up memory                           |
+|`initial_dnsmasq_restart`            | Initial dnsmasq restart to free up memory. 1/0 to enable/disable                              |
 |`boot_start_delay_s`                 | Start delay in seconds when service is started from system boot                               |
-|`custom_script`                      | Path to custom user scripts to execute on success on failure                                  |
+|`custom_script`                      | Path to custom user script to execute on success on failure                                   |
 |`cron_schedule`                      | Crontab schedule for automatic blocklist updates or `disable`                                 |
 
 For devices with low free memory, consider enabling the `initial_dnsmasq_restart` option to free up memory for use during the memory-intensive blocklist generation process by additionally restarting dnsmasq with no blocklist prior to the generation of the new blocklist. This option is disabled by default to prevent both the associated: dnsmasq downtime; and the temporary running of dnsmasq with no blocklist.
@@ -232,7 +232,7 @@ For example, if the an allowlist has this entry: `google.com` and a blocklist ha
 
 Note that in this mode, the test domains (specified via the option `test_domains`) will be automatically added to the allowlist in order for the checks to pass. You can use empty string in that option - this will bypass that check and block the default domains (google.com, microsoft.com, amazon.com). Alternatively, you can specify preferred test domains instead of the default ones.
 
-Also note that in this mode by default the Github domains will be blocked, so the automatic update functionality will not work - unless you add github.com to the allowlist.
+Also note that in this mode by default the Github domains will be blocked, so the automatic adblock-lean version update functionality will not work - unless you add github.com to the allowlist.
 
 The resulting blocklist generated in whitelist mode will be typically much smaller than otherwise, so you may need to reduce the value of the `min_good_line_count` option in order for the list to be accepted by adblock-lean.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Each configuration option is internally documented with comments in `/etc/adbloc
 
 | Variable                             |                         Setting                                                |
 | -----------------------------------: | :----------------------------------------------------------------------------- |
-|                `allowlist_only_mode` | Block all domains except domains in the allowlist(s). Enable (1) or disable(0) |
+|                     `whitelist_mode` | Block all domains except domains in the allowlist(s). Enable (1) or disable(0) |
 |                     `blocklist_urls` | One or more raw blocklist URLs to download and process                         |
 |                `blocklist_ipv4_urls` | One or more raw ipv4 blocklist URLs to download and process                    |
 |                     `allowlist_urls` | One or more raw allowlist URLs to download and process                         |
@@ -204,8 +204,10 @@ An excellent breakdown of highly suitable lists and their merits is provided at:
 
 https://github.com/hagezi/dns-blocklists
 
-## Allowlist-only mode
-This mode can be enabled by setting the config option `allowlist_only_mode` to `1`. In this mode all domain names resolution will return nx-domain, except for domains (and their subdomains) included in local and/or downloaded allowlists. Local blocklist and any blocklist download URLs are ignored in this mode, except ipv4 blocklist download URLs which will still be processed. This mode can be used to implement parental control or similar functionality.
+## Whitelist mode
+This mode can be used to implement parental control or similar functionality while also adblocking inside the allowed domains. It can be enabled by setting the config option `whitelist_mode` to `1`. In this mode all domain names will be resolved to 127.0.0.1, except for domains (and their subdomains) included in local and/or downloaded allowlists. In this mode, if blocklists are used in addition to allowlists, subdomains which are included in the blocklists and which are subdomains of allowed domains - will be blocked (with the 'nx domain' response).
+
+For example, if the an allowlist has this entry: `google.com` and a blocklist has this entry: `ads.google.com`, and `whitelist_mode` is set to `1`, then `ads.google.com` will be blocked, while `google.com` and `mail.google.com` (and any other subdomain of `google.com` which is not included in the blocklist) will work.
 
 ## User-configurable calls on success or failure
 

--- a/README.md
+++ b/README.md
@@ -143,34 +143,34 @@ adblock-lean reads in a config file from `/etc/adblock-lean/config`
 
 Default config can be generated using: `service adblock-lean gen_config`.
 
-Each configuration option is internally documented with comments in `/etc/adblock-lean/config`.
+Each configuration option is internally documented with comments in `/etc/adblock-lean/config`. Short version:
 
-| Variable                             |                         Setting                                                |
-| -----------------------------------: | :----------------------------------------------------------------------------- |
-|                     `whitelist_mode` | Block all domains except domains in the allowlist(s). Enable (1) or disable(0) |
-|                     `blocklist_urls` | One or more raw blocklist URLs to download and process                         |
-|                `blocklist_ipv4_urls` | One or more raw ipv4 blocklist URLs to download and process                    |
-|                     `allowlist_urls` | One or more raw allowlist URLs to download and process                         |
-|             `dnsmasq_blocklist_urls` | One or more dnsmasq format blocklist URLs to download and process              |
-|        `dnsmasq_blocklist_ipv4_urls` | One or more dnsmasq format ipv4 blocklist URLs to download and process         |
-|             `dnsmasq_allowlist_urls` | One or more dnsmasq format allowlist URLs to download and process              |
-|               `local_allowlist_path` | Path to local allowlist (domain will not be blocked)                           |
-|               `local_blocklist_path` | Path to local blocklist (domain will be blocked)                               |
-|                       `test_domains` | Domains used to test DNS resolution after loading the final blocklist          |
-|            `list_part_failed_action` | Governs failed lists handling: 'SKIP' or 'STOP'                                |
-|               `max_download_retries` | Maximum number of download retries for allowlist/blocklist parts               |
-|                `min_good_line_count` | Minimum number of good lines in final postprocessed blocklist                  |
-|      `min_blocklist_part_line_count` | Minimum number of lines of individual downloaded blocklist part                |
-| `min_blocklist_ipv4_part_line_count` | Minimum number of lines of individual downloaded ipv4 blocklist part           |
-|      `min_allowlist_part_line_count` | Minimum number of lines of individual downloaded blocklist part                |
-|              `max_file_part_size_KB` | Maximum size of any individual downloaded blocklist part                       |
-|         `max_blocklist_file_size_KB` | Maximim size of combined, processed blocklist                                  |
-|                      `deduplication` | Whether to perform sorting and deduplication of entries                        |
-|                    `use_compression` | Compress while processing, and final blocklists.  Reduces memory useage        |
-|            `initial_dnsmasq_restart` | Enable (1) or disable (0) initial dnsmasq restart to free up memory            |
-|                 `boot_start_delay_s` | Start delay in seconds when service is started from system boot                |
-|                      `custom_script` | Path to custom user scripts to execute on success on failure                   |
-|                      `cron_schedule` | Crontab schedule for automatic blocklist updates or `disable`                  |
+| Option                              | Description                                                                                   |
+| :-----------------------------------| :-------------------------------------------------------------------------------------------- |
+|`whitelist_mode`                     | Block all domains except domains in the allowlists and their subdomains. 1/0 to enable/disable|
+|`blocklist_urls`                     | One or more raw blocklist URLs to download and process                                        |
+|`blocklist_ipv4_urls`                | One or more raw ipv4 blocklist URLs to download and process                                   |
+|`allowlist_urls`                     | One or more raw allowlist URLs to download and process                                        |
+|`dnsmasq_blocklist_urls`             | One or more dnsmasq format blocklist URLs to download and process                             |
+|`dnsmasq_blocklist_ipv4_urls`        | One or more dnsmasq format ipv4 blocklist URLs to download and process                        |
+|`dnsmasq_allowlist_urls`             | One or more dnsmasq format allowlist URLs to download and process                             |
+|`local_allowlist_path`               | Path to local allowlist (domain will not be blocked)                                          |
+|`local_blocklist_path`               | Path to local blocklist (domain will be blocked)                                              |
+|`test_domains`                       | Domains used to test DNS resolution after loading the final blocklist                         |
+|`list_part_failed_action`            | Governs failed lists handling: 'SKIP' or 'STOP'                                               |
+|`max_download_retries`               | Maximum number of download retries for allowlist/blocklist parts                              |
+|`min_good_line_count`                | Minimum number of good lines in final postprocessed blocklist                                 |
+|`min_blocklist_part_line_count`      | Minimum number of lines of individual downloaded blocklist part                               |
+|`min_blocklist_ipv4_part_line_count` | Minimum number of lines of individual downloaded ipv4 blocklist part                          |
+|`min_allowlist_part_line_count`      | Minimum number of lines of individual downloaded blocklist part                               |
+|`max_file_part_size_KB`              | Maximum size in KB of any individual downloaded blocklist part                                |
+|`max_blocklist_file_size_KB`         | Maximim size in KB of combined, processed blocklist                                           |
+|`deduplication`                      | Whether to perform sorting and deduplication of entries                                       |
+|`use_compression`                    | Compress while processing, and final blocklists. Reduces memory usage. 1/0 to enable/disable  |
+|`initial_dnsmasq_restart`            | Enable (1) or disable (0) initial dnsmasq restart to free up memory                           |
+|`boot_start_delay_s`                 | Start delay in seconds when service is started from system boot                               |
+|`custom_script`                      | Path to custom user scripts to execute on success on failure                                  |
+|`cron_schedule`                      | Crontab schedule for automatic blocklist updates or `disable`                                 |
 
 For devices with low free memory, consider enabling the `initial_dnsmasq_restart` option to free up memory for use during the memory-intensive blocklist generation process by additionally restarting dnsmasq with no blocklist prior to the generation of the new blocklist. This option is disabled by default to prevent both the associated: dnsmasq downtime; and the temporary running of dnsmasq with no blocklist.
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -1196,7 +1196,7 @@ process_list_part()
 
 test_url_domains()
 {
-	local urls list_type list_format d domains dom IFS="${default_IFS}"
+	local urls list_type list_format d domains='' dom IFS="${default_IFS}"
 	for list_type in allowlist blocklist blocklist_ipv4
 	do
 		for list_format in raw dnsmasq
@@ -1204,13 +1204,15 @@ test_url_domains()
 			d=
 			[ "${list_format}" = dnsmasq ] && d="dnsmasq_"
 			eval "urls=\"\${${d}${list_type}_urls}\""
-			domains="$(printf %s "${urls}" | tr ' \t' '\n' | sed -E 's~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;' | sort -u)"
-			[ -z "${domains}" ] && continue
-			for dom in $domains
-			do
-				try_lookup_domain "${dom}" || return 1
-			done
+			[ -z "${urls}" ] && continue
+			domains="${domains}$(printf %s "${urls}" | tr ' \t' '\n' | sed -n '/http/{s~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;p;}')${nl}"
 		done
+	done
+	[ -z "${domains}" ] && return 0
+
+	for dom in $(printf %s "${domains}" | sort -u)
+	do
+		try_lookup_domain "${dom}" || return 1
 	done
 	:
 }

--- a/adblock-lean
+++ b/adblock-lean
@@ -263,8 +263,10 @@ print_def_config()
 	# values must be enclosed in double-quotes
 	# custom comments are not preserved after automatic config update
 
-	# Allowlist-only mode: only domains (and their subdomains) included in the allowlist(s) are allowed, all other domains are blocked
-	allowlist_only_mode="0" @ 0|1
+	# Whitelist mode: only domains (and their subdomains) included in the allowlist(s) are allowed, all other domains are blocked
+	# In this mode, if blocklists are used in addition to allowlists, subdomains included in the blocklists will be blocked,
+	# including subdomains of allowed domains
+	whitelist_mode="0" @ 0|1
 
 	# One or more *raw domain* format blocklist/ipv4 blocklist/allowlist urls separated by spaces
 	blocklist_urls="${blocklist_urls}" @ string
@@ -281,6 +283,13 @@ print_def_config()
 	# site2.com
 	local_allowlist_path="${config_dir}/allowlist" @ string
 	local_blocklist_path="${config_dir}/blocklist" @ string
+
+	# Test domains are automatically querried after loading the blocklist into dnsmasq,
+	# in order to verify that the blocklist didn't break DNS resolution
+	# If query for any of the test domains fails, previous blocklist is restored from backup
+	# If backup doesn't exist, the blocklist is removed and adblock-lean is stopped
+	# Leaving this empty will disable verification
+	test_domains="google.com microsoft.com amazon.com" @ string
 
 	# List part failed action:
 	# This option applies to blocklist/allowlist parts which failed to download or couldn't pass validation checks
@@ -1049,7 +1058,6 @@ cleanup_dl_status_files()
 # 1 - General error (stop processing)
 # 2 - Bad List (retry doesn't make sense)
 # 3 - Download Failure (retry makes sense)
-# 4 - Blocklist part ignored because allowlist_only_mode is on
 process_list_part()
 {
 	local list_id="${1}" list_type="${2}" list_origin="${3}" list_format="${4}" list_path="${5}" me="process_list_part" \
@@ -1070,8 +1078,6 @@ process_list_part()
 		allowlist) [ "${list_origin}" = local ] && dest_file="${abl_dir}/allowlist" ;;
 		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; }
 	esac
-
-	[ "${list_type}" = blocklist ] && [ "${allowlist_only_mode}" = 1 ] && return 4
 
 	eval "min_list_part_line_count=\"\${min_${list_type}_part_line_count}\""
 
@@ -1113,9 +1119,16 @@ process_list_part()
 
 	if [ "${list_type}" = blocklist ] && [ "${use_allowlist}" = 1 ]
 	then
-		# remove allowlist domains from blocklist
-		${awk_cmd} -F'/' 'NR==FNR { allow[$0]; next } { n=split($2,arr,"."); addr = arr[n];
-			for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "${abl_dir}/allowlist" -
+		case "${whitelist_mode}" in
+		0)
+			# remove allowlist domains from blocklist
+			${awk_cmd} 'NR==FNR { allow[$0]; next } { n=split($1,arr,"."); addr = arr[n];
+				for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "${abl_dir}/allowlist" - ;;
+		1)
+			# only print subdomains of allowlist domains
+			${awk_cmd} 'NR==FNR { allow[$0]; next } { n=split($1,arr,"."); addr = arr[n];
+				for ( i=n-1; i>1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) { print $1; next } } }' "${abl_dir}/allowlist" -
+		esac
 	else
 		cat
 	fi |
@@ -1142,8 +1155,7 @@ process_list_part()
 	if [ "${list_part_size_KB}" -ge "${max_file_part_size_KB}" ]
 	then
 		reg_failure "${list_origin} ${list_type} part size reached the maximum value set in config (${max_file_part_size_KB} KB)."
-		log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config." \
-			"Skipping ${list_type} part and continuing."
+		log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config."
 		rm -f "${dest_file}"
 		return 2
 	fi
@@ -1187,7 +1199,7 @@ gen_list_parts()
 	handle_process_failure()
 	{
 		[ "${list_part_failed_action}" = "STOP" ] && { log_msg "list_part_failed_action is set to 'STOP', exiting."; return 1; }
-		log_msg "Skipping file part and continuing."
+		log_msg "Skipping file and continuing."
 		:
 	}
 
@@ -1220,7 +1232,6 @@ gen_list_parts()
 					0)
 						log_process_success "local"
 						list_line_cnt=$(( list_line_cnt + list_part_line_count )) ;;
-					4) log_msg -warn "Allowlist-only mode is set to '1' in config. Ignoring blocklist part: ${local_list_path}." ;;
 					*) handle_process_failure || return 1
 				esac
 			fi
@@ -1280,10 +1291,7 @@ gen_list_parts()
 						2)
 							handle_process_failure || return 1
 							continue 2 ;;
-						3) ;;
-						4)
-							log_msg -warn "Allowlist-only mode is set to '1' in config. Ignoring blocklist part from ${list_url}."
-							continue 2 ;;
+						3)
 					esac
 
 					if [ "${retry}" -ge "${max_download_retries}" ]
@@ -1304,7 +1312,7 @@ gen_list_parts()
 		then
 			case ${list_type} in
 				blocklist)
-					[ "${allowlist_only_mode}" = 0 ] && return 1
+					[ "${whitelist_mode}" = 0 ] && return 1
 					log_msg -yellow "Allowlist-only mode is on - accepting empty blocklist." ;;
 				allowlist)
 					log_msg "Not using any allowlist for blocklist processing."
@@ -1447,13 +1455,14 @@ generate_and_process_blocklist_file()
 			rm -f "${abl_dir}/allowlist"
 		fi
 		# add the optional allowlist-only entry
-		if [ "${allowlist_only_mode}" = 1 ]
+		if [ "${whitelist_mode}" = 1 ]
 		then
 			printf '%s\n' "address=/#/#"
-			printf '%s\n' "server=/google.com/microsoft.com/amazon.com/#"
+			local allow_test_domains="$(printf %s "${test_domains}" | sed -E 's~[ \t]+$~~;s~^[ \t]+~~;s~[ \t]+~\n~g')"
+			[ -n "${allow_test_domains}" ] && printf %s "${allow_test_domains}" | convert_entries allowlist
 		fi
 		# add the blocklist test entry
-		printf '%s\n' "address=/adblocklean-test123.info/127.0.0.1"
+		printf '%s\n' "address=/adblocklean-test123.info/#"
 	} |
 
 	# limit size
@@ -1509,7 +1518,7 @@ generate_and_process_blocklist_file()
 
 	if [ "${final_entries_cnt}" -lt "${min_good_line_count}" ]
 	then
-		reg_failure "Entries count: $(int2human "${final_entries_cnt}") below the minimum value set in config ($(int2human "${min_good_line_count}"))."
+		reg_failure "Entries count ($(int2human "${final_entries_cnt}")) is below the minimum value set in config ($(int2human "${min_good_line_count}"))."
 		return 1
 	fi
 
@@ -1547,7 +1556,7 @@ check_active_blocklist()
 	nslookup "adblocklean-test123.info" 127.0.0.1 1>/dev/null 2>/dev/null ||
 			{ reg_failure "Lookup of the blocklist test domain failed with new blocklist."; return 4; }
 
-	for domain in google.com amazon.com microsoft.com
+	for domain in ${test_domains}
 	do
 		ns_res="$(nslookup "${domain}" 127.0.0.1 2>/dev/null)" ||
 			{ reg_failure "Lookup of '${domain}' failed with new blocklist."; return 2; }
@@ -1742,7 +1751,7 @@ update_pid_action() {
 		3) ;;
 		1) return 1 ;;
 		2) reg_failure "update_pid_action(): pid file '${pid_file}' has unexpected pid '${_pid}'."; return 1 ;;
-		0) reg_failure "update_pid_action(): pid file '${pid_file}' not found."; return 1
+		0) return 0
 	esac
 	mk_lock -f "${1}"
 	return ${?}
@@ -1885,7 +1894,7 @@ get_active_entries_cnt()
 		eval "[ ! \"\${${entry_type}_urls}\" ] && [ ! -s \"\${local_${entry_type}_path}\" ]" && continue
 		case ${entry_type} in
 			blocklist) list_prefix=local ;;
-			allowlist) list_prefix=server allow_opt="|#"
+			allowlist) list_prefix=server allow_opt="#"
 		esac
 		list_prefixes="${list_prefixes}${list_prefix}|"
 	done
@@ -1899,13 +1908,22 @@ get_active_entries_cnt()
 	else
 		printf ''
 	fi |
-	sed -E "s~^(${list_prefixes%|})\=/~~;" | tr "[/${allow_opt}]" '\n' | wc -w > "/tmp/abl_entries_cnt"
+	sed -E "s~^(${list_prefixes%|})\=/~~;" | tr "/${allow_opt}" '\n' | wc -w > "/tmp/abl_entries_cnt"
 
 	read -r cnt _ < "/tmp/abl_entries_cnt" || cnt=0
-	case ${cnt} in
-		[0-2]|'') printf 0; return 1 ;;
-		*) printf %s "$((cnt-3))" # to account for the blocklist test entry
-	esac
+	rm -f "/tmp/abl_entries_cnt"
+	case "${cnt}" in *[!0-9]*|'') printf 0; return 1; esac
+	local d i=0 IFS="${default_IFS}"
+	if [ "${whitelist_mode}" = 1 ]
+	then
+		i=1
+		for d in ${test_domains}
+		do
+			i=$((i+1))
+		done
+	fi
+	[ "${cnt}" -lt $((2+i)) ] && { printf 0; return 1; }
+	printf %s "$((cnt-2-i))"
 	:
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # shellcheck disable=SC3043,SC1091,SC3001,SC2018,SC2019,SC3020,SC3003,SC2181,SC2254,SC1090,SC3045
 
-# adblock-lean - super simple and lightweight adblocking for OpenWrt
+# adblock-lean - powerful and ultra efficient adblocking with dnsmasq on OpenWrt
 
 # Project homepage: https://github.com/lynxthecat/adblock-lean
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -1212,6 +1212,7 @@ test_url_domains()
 			done
 		done
 	done
+	:
 }
 
 gen_list_parts()

--- a/adblock-lean
+++ b/adblock-lean
@@ -44,6 +44,7 @@ update_log_file=/var/log/abl_update.log
 session_log_file=/var/log/abl_session.log
 hagezi_dl_url="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard"
 abl_cron_cmd="/etc/init.d/adblock-lean start"
+cron_service_path="/etc/init.d/cron"
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export HOME=/root
@@ -1966,6 +1967,7 @@ get_curr_crontab()
 rm_cron_job()
 {
 	local curr_cron
+	check_cron_service || return 0
 	curr_cron="$(get_curr_crontab)"
 	case ${?} in
 		1) return 1 ;;
@@ -1978,25 +1980,25 @@ rm_cron_job()
 	:
 }
 
+# returns 0 if crontab is readable and the crond process is running, 1 otherwise
+# sets $cron_reboot if above conditions are satisfied and cron is not implemented via the busybox binary
+check_cron_service()
+{
+	# check if service is enabled
+	${cron_service_path} enabled || return 1
+	# check reading crontab
+	crontab -u root -l &>/dev/null || return 1
+	# check for crond in running processes
+	pidof crond 1>/dev/null || return 1
+	:
+}
+
 # checks if the cron service is enabled and running
 # if not enabled or not running or if crontab doesn't exist, implements automatic correction
 # return codes: 0 - success, 1 - failure
 enable_cron_service()
 {
-	# returns 0 if crontab is readable and the crond process is running, 1 otherwise
-	# sets $cron_reboot if above conditions are satisfied and cron is not implemented via the busybox binary
-	check_cron_service()
-	{
-		# check if service is enabled
-		${cron_service_path} enabled || return 1
-		# check reading crontab
-		crontab -u root -l &>/dev/null || return 1
-		# check for crond in running processes
-		pidof crond 1>/dev/null || return 1
-		:
-	}
-
-	local cron_service_path="/etc/init.d/cron" enable_failed="Failed to enable and start the cron service"
+	local enable_failed="Failed to enable and start the cron service"
 
 	hash crontab || { reg_failure "${enable_failed}: 'crontab' utility is inaccessible."; return 1; }
 	[ -f "${cron_service_path}" ] || { reg_failure "${enable_failed}: the cron service was not found at path '${cron_service_path}'."; return 1; }
@@ -2775,11 +2777,14 @@ case "${action}" in
 					{ reg_failure "Failed to enable the adblock-lean service"; exit 1; }
 			else
 				log_msg -green "The adblock-lean service is already enabled."
+				exit 0
 			fi
 			load_config
-			if [ -n "${cron_job}" ]
+			if [ -n "${cron_schedule}" ] && [ "${cron_schedule}" != disable ]
 			then
 				upd_cron_job && luci_cron_job_creation_failed=
+			else
+				luci_cron_job_creation_failed=
 			fi
 		fi ;;
 	disable)
@@ -2789,10 +2794,10 @@ case "${action}" in
 			if enabled
 			then
 				log_msg -purple "Disabling adblock-lean."
+				load_config && rm_cron_job
 				disable && ! enabled ||
 					{ reg_failure "Failed to disable the adblock-lean service"; exit 1; }
 				stop -noexit
-				load_config && rm_cron_job
 			else
 				log_msg "The adblock-lean service is already disabled."
 			fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -1194,6 +1194,26 @@ process_list_part()
 	:
 }
 
+test_url_domains()
+{
+	local urls list_type list_format d domains dom IFS="${default_IFS}"
+	for list_type in allowlist blocklist blocklist_ipv4
+	do
+		for list_format in raw dnsmasq
+		do
+			d=
+			[ "${list_format}" = dnsmasq ] && d="dnsmasq_"
+			eval "urls=\"\${${d}${list_type}_urls}\""
+			domains="$(printf %s "${urls}" | tr ' \t' '\n' | sed -E 's~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;' | sort -u)"
+			[ -z "${domains}" ] && continue
+			for dom in $domains
+			do
+				try_lookup_domain "${dom}" || return 1
+			done
+		done
+	done
+}
+
 gen_list_parts()
 {
 	# 1 - list origin (local or downloaded)
@@ -1213,7 +1233,7 @@ gen_list_parts()
 
 	local list_type='' list_format='' list_id list_line_cnt list_part_line_count and_compressing='' list_urls list_url local_list_path
 
-	[ -z "${blocklist_urls}${dnsmasq_blocklist_urls}" ] && log_msg -yellow "NOTE: No URLs specified for blocklist download."
+	[ -z "${blocklist_urls}${dnsmasq_blocklist_urls}" ] && log_msg -yellow "" "NOTE: No URLs specified for blocklist download."
 
 	rm -f "${abl_dir}/allowlist"
 
@@ -1556,6 +1576,17 @@ check_dnsmasq_instance()
 	:
 }
 
+try_lookup_domain()
+{
+	local ns_res
+	ns_res="$(nslookup "${1}" 127.0.0.1 2>/dev/null)" ||
+		{ reg_failure "Lookup of '${1}' failed."; return 2; }
+
+	printf %s "${ns_res}" | grep -A1 ^Name | grep -qE '^(Address: *0\.0\.0\.0|Address: *127\.0\.0\.1)$' &&
+		{ reg_failure "Lookup of '${1}' resulted in 0.0.0.0 or 127.0.0.1."; return 3; }
+	:
+}
+
 # return values:
 # 0 - dnsmasq is running, and all checks passed
 # 1 - dnsmasq is not running
@@ -1573,11 +1604,7 @@ check_active_blocklist()
 
 	for domain in ${test_domains}
 	do
-		ns_res="$(nslookup "${domain}" 127.0.0.1 2>/dev/null)" ||
-			{ reg_failure "Lookup of '${domain}' failed with new blocklist."; return 2; }
-
-		printf %s "${ns_res}" | grep -A1 ^Name | grep -q '^Address: *0\.0\.0\.0$' &&
-			{ reg_failure "Lookup of '${domain}' resulted in 0.0.0.0 with new blocklist."; return 3; }
+		try_lookup_domain "${domain}" || return ${?}
 	done
 
 	:
@@ -2478,6 +2505,12 @@ start()
 
 	try_export_existing_blocklist
 	[ ${?} = 1 ] && exit 1
+
+	if [ "${initial_dnsmasq_restart}" != 1 ]
+	then
+		reg_action -blue "Testing connectivity." || exit 1
+		test_url_domains || initial_dnsmasq_restart=1
+	fi
 
 	if [ "${initial_dnsmasq_restart}" = 1 ]
 	then

--- a/adblock-lean
+++ b/adblock-lean
@@ -1015,7 +1015,7 @@ check_addnmount()
 	do
 		uci -q get dhcp.@dnsmasq[${i}].addnmount
 		i=$((i+1))
-	done | grep -qE "(^|[ \t])/bin(/\*|/busybox)*($|[ \t])" && return 0
+	done | grep -qE "('|^|[ \t])/bin(/\*|/busybox)*([ \t]|'|$)" && return 0
 	return 1
 }
 
@@ -2225,9 +2225,8 @@ setup()
 		2) exit 1 ;;
 		1)
 			print_msg "" "${purple}Creating dnsmasq addnmount UCI entry.${n_c}"
-			uci set dhcp.adblock_lean=dnsmasq &&
-			uci add_list dhcp.adblock_lean.addnmount='/bin/busybox' &&
-			uci commit || setup_failed "Failed to create addnmount entry."
+			uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox # adblock-lean' && uci commit ||
+				setup_failed "Failed to create addnmount entry."
 	esac
 	luci_addnmount_failed=
 
@@ -2780,11 +2779,17 @@ uninstall()
 		rm -rf "${config_dir}" || reg_failure "Failed to delete the config directory '${config_dir}'."
 	fi
 
-	if uci -q get dhcp.adblock_lean 1>/dev/null
-	then
+	local i="-1" entry
+	while uci -q get dhcp.@dnsmasq[${i}] >/dev/null && [ ${i} -lt 128 ]
+	do
+		i=$((i+1))
+		entry="$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" || continue
+		case "${entry}" in *adblock-lean*) ;; *) continue; esac
 		log_msg -purple "" "Deleting the custom addnmount entry from /etc/config/dhcp."
-		uci -q delete dhcp.adblock_lean && uci commit || reg_failure "Failed to delete the custom addnmount entry from /etc/config/dhcp."
-	fi
+		uci -q del_list dhcp.@dnsmasq[${i}].addnmount='/bin/busybox # adblock-lean' && uci commit ||
+			reg_failure "Failed to delete the custom addnmount entry from /etc/config/dhcp. Please delete manually."
+		break
+	done
 
 	log_msg -purple "" "Deleting the script from ${abl_service_path}."
 	rm -f "${abl_service_path}" ||

--- a/adblock-lean
+++ b/adblock-lean
@@ -2765,6 +2765,17 @@ update()
 	log_msg -green "adblock-lean has been updated to the latest version."
 
 	rm -f "${abl_dir}/adblock-lean.latest" "${abl_dir}/uclient-fetch_err"
+	if [ -n "${do_dialogs}" ]
+	then
+		print_msg "" "Start adblock-lean now? (y|n)"
+		pick_opt "y|n"
+		if [ "$REPLY" = y ]
+		then
+			. "${abl_service_path}" || exit 1
+			start
+			exit $?
+		fi
+	fi
 	exit 0
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -2754,12 +2754,9 @@ update()
 		}
 	fi
 
-	if [ "${1}" != "--simulation" ]
-	then
-		try_mv "${abl_dir}/adblock-lean.latest" "${abl_service_path}" || exit 1
-		chmod +x "${abl_service_path}"
-		${abl_service_path} enable
-	fi
+	try_mv "${abl_dir}/adblock-lean.latest" "${abl_service_path}" || exit 1
+	chmod +x "${abl_service_path}"
+	${abl_service_path} enable
 	log_msg -green "adblock-lean has been updated to the latest version."
 
 	rm -f "${abl_dir}/adblock-lean.latest" "${abl_dir}/uclient-fetch_err"

--- a/adblock-lean
+++ b/adblock-lean
@@ -1168,7 +1168,7 @@ process_list_part()
 		return 3
 	fi
 
-	if [ "${list_origin}" = downloaded ] && read -r rogue_element < "${abl_dir}/rogue_element"
+	if read -r rogue_element < "${abl_dir}/rogue_element"
 	then
 		rm -f "${dest_file}"
 		log_msg -warn "Rogue element: '${rogue_element}' identified originating in ${list_type} file part from: ${list_path}."

--- a/adblock-lean
+++ b/adblock-lean
@@ -2791,8 +2791,8 @@ uninstall()
 		then
 			case "$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" in */bin/busybox*) break; esac
 			addnmount_deleted=1
-			log_msg "Note: adblock-lean developers are not aware of any other software which may require the specific addnmount entry created by adblock-lean," \
-				"but if by any chance you have such software then it may stop working after removal and you may need to re-add the addnmount entry."
+			log_msg "Note: the adblock-lean developers are not aware of any other software that requires the specific addnmount entry created by adblock-lean." \
+				"Should the addnmount entry be required for any reason then you will need to manually re-add it."
 		fi
 		break
 	done

--- a/adblock-lean
+++ b/adblock-lean
@@ -1129,11 +1129,12 @@ process_list_part()
 		case "${whitelist_mode}" in
 		0)
 			# remove allowlist domains from blocklist
-			${awk_cmd} 'NR==FNR { allow[$0]; next } { n=split($1,arr,"."); addr = arr[n];
-				for ( i=n-1; i>=1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) next } } 1' "${abl_dir}/allowlist" - ;;
+			${awk_cmd} 'NR==FNR { if ($0 ~ /^\*\./) { allow_wild[substr($0,3)]; next }; allow[$0]; next }
+				{ n=split($1,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- )
+				{ addr = arr[i] "." addr; if ( (i>1 && addr in allow_wild) || addr in allow ) next } } 1' "${abl_dir}/allowlist" - ;;
 		1)
 			# only print subdomains of allowlist domains
-			${awk_cmd} 'NR==FNR { allow[$0]; next } { n=split($1,arr,"."); addr = arr[n];
+			${awk_cmd} 'NR==FNR { { if ($0 !~ /^\*/) { allow[$0] }; next } { n=split($1,arr,"."); addr = arr[n];
 				for ( i=n-1; i>1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) { print $1; next } } }' "${abl_dir}/allowlist" -
 		esac
 	else

--- a/adblock-lean
+++ b/adblock-lean
@@ -51,7 +51,7 @@ export HOME=/root
 START=99
 STOP=4
 
-EXTRA_COMMANDS="setup status pause resume gen_stats gen_config upd_cron_job print_log update"
+EXTRA_COMMANDS="setup status pause resume gen_stats gen_config upd_cron_job print_log update uninstall"
 EXTRA_HELP="
 adblock-lean custom commands:
 	setup           run automated setup for adblock-lean
@@ -63,7 +63,8 @@ adblock-lean custom commands:
 	upd_cron_job    create cron job for adblock-lean with schedule set in the config option 'cron_schedule'.
 	                if config option set to 'disable', remove existing cron job if any
 	print_log       print most recent session log
-	update          update adblock-lean to the latest version"
+	update          update adblock-lean to the latest version
+	uninstall       uninstall adblock-lean, remove all adblock-lean-related files and settings"
 
 
 ### UTILITY FUNCTIONS
@@ -999,7 +1000,13 @@ try_export_existing_blocklist()
 check_addnmount()
 {
 	hash uci 1>/dev/null || { reg_failure "uci command was not found."; return 2; }
-	uci -q get dhcp.@dnsmasq[0].addnmount | grep -qE "(^|[ \t])/bin(/\*|/busybox)*($|[ \t])"
+	local i=0
+	while uci -q get dhcp.@dnsmasq[${i}] >/dev/null && [ ${i} -lt 128 ]
+	do
+		uci -q get dhcp.@dnsmasq[${i}].addnmount
+		i=$((i+1))
+	done | grep -qE "(^|[ \t])/bin(/\*|/busybox)*($|[ \t])" && return 0
+	return 1
 }
 
 # return codes:
@@ -1018,11 +1025,11 @@ check_blocklist_compression_support()
 
 	check_addnmount && return 0
 	[ ${?} = 2 ] && return 2
-	reg_failure "No appropriate 'addnmount' entry in /etc/config/dhcp was identified."
-	log_msg "This is leveraged to give dnsmasq access to busybox gunzip to extract compressed blocklist." \
-		"Add: \"list addnmount '/bin/busybox'\" to /etc/config/dhcp at the end of the dnsmasq section." \
-		"Or simply run this command: uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox' && uci commit" \
-		"Either edit /etc/config/dhcp as described above or disable blocklist compression in config."
+	log_msg -warn "" "No appropriate 'addnmount' entry in /etc/config/dhcp was identified." \
+		"Final blocklist compression will be disabled."
+	log_msg "addnmount entry is required to give dnsmasq access to busybox gunzip in order to extract compressed blocklist." \
+		"Run 'service adblock-lean setup' to have the entry created automatically, or follow the steps in the README." \
+		"Alternatively, change the 'use_compression' option in adblock-lean config to '0'."
 	return 1
 }
 
@@ -2154,7 +2161,9 @@ setup()
 		2) exit 1 ;;
 		1)
 			print_msg "" "${purple}Creating dnsmasq addnmount UCI entry.${n_c}"
-			uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox' && uci commit || setup_failed "Failed to create addnmount entry."
+			uci set dhcp.adblock_lean=dnsmasq &&
+			uci add_list dhcp.adblock_lean.addnmount='/bin/busybox' &&
+			uci commit || setup_failed "Failed to create addnmount entry."
 	esac
 	luci_addnmount_failed=
 
@@ -2675,9 +2684,51 @@ update()
 	exit 0
 }
 
+uninstall()
+{
+	log_msg -purple "" "Uninstalling adblock-lean."
+	stop -noexit
+	if /sbin/service adblock-lean enabled &>/dev/null
+		then
+		log_msg -purple "" "Disabling adblock-lean."
+		disabling=1 /sbin/service adblock-lean disable && ! /sbin/service adblock-lean enabled ||
+			{ reg_failure "Failed to disable adblock-lean. Disable manually and then run this command again."; exit 1; }
+	fi
+
+	if [ -n "${do_dialogs}" ]
+	then
+		print_msg "" "Delete the config directory ${config_dir}?"
+		pick_opt "y|n"
+	else
+		REPLY="${luci_uninstall_rm_config}"
+	fi
+
+	if [ "${REPLY}" = y ]
+	then
+		log_msg -purple "" "Deleting the config directory."
+		rm -rf "${config_dir}" || reg_failure "Failed to delete the config directory '${config_dir}'."
+	fi
+
+	if uci -q get dhcp.adblock_lean 1>/dev/null
+	then
+		log_msg -purple "" "Deleting the custom addnmount entry from /etc/config/dhcp."
+		uci -q delete dhcp.adblock_lean && uci commit || reg_failure "Failed to delete the custom addnmount entry from /etc/config/dhcp."
+	fi
+
+	log_msg -purple "" "Deleting the script from ${abl_service_path}."
+	rm -f "${abl_service_path}" ||
+		{ reg_failure "Failed to delete the script from '${abl_service_path}'. Please delete manually."; exit 1; }
+
+	log_msg -purple "" "Uninstall complete."
+	exit 0
+}
+
 set_colors
 
-[ "${1}" = setup ] && { setup; exit 0; }
+case "${1}" in
+	setup) setup; exit 0 ;;
+	uninstall) uninstall; exit 0
+esac
 
 # handle enable/disable actions
 case "${action}" in
@@ -2685,9 +2736,9 @@ case "${action}" in
 		if ! [ "${enabling}" ]
 		then
 			export enabling=1
-			log_msg -purple "" "Enabling the adblock-lean service."
 			if ! /sbin/service adblock-lean enabled
 			then
+				log_msg -purple "" "Enabling the adblock-lean service."
 				/sbin/service adblock-lean enable && /sbin/service adblock-lean enabled ||
 					{ reg_failure "Failed to enable the adblock-lean service"; exit 1; }
 			else
@@ -2698,24 +2749,22 @@ case "${action}" in
 			then
 				upd_cron_job && luci_cron_job_creation_failed=
 			fi
-			enabling=
 		fi ;;
 	disable)
-		if ! [ "${disabling}" ]
+		if [ -z "${disabling}" ]
 		then
 			export disabling=1
-			log_msg -purple "Disabling adblock-lean."
-			if /sbin/service adblock-lean enabled
+			if enabled
 			then
-				/sbin/service adblock-lean disable && ! /sbin/service adblock-lean enabled ||
+				log_msg -purple "Disabling adblock-lean."
+				disable && ! enabled ||
 					{ reg_failure "Failed to disable the adblock-lean service"; exit 1; }
-				stop
+				stop -noexit
 				load_config && rm_cron_job
 			else
 				log_msg "The adblock-lean service is already disabled."
 			fi
-			disabling=
+			exit 0
 		fi
 esac
-
 :

--- a/adblock-lean
+++ b/adblock-lean
@@ -257,10 +257,13 @@ print_def_config()
 	cat <<-EOT | if [ "${1}" = '-d' ]; then cat; else sed 's/[ \t]*@.*//'; fi
 
 	# adblock-lean configuration options
-	# config_format=v4
+	# config_format=v5
 	#
 	# values must be enclosed in double-quotes
-	# comments must start at newline or inline after the closing double-quote
+	# custom comments are not preserved after automatic config update
+
+	# Allowlist-only mode: only domains (and their subdomains) included in the allowlist(s) are allowed, all other domains are blocked
+	allowlist_only_mode="0" @ 0|1
 
 	# One or more *raw domain* format blocklist/ipv4 blocklist/allowlist urls separated by spaces
 	blocklist_urls="${blocklist_urls}" @ string
@@ -272,14 +275,23 @@ print_def_config()
 	dnsmasq_blocklist_ipv4_urls="" @ string
 	dnsmasq_allowlist_urls="" @ string
 
-	# Path to optional local raw allowlist/blocklist domain files in the form:
+	# Path to optional local *raw domain* allowlist/blocklist files in the form:
 	# site1.com
 	# site2.com
 	local_allowlist_path="${config_dir}/allowlist" @ string
 	local_blocklist_path="${config_dir}/blocklist" @ string
 
-	# Whether to perform sorting and deduplication of entries (usually doesn't cause much slowdown, uses a bit more memory) - enable (1) or disable (0)
-	deduplication="1" @ 0|1
+	# List part failed action:
+	# This option applies to blocklist/allowlist parts which failed to download or couldn't pass validation checks
+	# SKIP - skip failed blocklist file part and continue blocklist generation
+	# STOP - stop blocklist generation (and fall back to previous blocklist if available)
+	list_part_failed_action="SKIP" @ SKIP|STOP
+
+	# Maximum number of download retries
+	max_download_retries="3" @ integer
+
+	# Minimum number of good lines in final postprocessed blocklist
+	min_good_line_count="${min_good_line_count}" @ integer
 
 	# Mininum number of lines of any individual downloaded part
 	min_blocklist_part_line_count="1" @ integer
@@ -292,8 +304,8 @@ print_def_config()
 	# Maximum total size of combined, processed blocklist
 	max_blocklist_file_size_KB="${max_blocklist_file_size_KB}" @ integer
 
-	# Minimum number of good lines in final postprocessed blocklist
-	min_good_line_count="${min_good_line_count}" @ integer
+	# Whether to perform sorting and deduplication of entries (usually doesn't cause much slowdown, uses a bit more memory) - enable (1) or disable (0)
+	deduplication="1" @ 0|1
 
 	# compress final blocklist, intermediate blocklist parts and the backup blocklist to save memory - enable (1) or disable (0)
 	use_compression="1" @ 0|1
@@ -302,14 +314,8 @@ print_def_config()
 	# new blocklist thereby to free up memory during generaiton of new blocklist - enable (1) or disable (0)
 	initial_dnsmasq_restart="0" @ 0|1
 
-	# Maximum number of download retries
-	max_download_retries="3" @ integer
-
-	# List part failed action:
-	# This option applies to blocklist/allowlist parts which failed to download or couldn't pass validation checks
-	# SKIP - skip failed blocklist file part and continue blocklist generation
-	# STOP - stop blocklist generation (and fall back to previous blocklist if available)
-	list_part_failed_action="SKIP" @ SKIP|STOP
+	# Start delay in seconds when service is started from system boot
+	boot_start_delay_s="120" @ integer
 
 	# If a path to custom script is specified and that script defines functions 'report_success()' and 'report_failure()'',
 	# one of these functions will be executed when adblock-lean completes the execution of some commands,
@@ -317,9 +323,6 @@ print_def_config()
 	# report_success() is only executed upon completion of the 'start' command
 	# Recommended path is '/usr/libexec/abl_custom-script.sh' which the luci app has permission to access
 	custom_script="" @ string
-
-	# Start delay in seconds when service is started from system boot
-	boot_start_delay_s="120" @ integer
 
 	# Crontab schedule expression for periodic list updates
 	cron_schedule="${cron_schedule:-"0 5 * * *"}" @ string
@@ -1039,6 +1042,7 @@ cleanup_dl_status_files()
 # 1 - General error (stop processing)
 # 2 - Bad List (retry doesn't make sense)
 # 3 - Download Failure (retry makes sense)
+# 4 - Blocklist part ignored because allowlist_only_mode is on
 process_list_part()
 {
 	local list_id="${1}" list_type="${2}" list_origin="${3}" list_format="${4}" list_path="${5}" me="process_list_part" \
@@ -1057,8 +1061,10 @@ process_list_part()
 
 	case ${list_type} in
 		allowlist) [ "${list_origin}" = local ] && dest_file="${abl_dir}/allowlist" ;;
-		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; } ;;
+		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; }
 	esac
+
+	[ "${list_type}" = blocklist ] && [ "${allowlist_only_mode}" = 1 ] && return 4
 
 	eval "min_list_part_line_count=\"\${min_${list_type}_part_line_count}\""
 
@@ -1107,13 +1113,8 @@ process_list_part()
 		cat
 	fi |
 
-	# check downloaded lists for rogue elements
-	if [ "${list_origin}" = downloaded ]
-	then
-		tee >(sed -nE "\~${val_entry_regex}~d;p;:1 n;b1" > "${abl_dir}/rogue_element")
-	else
-		cat
-	fi |
+	# check lists for rogue elements
+	tee >(sed -nE "\~${val_entry_regex}~d;p;:1 n;b1" > "${abl_dir}/rogue_element") |
 
 	# compress parts
 	if [ -n "${compress_part}" ]
@@ -1212,6 +1213,7 @@ gen_list_parts()
 					0)
 						log_process_success "local"
 						list_line_cnt=$(( list_line_cnt + list_part_line_count )) ;;
+					4) log_msg -warn "Allowlist-only mode is set to '1' in config. Ignoring blocklist part: ${local_list_path}." ;;
 					*) handle_process_failure || return 1
 				esac
 			fi
@@ -1272,6 +1274,9 @@ gen_list_parts()
 							handle_process_failure || return 1
 							continue 2 ;;
 						3) ;;
+						4)
+							log_msg -warn "Allowlist-only mode is set to '1' in config. Ignoring blocklist part from ${list_url}."
+							continue 2 ;;
 					esac
 
 					if [ "${retry}" -ge "${max_download_retries}" ]
@@ -1291,7 +1296,9 @@ gen_list_parts()
 		if [ "${list_line_cnt}" = 0 ] || { [ "${list_type}" = allowlist ] && [ ! -f "${abl_dir}/allowlist" ]; }
 		then
 			case ${list_type} in
-				blocklist) return 1 ;;
+				blocklist)
+					[ "${allowlist_only_mode}" = 0 ] && return 1
+					log_msg -yellow "Allowlist-only mode is on - accepting empty blocklist." ;;
 				allowlist)
 					log_msg "Not using any allowlist for blocklist processing."
 					use_allowlist=0
@@ -1431,6 +1438,12 @@ generate_and_process_blocklist_file()
 			# pack entries in 1024 characters long lines
 			convert_entries allowlist
 			rm -f "${abl_dir}/allowlist"
+		fi
+		# add the optional allowlist-only entry
+		if [ "${allowlist_only_mode}" = 1 ]
+		then
+			printf '%s\n' "address=/#/#"
+			printf '%s\n' "server=/google.com/microsoft.com/amazon.com/#"
 		fi
 		# add the blocklist test entry
 		printf '%s\n' "address=/adblocklean-test123.info/127.0.0.1"

--- a/adblock-lean
+++ b/adblock-lean
@@ -1326,7 +1326,7 @@ gen_list_parts()
 			case ${list_type} in
 				blocklist)
 					[ "${whitelist_mode}" = 0 ] && return 1
-					log_msg -yellow "Allowlist-only mode is on - accepting empty blocklist." ;;
+					log_msg -yellow "Whitelist mode is on - accepting empty blocklist." ;;
 				allowlist)
 					log_msg "Not using any allowlist for blocklist processing."
 					use_allowlist=0
@@ -1467,7 +1467,7 @@ generate_and_process_blocklist_file()
 			convert_entries allowlist
 			rm -f "${abl_dir}/allowlist"
 		fi
-		# add the optional allowlist-only entry
+		# add the optional whitelist entry
 		if [ "${whitelist_mode}" = 1 ]
 		then
 			# add block-everything entry: local=/*a/*b/*c/.../*z/

--- a/adblock-lean
+++ b/adblock-lean
@@ -26,6 +26,7 @@ IFS='
 nl='
 '
 delim="$(printf '\35')"
+CR_LF="$(printf '\r\n')"
 default_IFS="${IFS}"
 
 if [ -t 0 ]
@@ -650,6 +651,9 @@ parse_config()
 	for entry in ${curr_config}
 	do
 		case ${entry} in
+			*"${CR_LF}"*)
+				reg_failure "Config file contains Windows-format (CR LF) newlines. Convert the config file to Unix-format (LF) newlines."
+				return 1 ;;
 			*?=*) ;;
 			*) { inval_e; return 1; } ;;
 		esac
@@ -1173,7 +1177,12 @@ process_list_part()
 	if read -r rogue_element < "${abl_dir}/rogue_element"
 	then
 		rm -f "${dest_file}"
-		log_msg -warn "Rogue element: '${rogue_element}' identified originating in ${list_type} file part from: ${list_path}."
+		case "${rogue_element}" in
+			*"${CR_LF}"*)
+				log_msg -warn "${list_type} file from ${list_path} contains Windows-format (CR LF) newlines." \
+					"This file needs to be converted to Unix newline format (LF)." ;;
+			*) log_msg -warn "Rogue element: '${rogue_element}' identified originating in ${list_type} file from: ${list_path}."
+		esac
 		return 2
 	fi
 	rm -f "${abl_dir}/rogue_element"

--- a/adblock-lean
+++ b/adblock-lean
@@ -25,6 +25,7 @@ IFS='
 '
 nl='
 '
+delim="$(printf '\35')"
 default_IFS="${IFS}"
 
 if [ -t 0 ]
@@ -169,12 +170,12 @@ log_msg()
 			"-err") err_l=err color="${red}" msgs_prefix="Error: " ;;
 			"-warn") err_l=warn color="${yellow}" msgs_prefix="Warning: " ;;
 			-blue|-red|-green|-purple|-yellow) eval "color=\"\${${_arg#-}}\"" ;;
-			'') msgs="${msgs}dummy${nl}" ;;
-			*) msgs="${msgs}${msgs_prefix}${_arg}${nl}"; [ -n "${msgs_prefix}" ] && msgs_prefix=
+			'') msgs="${msgs}dummy${delim}" ;;
+			*) msgs="${msgs}${msgs_prefix}${_arg}${delim}"; [ -n "${msgs_prefix}" ] && msgs_prefix=
 		esac
 	done
-	msgs="${msgs%${nl}}"
-	local IFS="${nl}"
+	msgs="${msgs%"${delim}"}"
+	local IFS="${delim}"
 
 	for m in ${msgs}
 	do

--- a/adblock-lean
+++ b/adblock-lean
@@ -2834,6 +2834,16 @@ uninstall()
 
 set_colors
 
+# test process substitution support
+printf '%s\n%s\n' "#!/bin/sh" "printf %s >(:)" > /tmp/abl-test
+if ! /bin/sh /tmp/abl-test 1>/dev/null 2>/dev/null
+then
+	rm -f /tmp/abl-test
+	reg_failure "This shell does not support process substitution. To use adblock-lean, please update OpenWrt to 22.03 or later version."
+	exit 1
+fi
+rm -f /tmp/abl-test
+
 case "${1}" in
 	setup) setup; exit 0 ;;
 	uninstall) uninstall; exit 0

--- a/adblock-lean
+++ b/adblock-lean
@@ -2225,7 +2225,7 @@ setup()
 		2) exit 1 ;;
 		1)
 			print_msg "" "${purple}Creating dnsmasq addnmount UCI entry.${n_c}"
-			uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox # adblock-lean' && uci commit ||
+			uci add_list dhcp.@dnsmasq[0].addnmount='/bin/busybox' && uci commit ||
 				setup_failed "Failed to create addnmount entry."
 	esac
 	luci_addnmount_failed=
@@ -2249,7 +2249,7 @@ setup()
 	fi
 
 	# enable the service, update the cron job
-	/sbin/service adblock-lean enable || setup_failed
+	/sbin/service adblock-lean enable || exit 1
 	luci_service_enable_failed=
 
 	# determine if there are missing GNU utils
@@ -2779,17 +2779,25 @@ uninstall()
 		rm -rf "${config_dir}" || reg_failure "Failed to delete the config directory '${config_dir}'."
 	fi
 
-	local i="-1" entry
-	while uci -q get dhcp.@dnsmasq[${i}] >/dev/null && [ ${i} -lt 128 ]
+	local i="-1" addnmount_deleted=1
+	while [ ${i} -lt 128 ]
 	do
 		i=$((i+1))
-		entry="$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" || continue
-		case "${entry}" in *adblock-lean*) ;; *) continue; esac
+		uci -q get dhcp.@dnsmasq[${i}] >/dev/null || break
+		case "$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" in */bin/busybox*) ;; *) continue; esac
+		addnmount_deleted=
 		log_msg -purple "" "Deleting the custom addnmount entry from /etc/config/dhcp."
-		uci -q del_list dhcp.@dnsmasq[${i}].addnmount='/bin/busybox # adblock-lean' && uci commit ||
-			reg_failure "Failed to delete the custom addnmount entry from /etc/config/dhcp. Please delete manually."
+		if uci -q del_list dhcp.@dnsmasq[${i}].addnmount='/bin/busybox' && uci commit
+		then
+			case "$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" in */bin/busybox*) break; esac
+			addnmount_deleted=1
+			log_msg "Note: adblock-lean developers are not aware of any other software which may require the specific addnmount entry created by adblock-lean," \
+				"but if by any chance you have such software then it may stop working after removal and you may need to re-add the addnmount entry."
+		fi
 		break
 	done
+	[ -z "${addnmount_deleted}" ] &&
+		reg_failure "Failed to delete the custom addnmount entry from /etc/config/dhcp. Please delete manually."
 
 	log_msg -purple "" "Deleting the script from ${abl_service_path}."
 	rm -f "${abl_service_path}" ||

--- a/adblock-lean
+++ b/adblock-lean
@@ -2261,7 +2261,12 @@ setup()
 	fi
 
 	# enable the service, update the cron job
-	/sbin/service adblock-lean enable || exit 1
+	if /sbin/service adblock-lean enabled
+	then
+		upd_cron_job && luci_cron_job_creation_failed=
+	else
+		/sbin/service adblock-lean enable || exit 1
+	fi
 	luci_service_enable_failed=
 
 	# determine if there are missing GNU utils

--- a/adblock-lean
+++ b/adblock-lean
@@ -164,6 +164,7 @@ log_msg()
 {
 	local m msgs='' msgs_prefix='' _arg err_l=info color=
 
+	local IFS="${default_IFS}"
 	for _arg in "$@"
 	do
 		case "${_arg}" in
@@ -175,7 +176,7 @@ log_msg()
 		esac
 	done
 	msgs="${msgs%"${delim}"}"
-	local IFS="${delim}"
+	IFS="${delim}"
 
 	for m in ${msgs}
 	do

--- a/adblock-lean
+++ b/adblock-lean
@@ -59,7 +59,7 @@ adblock-lean custom commands:
 	pause           pause adblock-lean
 	resume          resume adblock-lean
 	gen_stats       generate dnsmasq stats for system log
-	gen_config      generate default config and enable the adblock-lean service
+	gen_config      generate default config based on one of the pre-defined presets
 	upd_cron_job    create cron job for adblock-lean with schedule set in the config option 'cron_schedule'.
 	                if config option set to 'disable', remove existing cron job if any
 	print_log       print most recent session log
@@ -2339,7 +2339,7 @@ gen_stats()
 	[ "${1}" != '-noexit' ] && exit 0
 }
 
-# generates config and enables the service
+# generates config
 gen_config()
 {
 	init_command gen_config || return 1

--- a/adblock-lean
+++ b/adblock-lean
@@ -2517,6 +2517,7 @@ start()
 
 	if [ "${initial_dnsmasq_restart}" = 1 ]
 	then
+		clean_dnsmasq_dir
 		restart_dnsmasq || exit 1
 	fi
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -2844,12 +2844,7 @@ case "${action}" in
 				exit 0
 			fi
 			load_config
-			if [ -n "${cron_schedule}" ] && [ "${cron_schedule}" != disable ]
-			then
-				upd_cron_job && luci_cron_job_creation_failed=
-			else
-				luci_cron_job_creation_failed=
-			fi
+			[ -n "${cron_schedule}" ] && upd_cron_job && luci_cron_job_creation_failed=
 		fi ;;
 	disable)
 		if [ -z "${disabling}" ]

--- a/adblock-lean
+++ b/adblock-lean
@@ -1075,7 +1075,7 @@ process_list_part()
 	esac
 
 	case ${list_type} in
-		allowlist) [ "${list_origin}" = local ] && dest_file="${abl_dir}/allowlist" ;;
+		allowlist) dest_file="${abl_dir}/allowlist.0" ;;
 		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; }
 	esac
 
@@ -1182,6 +1182,13 @@ process_list_part()
 		return 3
 	fi
 
+	# keep the allowlist consolidated in one file
+	if [ "${list_type}" = allowlist ]
+	then
+		cat "${dest_file}" >> "${abl_dir}/allowlist" || { reg_failure "Failed to merge allowlist part."; return 1; }
+		rm -f "${dest_file}"
+	fi
+
 	cleanup_dl_status_files
 	:
 }
@@ -1207,9 +1214,21 @@ gen_list_parts()
 
 	[ -z "${blocklist_urls}${dnsmasq_blocklist_urls}" ] && log_msg -yellow "NOTE: No URLs specified for blocklist download."
 
+	rm -f "${abl_dir}/allowlist"
+
+	if [ "${whitelist_mode}" = 1 ]
+	then
+		# allow test domains
+		for d in ${test_domains}
+		do
+			printf '%s\n' "${d}" >> "${abl_dir}/allowlist"
+		done
+		use_allowlist=1
+	fi
+
 	for list_type in allowlist blocklist blocklist_ipv4
 	do
-		rm -f "${abl_dir}/${list_type}"*
+		rm -f "${abl_dir}/${list_type}".*
 		list_id=0 list_line_cnt=0 list_part_line_count=0
 		and_compressing=
 		case ${list_type} in blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && and_compressing=" and compressing"; esac
@@ -1277,12 +1296,6 @@ gen_list_parts()
 					process_list_part "${list_id}" "${list_type}" "downloaded" "${list_format}" "${list_url}"
 					case ${?} in
 						0)
-							if [ "${list_type}" = allowlist ]
-							then
-								cat "${abl_dir}/${list_type}.${list_id}" >> "${abl_dir}/allowlist" ||
-									{ reg_failure "Failed to merge allowlist part."; return 1; }
-								rm -f "${abl_dir}/${list_type}.${list_id}"
-							fi
 							log_process_success "downloaded ${list_format}"
 							[ "${list_type}" = blocklist_ipv4 ] && use_blocklist_ipv4=1
 							list_line_cnt=$(( list_line_cnt + list_part_line_count ))
@@ -1457,9 +1470,10 @@ generate_and_process_blocklist_file()
 		# add the optional allowlist-only entry
 		if [ "${whitelist_mode}" = 1 ]
 		then
-			printf '%s\n' "address=/#/#"
-			local allow_test_domains="$(printf %s "${test_domains}" | sed -E 's~[ \t]+$~~;s~^[ \t]+~~;s~[ \t]+~\n~g')"
-			[ -n "${allow_test_domains}" ] && printf %s "${allow_test_domains}" | convert_entries allowlist
+			# add block-everything entry: local=/*a/*b/*c/.../*z/
+			printf 'local=/'
+			awk 'BEGIN{for (i=97; i<=122; i++) printf("*%c/",i);exit}'
+			printf '\n'
 		fi
 		# add the blocklist test entry
 		printf '%s\n' "address=/adblocklean-test123.info/#"


### PR DESCRIPTION
- implement the 'uninstall' command
- add whitelist mode
- fix allowlist domains removal from the blocklist
- correctly handle wildcards when removing allowlist domains from the blocklist
- fix a bug with the disable command
- add an option to specify test domains
- reorder the options
- some fairly minor changes to how the allowlist is generated, in order to accommodate the whitelist mode
- local lists are now checked for rogue elements, as well as downloaded lists
- detect Windows-style newlines in the config file and in the allowlist/blocklist files, and print correct errors when detected
- test connectivity to the domains included in the URLs before attempting download. if connectivity check fails, force dnsmasq restart before download
- change script description
- update the readme
- fix cron job not updated by the setup command when the service is already enabled
- actually install the new version when running the update command in simulation mode
- update(): offer to start the new version
- check for process substitution support and fail gracefully if the shell doesn't support it
