### PR TITLE
Simpler concurrency

### DIFF
--- a/abl-install.sh
+++ b/abl-install.sh
@@ -135,6 +135,7 @@ log_msg()
 
 	for m in ${msgs}
 	do
+		IFS="${DEFAULT_IFS}"
 		case "${m}" in
 			dummy) echo ;;
 			*)

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -465,7 +465,7 @@ log_msg "" "adblock-lean ${REF} has been installed."
 
 if [ -n "${DO_DIALOGS}" ]
 then
-	if [ -n "${IS_UPDATE}" ]
+	if [ -n "${IS_UPDATE}" ] && [ -s "${ABL_CONFIG_FILE}" ]
 	then
 		print_msg "" "Start adblock-lean now? (y|n)"
 		pick_opt "y|n"

--- a/adblock-lean
+++ b/adblock-lean
@@ -280,7 +280,7 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
-		[ -n "${SCHEDULER_PID}" ] &&
+		[ -n "${SCHEDULER_PID}" ] && [ ! -f "${SCHEDULE_DIR}/scheduler_done_${SCHEDULER_PID}" ] &&
 		{
 			log_msg -warn "Killing unfinished processing jobs."
 			kill_pids_recursive "${SCHEDULER_PID}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -1133,11 +1133,11 @@ stop()
 	[ -n "${DNSMASQ_CONF_D}" ] ||
 	{
 		reg_failure "Failed to get DNSMASQ_CONF_D from config. Can not delete the blocklist from dnsmasq config directory."
-		exit 1
+		stop_rc=1
 	}
 
 	log_msg "Removing any adblock-lean blocklist files in dnsmasq config directories."
-	clean_dnsmasq_dir || exit 1
+	clean_dnsmasq_dir || stop_rc=1
 	restart_dnsmasq -nostop || stop_rc=1
 	log_msg -purple "" "Stopped adblock-lean."
 	[ -n "$noexit" ] && return "${stop_rc}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -60,8 +60,7 @@ ABL_CRON_CMD="/etc/init.d/adblock-lean start"
 
 ABL_GH_URL_API=https://api.github.com/repos/lynxthecat/adblock-lean
 
-DL_SCHEDULER_PID=
-PROCESS_SCHEDULER_PID=
+SCHEDULER_PID=
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -254,6 +254,7 @@ log_msg()
 
 	for m in ${msgs}
 	do
+		IFS="${DEFAULT_IFS}"
 		case "${m}" in
 			dummy) echo ;;
 			*)
@@ -492,6 +493,7 @@ kill_pids_recursive()
 		local IFS="${_NL_}"
 		for pid in ${child_pids}
 		do
+			IFS="${DEFAULT_IFS}"
 			is_included "${pid}" "${prev_pids}" " " || eval "${1}=\"\${${1}}\${pid} \""
 			add_child_pids "${1}" "${pid}"
 		done

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -712,10 +712,11 @@ parse_config()
 	def_config_format="$(printf %s "${def_config}" | get_config_format)"
 	luci_def_config_format=${def_config_format}
 
-	local IFS=$'\n'
+	local IFS="${_NL_}"
 	for entry in ${curr_config}
 	do
-		case ${entry} in
+		IFS="${DEFAULT_IFS}"
+		case "${entry}" in
 			*"${CR_LF}"*)
 				reg_failure "Config file contains Windows-format (CR LF) newlines. Convert the config file to Unix-format (LF) newlines."
 				return 1 ;;
@@ -838,9 +839,10 @@ load_config()
 		then
 			print_msg "" "${blue}Perform following automatic changes?${n_c}"
 			cnt=0
-			local IFS=$'\n'
+			local IFS="${_NL_}"
 			for fix in ${conf_fixes}
 			do
+				IFS="${DEFAULT_IFS}"
 				[ -z "${fix}" ] && continue
 				cnt=$((cnt+1))
 				print_msg "${cnt}. ${fix}"
@@ -867,8 +869,7 @@ fix_config()
 
 	# recreate config from default while replacing values with values from the existing config
 	fixed_config="$(
-		IFS=$'\n'
-		print_def_config -c "${DNSMASQ_CONF_D}" -i "${DNSMASQ_INSTANCE}" -n "${DNSMASQ_INDEX}" | while read -r line
+		print_def_config -c "${DNSMASQ_CONF_D}" -i "${DNSMASQ_INSTANCE}" -n "${DNSMASQ_INDEX}" | while IFS="${_NL_}" read -r line
 		do
 			case ${line} in
 				\#*|'') printf '%s\n' "${line}"; continue ;;
@@ -1310,7 +1311,7 @@ get_dnsmasq_instance_ns()
 # ALL_CONF_DIRS, ${instance}_CONF_DIRS, ${instance}_CONF_DIRS_CNT,
 # ${instance}_INDEX, ${instance}_RUNNING
 get_dnsmasq_instances() {
-	local nonempty='' instance instances instance_index l1_conf_file l1_conf_files conf_dirs conf_dirs_cnt IFS_OLD i s f dir
+	local nonempty='' instance instances instance_index l1_conf_file l1_conf_files conf_dirs conf_dirs_cnt i s f dir
 	DNSMASQ_INSTANCES=
 	DNSMASQ_INSTANCES_CNT=0
 	reg_action -blue "Checking dnsmasq instances."
@@ -1353,10 +1354,9 @@ get_dnsmasq_instances() {
 		json_select ..
 		json_select ..
 
-		IFS_OLD="$IFS"
 		IFS="${_NL_}"
 		set -- ${l1_conf_files}
-		IFS="${IFS_OLD}"
+		IFS="${DEFAULT_IFS}"
 
 		# get ifaces for instance
 		ifaces="$(${AWK_CMD} -F= '/^\s*interface=/ {if (!seen[$2]++) {ifaces = ifaces $2 ", "} } END {print ifaces}' "$@")"
@@ -1372,7 +1372,7 @@ get_dnsmasq_instances() {
 
 		IFS="${_NL_}"
 		set -- ${conf_dirs}
-		IFS="${IFS_OLD}"
+		IFS="${DEFAULT_IFS}"
 		for dir in "${@}"
 		do
 			add2list ALL_CONF_DIRS "${dir}"

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -481,9 +481,8 @@ print_def_config()
 	# Start delay in seconds when service is started from system boot
 	boot_start_delay_s="120" @ integer
 
-	# Number of parallel download and processing threads
-	DL_THREADS="1" @ integer
-	PROCESS_THREADS="1" @ integer
+	# Maximal count of download and processing jobs run in parallel
+	MAX_PARALLEL_JOBS="1" @ integer
 
 	# If a path to custom script is specified and that script defines functions 'report_success()' and 'report_failure()'',
 	# one of these functions will be executed when adblock-lean completes the execution of some commands,

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -164,7 +164,7 @@ print_timed_msg -yellow "Scheduling $list_origin job (running jobs: $RUNNING_JOB
 	handle_done_jobs || return 1
 
 	# wait for job vacancy
-	while [ "${RUNNING_JOBS_CNT}" -ge "${PROCESS_THREADS}" ]
+	while [ "${RUNNING_JOBS_CNT}" -ge "${MAX_PARALLEL_JOBS}" ]
 	do
 print_timed_msg -yellow "Waiting for vacancy (running jobs: $RUNNING_JOBS_CNT, running PIDS: $RUNNING_PIDS)"
 		[ -n "${RUNNING_PIDS}" ] ||
@@ -528,7 +528,7 @@ gen_list_parts()
 		use_allowlist=1
 	fi
 
-	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${PROCESS_THREADS})."
+	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${MAX_PARALLEL_JOBS})."
 	print_msg ""
 
 	set +m # disable job complete notification

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -317,16 +317,6 @@ process_list_part()
 		exit "${1}"
 	}
 
-	rm_ucl_err_file()
-	{
-		rm -f "${ucl_err_file}"
-	}
-
-	rm_rogue_el_file()
-	{
-		rm -f "${rogue_el_file}"
-	}
-
 	# shellcheck disable=SC2317
 	dl_list()
 	{
@@ -366,14 +356,14 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 
 	while :
 	do
-		rm_rogue_el_file
+		rm -f "${rogue_el_file}"
 		rm -f "${list_part_size_file}" "${list_part_line_cnt_file}"
 
 		# Download or cat the list
 		local fetch_cmd lines_cnt_low='' dl_completed=''
 		case "${list_origin}" in
 			DL)
-				rm_ucl_err_file
+				rm -f "${ucl_err_file}"
 				fetch_cmd=dl_list ;;
 			LOCAL) fetch_cmd="cat"
 		esac
@@ -454,7 +444,7 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 		if [ -s "${rogue_el_file}" ]
 		then
 			read -r -n512 rogue_element < "${rogue_el_file}"
-			rm_rogue_el_file
+			rm -f "${rogue_el_file}"
 			local rogue_el_print
 			if [ -n "${rogue_element}" ]
 			then
@@ -487,9 +477,9 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 		then
 			reg_failure "Failed to download list part from URL '${list_url}'."
 			[ -s "${ucl_err_file}" ] && reg_failure "uclient-fetch errors: '$(cat "${ucl_err_file}")'."
-			rm_ucl_err_file
+			rm -f "${ucl_err_file}"
 		else
-			rm_ucl_err_file
+			rm -f "${ucl_err_file}"
 			finalize_job 0
 		fi
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -459,7 +459,7 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 						"This file needs to be converted to Unix newline format (LF)." ;;
 				*) log_msg -warn "${rogue_el_print} identified in ${list_type} file from: ${list_path}."
 			esac
-			finalize_job 2
+			finalize_job 3
 		fi
 
 		[ -f "${list_part_line_cnt_file}" ] && read -r part_line_count _ < "${list_part_line_cnt_file}"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -528,6 +528,9 @@ gen_list_parts()
 		use_allowlist=1
 	fi
 
+	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${PROCESS_THREADS})."
+	print_msg ""
+
 	set +m # disable job complete notification
 
 	touch "${SCHEDULE_DIR}/nonfatal" || return 1 # serves as flag that no fatal error occured

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -44,16 +44,16 @@ try_gunzip()
 # returns status 0 if the result is null, 1 if not
 subtract_a_from_b() {
 	sab_out="${3:-___dummy}"
-	case "$2" in '') unset "$sab_out"; return 0; esac
-	case "$1" in '') eval "$sab_out"='$2'; [ ! "$2" ]; return; esac
-	_fs_su="${4:-"${_NL_}"}"
-	rv_su=0 _subt=
-	local IFS="$_fs_su"
-	for e in $2; do
-		is_included "$e" "$1" "$_fs_su" || { add2list _subt "$e" "$_fs_su"; rv_su=1; }
+	case "${2}" in '') unset "${sab_out}"; return 0; esac
+	case "${1}" in '') eval "${sab_out}"='${2}'; [ ! "${2}" ]; return; esac
+	local _fs_su="${4:-"${_NL_}"}"
+	local e rv_su=0 _subt=
+	local IFS="${_fs_su}"
+	for e in ${2}; do
+		is_included "${e}" "${1}" "${_fs_su}" || { add2list _subt "${e}" "${_fs_su}"; rv_su=1; }
 	done
-	eval "$sab_out"='$_subt'
-	return $rv_su
+	eval "${sab_out}"='$_subt'
+	return ${rv_su}
 }
 
 # 1 - var name for output


### PR DESCRIPTION
Changes in this PR:
- Correctly set and reset IFS
- abl-install: offer to start setup rather if the config file is not present
- stop(): fix the '-noexit' option not honoured in some cases
- Ensure that the scheduler and its child processes are only killed under fail conditions when this is needed
- abl-process: terminate the scheduler timeout watchdog when the scheduler exits
- abl-process: notify at processing start and print ${MAX_PARALLEL_JOBS}
- Replace config options 'DL_THREADS', 'PROCESS_THREADS' with one option - 'MAX_PARALLEL_JOBS'
- process_list_part(): remove unneeded functions
- process_list_part(): return error code 3 when the part exceeded maximum part size
- Remove unused variables
