### PR TITLE
Simplify concurrency implementation

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -279,7 +279,11 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
-		[ -n "${PROCESS_SCHEDULER_PID}${DL_SCHEDULER_PID}" ] && kill_pids_recursive "${PROCESS_SCHEDULER_PID} ${DL_SCHEDULER_PID}"
+		[ -n "${SCHEDULER_PID}" ] &&
+		{
+			log_msg -warn "Killing unfinished processing scheduler (PID: ${SCHEDULER_PID}) and its jobs.";
+			kill_pids_recursive "${SCHEDULER_PID}"
+		}
 		rm -rf "${ABL_DIR}"
 	fi
 	[ -n "${LOCK_REQ}" ] && rm_lock

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -7,13 +7,11 @@
 : "${max_download_retries:=}" "${deduplication:=}" "${max_blocklist_file_size_KB:=}" "${min_good_line_count:=}" "${local_allowlist_path:=}"
 : "${blue:=}" "${n_c:=}"
 
-TO_PROCESS_DIR="${ABL_DIR}/to_process"
 PROCESSED_PARTS_DIR="${ABL_DIR}/list_parts"
 
 SCHEDULE_DIR="${ABL_DIR}/schedule"
 DL_IN_PROGRESS_FILE="${SCHEDULE_DIR}/dl_in_progress"
 
-IDLE_TIMEOUT_S=300 # 5 minutes
 PROCESSING_TIMEOUT_S=900 # 15 minutes
 
 
@@ -83,25 +81,6 @@ get_elapsed_time_s()
 
 # JOB SCHEDULER FUNCTIONS
 
-# 1 - var name for output
-# 2 - job PID
-get_dl_job_url()
-{
-	get_url_failed()
-	{
-		reg_failure "get_dl_job_url: URL reg file '${reg_file}' ${1}."
-	}
-
-	local line reg_file="${SCHEDULE_DIR}/url_${2}"
-	unset "${1}"
-	[ -f "${reg_file}" ] || { get_url_failed "not found"; return 1; }
-	read -r line < "${reg_file}" || { get_url_failed "could not be read"; return 1; }
-	[ -n "${line}" ] || { get_url_failed "is empty"; return 1; }
-
-	eval "${1}"='${line##*=}'
-	:
-}
-
 # get current job PID
 # 1 - var name for output
 get_curr_job_pid()
@@ -114,114 +93,47 @@ get_curr_job_pid()
 	eval "${1}=\"${__pid}\""
 }
 
-# 1 - job type (DL|PROCESS)
-# the rest of the args passed as-is to workers
-schedule_job()
+handle_fatal()
 {
-	local job_type="${1}"
-	shift
+	[ -f "${SCHEDULE_DIR}/nonfatal" ] && return 0
 
-print_timed_msg -yellow "Scheduling $job_type job (running jobs: $RUNNING_JOBS_CNT)"
-
-	handle_done_jobs "${job_type}" || return 1
-
-	# wait for job vacancy
-	while [ "${RUNNING_JOBS_CNT}" -ge "${MAX_THREADS}" ]
-	do
-print_timed_msg -yellow "Waiting for $job_type vacancy (running jobs: $RUNNING_JOBS_CNT)"
-		[ -n "${RUNNING_PIDS}" ] ||
-			{ reg_failure "\$RUNNING_JOBS_CNT=${RUNNING_JOBS_CNT} but no registered jobs PIDs."; return 1; }
-
-		wait -n ${RUNNING_PIDS} # wait for any one of the PIDs to finish
-		handle_done_jobs "${job_type}" || return 1
-	done
-
-	RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT+1))
-	case "${job_type}" in
-		DL) dl_list_part "${@}" & ;;
-		PROCESS) process_list_part "${@}" &
-	esac
-
-	add2list RUNNING_PIDS "${!}" " "
-
-	:
+	local fatal_pid fatal_path
+	[ ! -s "${SCHEDULE_DIR}/fatal" ] || ! read -r fatal_pid fatal_path < "${SCHEDULE_DIR}/fatal" ||
+		[ -f "${SCHEDULE_DIR}/dl_failed_${fatal_pid}" ] && return 1
+	: "${fatal_pid:=unknown}"
+	: "${fatal_path:=unknown}"
+	reg_failure "job with pid '${fatal_pid}' (path: '${fatal_path}') reported fatal error."
+	return 1
 }
 
-# 1 - job type (DL|PROCESS)
-# 2 - pid
-# 3 - return code
-# 4 - DL thread PID
-reg_done_job()
-{
-	[ -n "${2}" ] && touch "${SCHEDULE_DIR}/done_${1}_${2}_${3}_${4}"
-	if [ "${3}" = 1 ]
-	then
-		local fatal_pars=
-		if [ -n "${1}" ] && [ -n "${2}" ]
-		then
-			fatal_pars="${1} ${2}"
-		fi
-		rm -f "${SCHEDULE_DIR}/nonfatal"
-		printf '%s\n' "${fatal_pars}" > "${SCHEDULE_DIR}/fatal"
-	fi
-}
-
-# 1 - job type (DL|PROCESS)
-# 2 (optional) - only handle job with pid $2
+# 1 (optional) - only handle job with pid $1
 handle_done_jobs()
 {
-	local job_type="${1}" done_job_file done_job_rv done_pid done_dl_pid job_url suffix=
-	[ -n "${2}" ] && suffix="${2}_"
+	local done_job_file done_job_rv done_pid done_dl_pid job_url suffix=
+	[ -n "${1}" ] && suffix="${1}_"
 
-	[ -f "${SCHEDULE_DIR}/nonfatal" ] ||
-	{
-		local fatal_type fatal_pid
-		[ ! -s "${SCHEDULE_DIR}/fatal" ] || ! read -r fatal_type fatal_pid < "${SCHEDULE_DIR}/fatal" ||
-			[ -f "${SCHEDULE_DIR}/dl_failed_${fatal_pid}" ] && return 1
-		: "${fatal_type:=unknown}"
-		: "${fatal_pid:=unknown}"
-		reg_failure "${fatal_type} job with pid '${fatal_pid}' reported fatal error."
-		return 1
-	}
+	handle_fatal || cleanup_and_exit 1
 
-	# clean up processed files related to failed downloads
-	local failed_dl_file failed_suffix
-	for failed_dl_file in "${SCHEDULE_DIR}/failed_"*
-	do
-		[ -s "${failed_dl_file}" ] || continue
-		failed_suffix="${failed_dl_file##*_}"
-		rm -f "${failed_dl_file}"\
-			"${PROCESSED_PARTS_DIR}/"*"-${failed_suffix}" \
-			"${PROCESSED_PARTS_DIR}/"*"-${failed_suffix}.gz" \
-			"${ABL_DIR}/"*"-${failed_suffix}"
-	done
-
-	for done_job_file in "${SCHEDULE_DIR}/done_${job_type}_${suffix}"*
+	for done_job_file in "${SCHEDULE_DIR}/done_${suffix}"*
 	do
 		[ -e "${done_job_file}" ] || break
 		rm -f "${done_job_file}"
 		local done_filename="${done_job_file##*/}" IFS=_
 		set -- ${done_filename}
 		IFS="${DEFAULT_IFS}"
-		done_pid="${3}" done_job_rv="${4}" done_dl_pid="${5}"
-print_timed_msg -yellow "$job_type job $done_pid completed."
+		done_pid="${2}" done_job_rv="${3}"
+print_timed_msg -yellow "Job $done_pid completed."
 		subtract_a_from_b "${done_pid}" "${RUNNING_PIDS}" RUNNING_PIDS " "
 		RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT-1))
 
 		if [ "${done_job_rv}" != 0 ]
 		then
-			get_a_arr_val "${job_type}_JOBS_URLS" "${done_pid}" job_url
-
-			local job_type_print
-			case "${job_type}" in
-				DL) job_type_print=Download ;;
-				PROCESS) job_type_print=Processing
-			esac
+			get_a_arr_val JOBS_URLS "${done_pid}" job_url
 
 			[ -f "${SCHEDULE_DIR}/dl_failed_${done_dl_pid}" ] && return 0
 			touch "${SCHEDULE_DIR}/dl_failed_${done_dl_pid}"
 
-			reg_failure "${job_type_print} job (PID ${done_pid}) for list '${job_url}' returned code ${done_job_rv}."
+			reg_failure "Processing job (PID ${done_pid}) for list '${job_url}' returned code ${done_job_rv}."
 			[ "${list_part_failed_action}" = "STOP" ] && { log_msg "list_part_failed_action is set to 'STOP', exiting."; return 1; }
 			log_msg "Skipping file and continuing."
 		fi
@@ -229,63 +141,72 @@ print_timed_msg -yellow "$job_type job $done_pid completed."
 	:
 }
 
-# 1 - job type (DL|PROCESS)
-handle_running_jobs()
+# 1 - list origin (DL|LOCAL)
+# 2 - list URL or local path
+# 3 - list type (blocklist|blocklist_ipv4|allowlist)
+# 4 - list format (raw|dnsmasq)
+# the rest of the args passed as-is to workers
+schedule_job()
 {
-	local job_pid
+	local list_origin="${1}" list_path="${2}" list_type="${3}" list_format="${4}"
 
-	# handle errors in previously finished jobs
-	handle_done_jobs "${1}" || return 1
+print_timed_msg -yellow "Scheduling $list_origin job (running jobs: $RUNNING_JOBS_CNT)"
 
-	# wait for jobs to finish and handle errors
-	local IFS="${DEFAULT_IFS}"
-	for job_pid in ${RUNNING_PIDS}
+	handle_done_jobs || return 1
+
+	# wait for job vacancy
+	while [ "${RUNNING_JOBS_CNT}" -ge "${PROCESS_THREADS}" ]
 	do
-		wait "${job_pid}"
-		handle_done_jobs "${1}" "${job_pid}" || return 1
+print_timed_msg -yellow "Waiting for vacancy (running jobs: $RUNNING_JOBS_CNT, running PIDS: $RUNNING_PIDS)"
+		[ -n "${RUNNING_PIDS}" ] ||
+			{ reg_failure "\$RUNNING_JOBS_CNT=${RUNNING_JOBS_CNT} but no registered jobs PIDs."; return 1; }
+
+		wait -n ${RUNNING_PIDS} # wait for any one of the PIDs to finish
+		handle_done_jobs || return 1
 	done
+
+	RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT+1))
+	process_list_part "${@}" &
+
+	add2list RUNNING_PIDS "${!}" " "
+
 	:
 }
 
-schedule_local_jobs()
+# 1 - scheduler PID
+scheduler_timeout_watchdog()
 {
-	local list_types="${1}" local_list_path
-	for list_type in ${list_types}
+	local sched_time_s=0
+	while :
 	do
-		list_num=0
-		if [ "${list_type}" != blocklist_ipv4 ]
-		then
-			eval "local_list_path=\"\${local_${list_type}_path}\""
-			if [ ! -f "${local_list_path}" ]
-			then
-				log_msg -blue "" "No local ${list_type} identified."
-			elif [ ! -s "${local_list_path}" ]
-			then
-				log_msg -warn "" "Local ${list_type} file is empty."
-			else
-				log_msg -blue "" "Scheduling processing for the local ${list_type}."
-				ln -sf "${local_list_path}" "${TO_PROCESS_DIR}/${list_type}-local-raw-${list_num}"
-			fi
-		fi
+		[ -f "${SCHEDULE_DIR}/scheduler_done_${1}" ] && exit 0
+		handle_fatal || cleanup_and_exit 1
+		[ "${sched_time_s}" -lt "${PROCESSING_TIMEOUT_S}" ] ||
+		{
+			reg_failure "Processing timeout (${PROCESSING_TIMEOUT_S} s) for scheduler (PID: ${1}): stopping unfinished processing."
+			cleanup_and_exit 1
+		}
+		sched_time_s=$((sched_time_s+1))
+		sleep 1
 	done
-	:
 }
 
 # 1 - list types (allowlist|blocklist|blocklist_ipv4)
-schedule_download_jobs()
+schedule_jobs()
 {
 	finalize_scheduler()
 	{
 		rm -f "${DL_IN_PROGRESS_FILE}"
+		[ "${1}" != 0 ] && [ -n "${RUNNING_PIDS}" ] && kill_pids_recursive "${RUNNING_PIDS}"
+		touch "${SCHEDULE_DIR}/scheduler_done_${scheduler_pid}"
 		exit "${1}"
 	}
 
-	local list_type list_types="${1}" list_format list_url list_num
+	local list_type list_types="${1}" list_format list_url scheduler_pid
+	get_curr_job_pid scheduler_pid
 	RUNNING_PIDS=
 	RUNNING_JOBS_CNT=0
-	MAX_THREADS="${DL_THREADS}"
 
-	rm -f "${SCHEDULE_DIR}"/url_*
 	for list_type in ${list_types}
 	do
 		for list_format in raw dnsmasq
@@ -313,140 +234,80 @@ schedule_download_jobs()
 				esac
 			fi
 
-			list_num=0
 			for list_url in ${list_urls}
 			do
-				list_num=$((list_num+1))
 				list_part_line_count=0
-				schedule_job DL "${list_url}" "${list_type}" "${list_format}" "${list_num}" || finalize_scheduler 1
-				set_a_arr_el DL_JOBS_URLS "${!}=${list_url}"
+				schedule_job DL "${list_url}" "${list_type}" "${list_format}" || finalize_scheduler 1
+				set_a_arr_el JOBS_URLS "${!}=${list_url}"
 			done
 		done
+
+		# schedule local jobs
+		if [ "${list_type}" != blocklist_ipv4 ]
+		then
+			local local_list_path
+			eval "local_list_path=\"\${local_${list_type}_path}\""
+			if [ ! -f "${local_list_path}" ]
+			then
+				log_msg -blue "" "No local ${list_type} identified."
+			elif [ ! -s "${local_list_path}" ]
+			then
+				log_msg -warn "" "Local ${list_type} file is empty."
+			else
+				log_msg -blue "" "Scheduling processing for the local ${list_type}."
+				schedule_job LOCAL "${local_list_path}" "${list_type}" raw
+				set_a_arr_el JOBS_URLS "${!}=${local_list_path}"
+			fi
+		fi
 	done
 
-	handle_running_jobs DL
+	# handle errors in previously finished jobs
+	handle_done_jobs || finalize_scheduler 1
+
+	# wait for jobs to finish and handle errors
+	local job_pid
+	for job_pid in ${RUNNING_PIDS}
+	do
+		wait "${job_pid}"
+		handle_done_jobs "${job_pid}" || finalize_scheduler 1
+	done
+
 	finalize_scheduler ${?}
 }
 
-schedule_processing_jobs()
-{
-	finalize_scheduler()
-	{
-		[ -n "${2}" ] && reg_failure "${2}"
-		exit "${1}"
-	}
-
-	# 1 - var name for output
-	# extra args - paths with optional patterns
-	find_files_to_process()
-	{
-		local f var_name="${1}" to_process=
-		shift
-		unset "${var_name}"
-		# shellcheck disable=SC2048
-		for f in ${*}
-		do
-			[ -e "${f}" ] || continue
-			add2list to_process "${f}"
-		done
-		subtract_a_from_b "${files_processed}" "${to_process}" "${var_name}"
-		eval "[ -n \"\${${var_name}}\" ]"
-	}
-
-	local dl_url file files_to_process processing_time_s=0 list_type list_types="${1}" files_processed='' find_names=
-	for list_type in ${list_types}
-	do
-		add2list find_names "${TO_PROCESS_DIR}/${list_type}-*" " "
-	done
-
-	RUNNING_PIDS=
-	RUNNING_JOBS_CNT=0
-	MAX_THREADS="${PROCESS_THREADS}"
-
-	while :
-	do
-		get_elapsed_time_s processing_time_s "${INITIAL_UPTIME_S}"
-		[ "${processing_time_s}" -lt "${PROCESSING_TIMEOUT_S}" ] ||
-				finalize_scheduler 1 "Processing timeout (${PROCESSING_TIMEOUT_S} s): stopping unfinished processing."
-
-		find_files_to_process files_to_process "${find_names}" || [ -f "${DL_IN_PROGRESS_FILE}" ] || break
-
-		local idle_time_s=0
-		while [ -f "${DL_IN_PROGRESS_FILE}" ] && [ -z "${files_to_process}" ]
-		do
-			[ "${idle_time_s}" -lt "${IDLE_TIMEOUT_S}" ] ||
-				finalize_scheduler 1 "Idle timeout (${IDLE_TIMEOUT_S} s): giving up on waiting for files to process."
-			sleep 1
-			idle_time_s=$((idle_time_s+1))
-			find_files_to_process files_to_process "${find_names}"
-		done
-
-		local IFS="${_NL_}"
-		for file in ${files_to_process}
-		do
-			# parse the filename to get list info
-			IFS="-"
-			set -- ${file##*/}
-			IFS="${DEFAULT_IFS}"
-			local list_type="${1}" list_origin="${2}" list_format="${3}" list_num="${4}" dl_pid="${5}"
-
-			[ -n "${dl_pid}" ] && { get_dl_job_url dl_url "${dl_pid}" || finalize_scheduler 1; }
-			schedule_job PROCESS "${list_num}" "${list_type}" "${list_origin}" "${list_format}" "${file}" "${dl_pid}" "${dl_url}" ||
-				finalize_scheduler 1
-			case "${list_origin}" in
-				downloaded) list_url="${dl_url}" ;;
-				local) eval "list_url=\"\${local_${list_type}_path}\""
-			esac
-			set_a_arr_el PROCESS_JOBS_URLS "${!}=${list_url}"
-			add2list files_processed "${file}"
-		done
-		IFS="${DEFAULT_IFS}"
-	done
-
-	handle_running_jobs PROCESS
-	finalize_scheduler ${?}
-}
-
-# 1 - URL
-# 2 - list type (allowlist|blocklist|blocklist_ipv4)
-# 3 - list format (dnsmasq|raw)
-# 4 - list num
+# 1 - list origin (DL|LOCAL)
+# 2 - list URL or local path
+# 3 - list type (blocklist|blocklist_ipv4|allowlist)
+# 4 - list format (raw|dnsmasq)
+# the rest of the args passed as-is to workers
 #
 # return codes:
 # 0 - Success
 # 1 - Fatal error (stop processing)
-# 2 - Download Failure
-dl_list_part()
+# 2 - Download failure
+# 3 - Processing failure
+process_list_part()
 {
 	finalize_job()
 	{
-		[ -n "${2}" ] && reg_failure "${2}"
-		[ "${1}" = 0 ] || cleanup_after_failed_dl
-		reg_done_job DL "${curr_job_pid}" "${1}" "${curr_job_pid}"
+		[ -n "${curr_job_pid}" ] && touch "${SCHEDULE_DIR}/done_${curr_job_pid}_${1}"
+		case "${1}" in
+			0)
+				local part=
+				[ "${list_origin}" = DL ] && part=" part"
+				log_msg -green "Successfully processed list${part} from ${blue}${list_path}${n_c} (size: $(bytes2human "${list_part_size_B}"), lines: $(int2human "${list_part_line_count}"))." ;;
+			*)
+				rm -f "${dest_file}" "${list_part_size_file}" "${list_part_line_cnt_file}"
+				if [ "${1}" = 1 ]
+				then
+					rm -f "${SCHEDULE_DIR}/nonfatal"
+					[ ! -f "${SCHEDULE_DIR}/fatal" ] && [ -n "${curr_job_pid}" ] &&
+						printf '%s\n' "${curr_job_pid} ${list_path}" > "${SCHEDULE_DIR}/fatal"
+				fi
+		esac
+
+		[ -n "${2}" ] && reg_failure "process_list_part: ${2}"
 		exit "${1}"
-	}
-
-	# delete processed files and send USR1 signal to the processing thread
-	cleanup_after_failed_dl()
-	{
-		local curr_job_pid="${1}" process_job_id process_pid filename
-
-		for file in "${SCHEDULE_DIR}/process_pid-${curr_job_pid}-"*
-		do
-			[ -e "${file}" ] || return 0
-
-			filename="${file##*/}"
-			local IFS=-
-			set -- ${filename}
-			IFS="${DEFAULT_IFS}"
-			process_pid="${3}"
-			[ -n "${process_pid}" ] || return 1
-			kill -s USR1 "${process_pid}" 2>/dev/null
-			[ -s "${file}" ] && read -r process_job_id < "${file}" && [ -n "${process_job_id}" ] || return 1
-			rm -f "${PROCESSED_PARTS_DIR}/${process_job_id}"* \
-				"${ABL_DIR}/size_${process_job_id}" "${ABL_DIR}/linecnt_${process_job_id}"
-			return 0
-		done
 	}
 
 	rm_ucl_err_file()
@@ -454,65 +315,174 @@ dl_list_part()
 		rm -f "${ucl_err_file}"
 	}
 
-	local me=dl_list_part dl_completed='' retry=1 \
-		list_url="${1}" list_type="${2}" list_format="${3}" list_num="${4}" curr_job_pid
+	rm_rogue_el_file()
+	{
+		rm -f "${rogue_el_file}"
+	}
+
+	# shellcheck disable=SC2317
+	dl_list()
+	{
+		uclient-fetch "${1}" -O- --timeout=3 2> "${ucl_err_file}"
+	}
+
+	local list_origin="${1}" list_path="${2}" list_type="${3}" list_format="${4}" curr_job_pid
+
 	get_curr_job_pid curr_job_pid || return 1
-	local list_id="${list_type}-downloaded-${list_format}-${list_num}"
+
+print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
+
+	for v in 1 2 3 4; do
+		eval "[ -z \"\${${v}}\" ]" && finalize_job 1 "Missing argument ${v}."
+	done
+
+	case "${list_type}" in
+		allowlist|blocklist) val_entry_regex='^[[:alnum:]-]+$|^(\*|[[:alnum:]_-]+)([.][[:alnum:]_-]+)+$' ;;
+		blocklist_ipv4) val_entry_regex='^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])$' ;;
+		*) finalize_job 1 "Invalid list type '${list_type}'"
+	esac
+
+	local list_id="${list_type}-${list_origin}-${list_format}"
 	local job_id="${list_id}-${curr_job_pid}"
-	local ucl_err_file="${ABL_DIR}/ucl_err_${job_id}"
+	local dest_file="${PROCESSED_PARTS_DIR}/${job_id}" \
+		ucl_err_file="${ABL_DIR}/ucl_err_${job_id}" \
+		rogue_el_file="${ABL_DIR}/rogue_el_${job_id}" \
+		list_part_size_file="${ABL_DIR}/size_${job_id}" \
+		list_part_line_cnt_file="${ABL_DIR}/linecnt_${job_id}" \
+		list_part_line_count compress_part='' min_list_part_line_count='' \
+		list_part_size_B='' list_part_size_KB='' retry=1
 
-print_timed_msg -yellow "Starting DL job (PID: $curr_job_pid)"
-
-	printf '%s\n' "${list_url}" > "${SCHEDULE_DIR}/url_${curr_job_pid}"
+	case ${list_type} in
+		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; }
+	esac
+	eval "min_list_part_line_count=\"\${min_${list_type}_part_line_count}\""
 
 	while :
 	do
-		rm_ucl_err_file
+		rm_rogue_el_file
+		rm -f "${list_part_size_file}" "${list_part_line_cnt_file}"
 
-		log_msg "Downloading ${list_format} ${list_type} part from ${blue}${list_url}${n_c}"
-		local fifo_file="${TO_PROCESS_DIR}/${job_id}-${retry}"
-			dl_failed_file="${SCHEDULE_DIR}/failed_${curr_job_pid}-${retry}"
-		rm -f "${dl_failed_file}"
 
-		exec 3<> <(:)
-		local sig=
-		trap 'sig=OK; printf "" >&3' USR1
-		trap 'sig=RETRY; printf "" >&3' USR2
-		trap 'sig=QUIT; printf "" >&3' HUP
+		# Download or cat the list
+		local fetch_cmd lines_cnt_low='' dl_completed=''
+		case "${list_origin}" in
+			DL)
+				rm_ucl_err_file
+				fetch_cmd=dl_list ;;
+			LOCAL) fetch_cmd="cat"
+		esac
 
-		[ -e "${fifo_file}" ] && finalize_job 1 "fifo file '${fifo_file}' already exists."
-		mkfifo "${fifo_file}" || finalize_job 1 "Failed to create fifo file '${fifo_file}'."
+		log_msg "Processing ${list_format} ${list_type} from ${blue}${list_path}${n_c}"
 
-		{ uclient-fetch "${list_url}" -O- --timeout=3 2> "${ucl_err_file}" || printf fail > "${dl_failed_file}"; } |
-			{ cat 1> "${fifo_file}"; head -c1 1> "${dl_failed_file}"; cat &> /dev/null; }
+		${fetch_cmd} "${list_path}" |
+		# limit size
+		{ head -c "${max_file_part_size_KB}k"; cat 1>/dev/null; } |
 
-		[ -s "${dl_failed_file}" ] && finalize_job 2 # file too big
+		# Count bytes
+		tee >(wc -c > "${list_part_size_file}") |
+
+		# Remove comment lines and trailing comments, remove whitespaces
+		$SED_CMD 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d' |
+
+		# Convert dnsmasq format to raw format
+		if [ "${list_format}" = dnsmasq ]
+		then
+			local rm_prefix_expr="s~^[ \t]*(local|server|address)=/~~" rm_suffix_expr=''
+			case "${list_type}" in
+				blocklist) rm_suffix_expr='s~/$~~' ;;
+				blocklist_ipv4) rm_prefix_expr="s~^[ \t]*bogus-nxdomain=~~" ;;
+				allowlist) rm_suffix_expr='s~/#$~~'
+			esac
+			$SED_CMD -E "${rm_prefix_expr};${rm_suffix_expr}" | tr '/' '\n'
+		else
+			cat
+		fi |
+
+		# Count entries
+		tee >(wc -w > "${list_part_line_cnt_file}") |
+
+		# Convert to lowercase
+		case "${list_type}" in allowlist|blocklist) tr 'A-Z' 'a-z' ;; *) cat; esac |
+
+		if [ "${list_type}" = blocklist ] && [ "${use_allowlist}" = 1 ]
+		then
+			case "${whitelist_mode}" in
+			0)
+				# remove allowlist domains from blocklist
+				${AWK_CMD} 'NR==FNR { if ($0 ~ /^\*\./) { allow_wild[substr($0,3)]; next }; allow[$0]; next }
+					{ n=split($1,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- )
+					{ addr = arr[i] "." addr; if ( (i>1 && addr in allow_wild) || addr in allow ) next } } 1' "${PROCESSED_PARTS_DIR}/allowlist" - ;;
+			1)
+				# only print subdomains of allowlist domains
+				${AWK_CMD} 'NR==FNR { if ($0 !~ /^\*/) { allow[$0] }; next } { n=split($1,arr,"."); addr = arr[n];
+					for ( i=n-1; i>1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) { print $1; next } } }' "${PROCESSED_PARTS_DIR}/allowlist" -
+			esac
+		else
+			cat
+		fi |
+
+		# check lists for rogue elements
+		tee >($SED_CMD -nE "\~${val_entry_regex}~d;p;:1 n;b1" > "${rogue_el_file}") |
+
+		# compress parts
+		if [ -n "${compress_part}" ]
+		then
+			busybox gzip
+		else
+			cat
+		fi > "${dest_file}"
+
+		[ -f "${list_part_size_file}" ] && read -r list_part_size_B _ < "${list_part_size_file}" || finalize_job 1
+		rm -f "${list_part_size_file}"
+		: "${list_part_size_B:=0}"
+		list_part_size_KB=$((list_part_size_B/1024))
+		if [ "${list_part_size_KB}" -ge "${max_file_part_size_KB}" ]
+		then
+			reg_failure "Size of ${list_type} part from '${list_path}' reached the maximum value set in config (${max_file_part_size_KB} KB)."
+			log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config."
+			finalize_job 2
+		fi
 
 		[ -f "${ucl_err_file}" ] && grep -q "Download completed" "${ucl_err_file}" && dl_completed=1
 
-		if [ "${dl_completed}" = 1 ]
+		if [ -s "${rogue_el_file}" ]
 		then
-			rm -f "${dl_failed_file}"
+			read -r -n512 rogue_element < "${rogue_el_file}"
+			rm_rogue_el_file
+			local rogue_el_print
+			if [ -n "${rogue_element}" ]
+			then
+				rogue_el_print="Rogue element '${rogue_element}'"
+			else
+				rogue_el_print="Unknown rogue element"
+			fi
 
-			# wait for processing thread signal
-			[ -z "${sig}" ] && read -r _ <&3
-
-			case "${sig}" in
-				OK)
-					log_msg -green "Successfully downloaded list part from ${blue}${list_url}${n_c}"
-					finalize_job 0 ;;
-				QUIT) finalize_job 2 ;;
-				RETRY) ;;
-				*) finalize_job 1 "Download thread (PID ${curr_job_pid}) received unexpected signal '${sig}'."
+			case "${rogue_element}" in
+				*"${CR_LF}"*)
+					log_msg -warn "${list_type} file from '${list_path}' contains Windows-format (CR LF) newlines." \
+						"This file needs to be converted to Unix newline format (LF)." ;;
+				*) log_msg -warn "${rogue_el_print} identified in ${list_type} file from: ${list_path}."
 			esac
+			finalize_job 2
 		fi
 
-		cleanup_after_failed_dl "${curr_job_pid}"
+		[ -f "${list_part_line_cnt_file}" ] && read -r list_part_line_count _ < "${list_part_line_cnt_file}"
+		: "${list_part_line_count:=0}"
+		if [ "${list_origin}" = DL ] && [ "${list_part_line_count}" -lt "${min_list_part_line_count}" ]
+		then
+			lines_cnt_low=1
+			reg_failure "Line count in downloaded ${list_type} part from '${list_path}' is $(int2human "${list_part_line_count}"), which is less than configured minimum: $(int2human "${min_list_part_line_count}")."
+		fi
 
-		reg_failure "Failed to download list part from URL '${list_url}'."
-		[ -f "${ucl_err_file}" ] && [ -z "${dl_completed}" ] &&
-			reg_failure "uclient-fetch errors: '$(cat "${ucl_err_file}")'."
-		rm_ucl_err_file
+		if [ "${list_origin}" = DL ] && { [ -z "${dl_completed}" ] || [ -n "${lines_cnt_low}" ]; }
+		then
+			reg_failure "Failed to download list part from URL '${list_url}'."
+			[ -s "${ucl_err_file}" ] && reg_failure "uclient-fetch errors: '$(cat "${ucl_err_file}")'."
+			rm_ucl_err_file
+		else
+			rm_ucl_err_file
+			finalize_job 0
+		fi
 
 		retry=$((retry + 1))
 		if [ "${retry}" -gt "${max_download_retries}" ]
@@ -522,233 +492,7 @@ print_timed_msg -yellow "Starting DL job (PID: $curr_job_pid)"
 
 		reg_action -blue "Sleeping for 5 seconds after failed download attempt." || finalize_job 1
 		sleep 5
-
-		continue
 	done
-	finalize_job 1
-}
-
-# 1 - list number
-# 2 - list type (allowlist|blocklist|blocklist_ipv4)
-# 3 - list origin (local|downloaded)
-# 4 - list format (dnsmasq|raw)
-# 5 - symlink path (for local lists) or fifo path (for downloaded lists)
-# 6 - (optional): download PID
-# 7 - (optional): download URL
-#
-# return codes:
-# 0 - Success
-# 1 - Fatal error (stop processing)
-# 2 - Bad List
-# 3 - Possibly failed download
-# 4 - Received HUP signal from the DL job
-process_list_part()
-{
-	finalize_job()
-	{
-		if [ "${1}" != 0 ]
-		then
-			rm -f "${dest_file}" "${list_part_size_file}" "${list_part_line_cnt_file}"
-		fi
-
-		local sig=
-		case "${1}" in
-			0) sig=USR1 ;;
-			1|2) sig=HUP ;;
-			3) sig=USR2 ;;
-			4) log_msg "Processing thread (PID: ${curr_job_pid}) received interrupt signal." ;;
-		esac
-		if [ -n "${sig}" ]
-		then
-			if [ "${list_origin}" = downloaded ] && [ -z "${list_was_read}" ] && [ -n "${list_file}" ]
-			then
-				[ -e "${list_file}" ] || sleep 1
-				[ -e "${list_file}" ] && cat "${list_file}" >/dev/null & # unblock the pipe
-			fi
-			kill -s "${sig}" "${dl_pid}" 2>/dev/null # signal process result to the DL thread
-		fi
-		rm -f "${list_file}"
-
-		if [ "${1}" = 0 ]
-		then
-			local part=
-			[ "${list_origin}" = downloaded ] && part=" part"
-			log_msg -green "Successfully processed list${part} from ${blue}${list_path}${n_c} (size: ${list_part_size_human}, lines: $(int2human "${list_part_line_count}"))."
-		fi
-
-		[ -n "${2}" ] && reg_failure "${2}"
-		reg_done_job PROCESS "${curr_job_pid}" "${1}" "${dl_pid}"
-		exit "${1}"
-	}
-
-	rm_rogue_el_file()
-	{
-		rm -f "${rogue_el_file}"
-	}
-
-	local list_num="${1}" list_type="${2}" list_origin="${3}" list_format="${4}" list_file="${5}" dl_pid="${6}" list_url="${7}"
-	local curr_job_pid me="process_list_part"
-	get_curr_job_pid curr_job_pid || finalize_job 1
-	local list_path val_entry_regex dl_retry='' list_was_read=''
-
-	for v in 1 2 3 4 5; do
-		eval "[ -z \"\${${v}}\" ]" && finalize_job 1 "${me}: Missing argument ${v}."
-	done
-
-	case "${list_type}" in
-		allowlist|blocklist) val_entry_regex='^[[:alnum:]-]+$|^(\*|[[:alnum:]_-]+)([.][[:alnum:]_-]+)+$' ;;
-		blocklist_ipv4) val_entry_regex='^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])$' ;;
-		*) finalize_job 1 "${me}: Invalid list type '${list_type}'"
-	esac
-
-print_timed_msg -yellow "Starting PROCESS job (PID: $curr_job_pid)"
-
-	case "${list_origin}" in
-		local)
-			list_path="$(readlink -f "${list_file}")" ;;
-		downloaded)
-			list_path="${list_url}"
-			dl_retry="${list_file##*-}"
-	esac
-
-	local job_id="${list_type}-${list_origin}-${list_format}-${list_num}-${curr_job_pid}-${dl_pid}-${dl_retry}"
-	local dest_file="${PROCESSED_PARTS_DIR}/${job_id}" \
-		rogue_el_file="${ABL_DIR}/rogue_el_${job_id}" \
-		list_part_size_file="${ABL_DIR}/size_${job_id}" \
-		list_part_line_cnt_file="${ABL_DIR}/linecnt_${job_id}" \
-		list_part_line_count compress_part='' min_list_part_line_count='' \
-		list_part_size_B='' list_part_size_KB=''
-
-	printf '%s\n' "${job_id}" > "${SCHEDULE_DIR}/process_pid-${dl_pid}-${curr_job_pid}"
-
-	log_msg "Processing ${list_format} ${list_type} part from ${blue}${list_path}${n_c}"
-
-	[ -e "${list_file}" ] || finalize_job 1 "${me}: list file '${list_file}' not found."
-
-	case ${list_type} in
-		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; }
-	esac
-
-	eval "min_list_part_line_count=\"\${min_${list_type}_part_line_count}\""
-
-	rm_rogue_el_file
-
-	trap 'finalize_job 4' USR1
-
-	# read input file and limit size
-	list_was_read=1
-	{ head -c "${max_file_part_size_KB}k" "${list_file}"; cat 1>/dev/null; } |
-
-	# Count bytes
-	tee >(wc -c > "${list_part_size_file}") |
-
-	# Remove comment lines and trailing comments, remove whitespaces
-	$SED_CMD 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d' |
-
-	# Convert dnsmasq format to raw format
-	if [ "${list_format}" = dnsmasq ]
-	then
-		local rm_prefix_expr="s~^[ \t]*(local|server|address)=/~~" rm_suffix_expr=''
-		case "${list_type}" in
-			blocklist) rm_suffix_expr='s~/$~~' ;;
-			blocklist_ipv4) rm_prefix_expr="s~^[ \t]*bogus-nxdomain=~~" ;;
-			allowlist) rm_suffix_expr='s~/#$~~'
-		esac
-		$SED_CMD -E "${rm_prefix_expr};${rm_suffix_expr}" | tr '/' '\n'
-	else
-		cat
-	fi |
-
-	# Count entries
-	tee >(wc -w > "${list_part_line_cnt_file}") |
-
-	# Convert to lowercase
-	case "${list_type}" in allowlist|blocklist) tr 'A-Z' 'a-z' ;; *) cat; esac |
-
-	if [ "${list_type}" = blocklist ] && [ -n "${use_allowlist}" ]
-	then
-		case "${whitelist_mode}" in
-		0)
-			# remove allowlist domains from blocklist
-			${AWK_CMD} 'NR==FNR { if ($0 ~ /^\*\./) { allow_wild[substr($0,3)]; next }; allow[$0]; next }
-				{ n=split($1,arr,"."); addr = arr[n]; for ( i=n-1; i>=1; i-- )
-				{ addr = arr[i] "." addr; if ( (i>1 && addr in allow_wild) || addr in allow ) next } } 1' "${PROCESSED_PARTS_DIR}/allowlist" - ;;
-		1)
-			# only print subdomains of allowlist domains
-			${AWK_CMD} 'NR==FNR { if ($0 !~ /^\*/) { allow[$0] }; next } { n=split($1,arr,"."); addr = arr[n];
-				for ( i=n-1; i>1; i-- ) { addr = arr[i] "." addr; if ( addr in allow ) { print $1; next } } }' "${PROCESSED_PARTS_DIR}/allowlist" -
-		esac
-	else
-		cat
-	fi |
-
-	# check lists for rogue elements
-	tee >($SED_CMD -nE "/${val_entry_regex}/d;p;:1 n;b1" > "${rogue_el_file}") |
-
-	# compress parts
-	if [ -n "${compress_part}" ]
-	then
-		busybox gzip
-	else
-		cat
-	fi > "${dest_file}"
-
-	[ -f "${list_part_size_file}" ] && read -r list_part_size_B _ < "${list_part_size_file}" || finalize_job 1
-	list_part_size_KB=$(( (list_part_size_B + 0) / 1024 ))
-	list_part_size_human="$(bytes2human "${list_part_size_B:-0}")"
-	[ -f "${list_part_line_cnt_file}" ] && read -r list_part_line_count _ < "${list_part_line_cnt_file}"
-	: "${list_part_line_count:=0}"
-
-	rm -f "${list_part_size_file}"
-
-	if [ "${list_part_size_KB}" -ge "${max_file_part_size_KB}" ]
-	then
-		reg_failure "Size of ${list_type} part from '${list_path}' reached the maximum value set in config (${max_file_part_size_KB} KB)."
-		log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config."
-		finalize_job 2
-	fi
-
-	if read -r rogue_element < "${rogue_el_file}"
-	then
-		rm_rogue_el_file
-		case "${rogue_element}" in
-			*"${CR_LF}"*)
-				log_msg -warn "${list_type} file from '${list_path}' contains Windows-format (CR LF) newlines." \
-					"This file needs to be converted to Unix newline format (LF)." ;;
-			*) log_msg -warn "Rogue element: '${rogue_element}' identified originating in ${list_type} file from: ${list_path}."
-		esac
-		finalize_job 2
-	fi
-	rm_rogue_el_file
-
-	if [ "${list_origin}" = downloaded ] && [ "${list_part_line_count}" -lt "${min_list_part_line_count}" ]
-	then
-		reg_failure "Line count in downloaded ${list_type} part from '${list_path}' is $(int2human "${list_part_line_count}"), which is less than configured minimum: $(int2human "${min_list_part_line_count}")."
-		for file in "${ABL_DIR}/ucl_err_"*"-${dl_pid}"
-		do
-			[ -e "${file}" ] || break
-			log_msg "uclient-fetch log: '$(cat "${file}")'."
-			break
-		done
-		finalize_job 3
-	fi
-
-	finalize_job 0
-}
-
-# 1 - var name for output
-# 2 - list type (allowlist|blocklist|blocklist_ipv4)
-get_processed_lines_cnt()
-{
-	local file part_line_count=0 list_type_line_count=0
-	for file in "${ABL_DIR}/linecnt_${2}-"*
-	do
-		[ -e "${file}" ] || break
-		read -r part_line_count < "${file}"
-		: "${part_line_count:=0}"
-		list_type_line_count=$((list_type_line_count+part_line_count))
-	done
-	eval "${1}"='${list_type_line_count}'
 }
 
 gen_list_parts()
@@ -758,12 +502,11 @@ gen_list_parts()
 	[ -z "${blocklist_urls}${dnsmasq_blocklist_urls}" ] && log_msg -yellow "" "NOTE: No URLs specified for blocklist download."
 
 	# clean up before processing
-	rm -rf "${PROCESSED_PARTS_DIR}" "${TO_PROCESS_DIR}" "${SCHEDULE_DIR}"
+	rm -rf "${PROCESSED_PARTS_DIR}" "${SCHEDULE_DIR}"
 
 	local file list_line_count list_types
 	try_mkdir -p "${SCHEDULE_DIR}" &&
-	try_mkdir -p "${PROCESSED_PARTS_DIR}" &&
-	try_mkdir -p "${TO_PROCESS_DIR}" || return 1
+	try_mkdir -p "${PROCESSED_PARTS_DIR}" || return 1
 
 	if [ "${whitelist_mode}" = 1 ]
 	then
@@ -771,6 +514,7 @@ gen_list_parts()
 		for d in ${test_domains}
 		do
 			printf '%s\n' "${d}" >> "${PROCESSED_PARTS_DIR}/allowlist"
+			preprocessed_line_count=$((preprocessed_line_count+1))
 		done
 		use_allowlist=1
 	fi
@@ -782,39 +526,30 @@ gen_list_parts()
 	# Asynchronously download and process parts, allowlist must be processed separately and first
 	for list_types in allowlist "blocklist blocklist_ipv4"
 	do
-		local process_list_types='' dl_list_types='' local_list_types=''
+		local schedule_req=''
 		for list_type in ${list_types}
 		do
 			eval "list_urls=\"\${${list_type}_urls}\""
 			if eval "[ -n \"\${${list_type}_urls}\${dnsmasq_${list_type}_urls}\" ]"
 			then
-				process_list_types=1
-				dl_list_types=1
+				schedule_req=1
 				touch "${DL_IN_PROGRESS_FILE}" || return 1
 			fi
 			if eval "[ -f \"\${local_${list_type}_path}\" ]"
 			then
-				process_list_types=1
-				local_list_types=1
+				schedule_req=1
 			fi
 		done
 
-		if [ -n "${process_list_types}" ]
+		if [ -n "${schedule_req}" ]
 		then
-			[ -n "${dl_list_types}" ] && {
-				schedule_download_jobs "${list_types}" &
-				DL_SCHEDULER_PID=${!}
-			}
-			[ -n "${local_list_types}" ] && schedule_local_jobs "${list_types}" # synchronous
+			schedule_jobs "${list_types}" &
+			SCHEDULER_PID=${!}
 
-			schedule_processing_jobs "${list_types}" &
-			PROCESS_SCHEDULER_PID=${!}
-
-			wait "${PROCESS_SCHEDULER_PID}" || return 1
-
-			[ -n "${dl_list_types}" ] && {
-				wait "${DL_SCHEDULER_PID}" || return 1
-			}
+			echo "Waiting for scheduler..." >&2
+			scheduler_timeout_watchdog "${SCHEDULER_PID}" &
+			wait "${SCHEDULER_PID}" || return 1
+			SCHEDULER_PID=''
 		fi
 
 		if [ "${list_types}" = allowlist ]
@@ -831,8 +566,15 @@ gen_list_parts()
 		for list_type in ${list_types}
 		do
 			# count lines for current list type
-			local file list_line_count
-			get_processed_lines_cnt list_line_count "${list_type}"
+			local file part_line_count=0 list_line_count=0
+			for file in "${ABL_DIR}/linecnt_${list_type}-"*
+			do
+				[ -e "${file}" ] || break
+				read -r part_line_count < "${file}"
+				: "${part_line_count:=0}"
+				list_line_count=$((list_line_count+part_line_count))
+			done
+
 			if [ "${list_line_count}" = 0 ]
 			then
 				case "${list_type}" in


### PR DESCRIPTION
This is a partial rewrite of the scheduler implementation in abl_process.sh

This implementation only uses one scheduler, (re-)merges the download and processing into one function and eliminates a lot of overhead associated with synchronization and data exchange between the download thread and the associated processing thread, dealing away with fifo's and lots of temporary files used for the aforementioned information exchange.

This is much simpler, much more straightforward, and much easier to maintain. Also seems somewhat faster.

In addition, this includes a timeout watchdog running in its own thread, which will terminate the program when timeout is reached. This allows to avoid polling in the scheduler thread and the associated `sleep 1` commands which were causing some (minor) delay in execution in the Concurrency branch.