### PR TITLE
Simpler concurrency

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -279,6 +279,7 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
+		[ -n "${WATCHDOG_PID}" ] && kill -9 "${WATCHDOG_PID}" 2>/dev/null
 		[ -n "${SCHEDULER_PID}" ] && [ ! -f "${SCHEDULE_DIR}/scheduler_done_${SCHEDULER_PID}" ] &&
 		{
 			log_msg -warn "Killing unfinished processing jobs."

--- a/adblock-lean
+++ b/adblock-lean
@@ -280,7 +280,6 @@ cleanup_and_exit()
 	if [ -n "${CLEANUP_REQ}" ]
 	then
 		[ "${1}" != 0 ] && print_msg "" "Cleaning up..."
-		[ -n "${WATCHDOG_PID}" ] && kill -9 "${WATCHDOG_PID}" 2>/dev/null
 		[ -n "${SCHEDULER_PID}" ] && [ -d "/proc/${SCHEDULER_PID}" ] && kill -s USR1 "${SCHEDULER_PID}"
 		rm -rf "${ABL_DIR}"
 	fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -255,7 +255,7 @@ log_msg()
 	do
 		IFS="${DEFAULT_IFS}"
 		case "${m}" in
-			dummy) echo ;;
+			dummy) printf '\n' ;;
 			*)
 				print_msg ${color} "${m}"
 				logger -t adblock-lean -p user."${err_l}" "${m}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -279,12 +279,9 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
+		[ "${1}" != 0 ] && print_msg "" "Cleaning up..."
 		[ -n "${WATCHDOG_PID}" ] && kill -9 "${WATCHDOG_PID}" 2>/dev/null
-		[ -n "${SCHEDULER_PID}" ] && [ ! -f "${SCHEDULE_DIR}/scheduler_done_${SCHEDULER_PID}" ] &&
-		{
-			log_msg -warn "Killing unfinished processing jobs."
-			kill_pids_recursive "${SCHEDULER_PID}"
-		}
+		[ -n "${SCHEDULER_PID}" ] && [ -d "/proc/${SCHEDULER_PID}" ] && kill -s USR1 "${SCHEDULER_PID}"
 		rm -rf "${ABL_DIR}"
 	fi
 	[ -n "${LOCK_REQ}" ] && rm_lock
@@ -467,8 +464,8 @@ log_success()
 # kills any running adblock-lean instances
 kill_abl_pids()
 {
-	local pgrep_ptrn="(/etc/rc.common /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
-	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} 's/\s+.*//' | tr '\n' ' ')" "${$}"
+	local pgrep_ptrn="((/etc/rc.common|sh|/bin/sh) /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
+	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
 }
 
 # kills specified pid's and their offspring
@@ -512,8 +509,7 @@ kill_pids_recursive()
 	done
 	[ -n "${initial_pids}" ] || return 0
 
-	kill ${initial_pids} 2>/dev/null
-
+	kill "${initial_pids}" 2>/dev/null
 	local running_pids="${initial_pids}" k_attempt=0
 	while :
 	do
@@ -525,7 +521,7 @@ kill_pids_recursive()
 			add_child_pids running_pids "${pid}"
 		done
 
-		kill ${running_pids} 2>/dev/null
+		kill "${running_pids}" 2>/dev/null
 
 		local alive_pids=''
 		for pid in ${running_pids}
@@ -537,7 +533,7 @@ kill_pids_recursive()
 
 		sleep 1
 	done
-	kill -9 ${running_pids} 2>/dev/null
+	kill -9 "${running_pids}" 2>/dev/null
 	:
 }
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -504,7 +504,9 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 		fi
 
 		reg_action -blue "Sleeping for 5 seconds after failed download attempt." || finalize_job 1
-		sleep 5
+		sleep 5 &
+		local sleep_pid=${!}
+		wait ${sleep_pid}
 	done
 }
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -489,7 +489,7 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 
 		if [ "${list_origin}" = DL ] && { [ -z "${dl_completed}" ] || [ -n "${lines_cnt_low}" ]; }
 		then
-			reg_failure "Failed to download list part from URL '${list_url}'."
+			reg_failure "Failed download attempt for URL '${list_url}'."
 			[ -s "${ucl_err_file}" ] && log_msg "uclient-fetch output: ${_NL_}'$(cat "${ucl_err_file}")'."
 			rm -f "${ucl_err_file}"
 		else


### PR DESCRIPTION
This implements @lynxthecat's ideas and improves handling of filesystem delays which would previously cause occasional fatal errors or appear as download errors.
- Remove the timeout watchdog
- Communicate job completion directly from jobs to the scheduler via a FIFO file (rather than via temp file)
- Communicate fatal errors directly from jobs to the scheduler via a signal (rather than via temp file)
- Use timed `read` to implement timeouts
- Reintroduce idle timeout
- When the files storing lines count and filesize are missing during processing, sleep for 1 second to give the filesystem time to catch up and try again before throwing an error