### PR TITLE
Simpler concurrency

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -853,7 +853,7 @@ update_version()
 abl_post_update_1()
 {
 	# fix incorrect rc.d symlink from older versions
-	[ -f /etc/rc.d/K4adblock-lean ] && mv /etc/rc.d/K4adblock-lean /etc/rc.d/K${START}adblock-lean
+	[ -f /etc/rc.d/K4adblock-lean ] || [ -f /etc/rc.d/k99adblock-lean ] && mv /etc/rc.d/K*adblock-lean /etc/rc.d/K${STOP}adblock-lean
 
 	# @temp_workaround - remove a few months from now
 	# when upgrading from older versions, fetch and install latest release

--- a/adblock-lean
+++ b/adblock-lean
@@ -270,7 +270,7 @@ log_msg()
 # 2 - err level
 write_log_file()
 {
-	[ -n "${LOG_FILE}" ] && { printf '['; date +'%b %d %Y, %H:%M:%S' | tr -d '\n'; printf '] %s\n' "${2:-info}: ${1}"; } >> "${LOG_FILE}"
+	[ -n "${LOG_FILE}" ] && date +"[%b %d %Y, %H:%M:%S] ${2:-info}: ${1}" >> "${LOG_FILE}"
 }
 
 # exit with code ${1}

--- a/adblock-lean
+++ b/adblock-lean
@@ -270,7 +270,7 @@ log_msg()
 # 2 - err level
 write_log_file()
 {
-	[ -n "${LOG_FILE}" ] && date +"[%b %d %Y, %H:%M:%S] ${2:-info}: ${1}" >> "${LOG_FILE}"
+	[ -n "${LOG_FILE}" ] && date +"[%b %d %Y, %H:%M:%S] ${2:-info}: ${1}" >> "${LOG_FILE}" &
 }
 
 # exit with code ${1}

--- a/adblock-lean
+++ b/adblock-lean
@@ -51,6 +51,7 @@ ABL_CONFIG_FILE=${ABL_CONFIG_DIR}/config
 CONFIG_FORMAT=v7
 
 PID_FILE="${ABL_PID_DIR}/adblock-lean.pid"
+ACTION_FILE="${ABL_PID_DIR}/adblock-lean.action"
 
 ABL_UPDATE_LOG_FILE=/var/log/abl_update.log
 ABL_SESSION_LOG_FILE=/var/log/abl_session.log
@@ -159,7 +160,7 @@ try_mkdir()
 # output via $REPLY
 pick_opt()
 {
-	update_pid_action "Waiting for user input in console" || return 1
+	update_action_file "Waiting for user input in console" || return 1
 	while :
 	do
 		printf %s "$1: " 1>${MSGS_DEST}
@@ -328,9 +329,6 @@ restart_dnsmasq()
 	:
 }
 
-# args:
-# 1 - (optional) -f to skip check for existing lock
-# 1/2 - action to write to the pid file
 #
 # return codes:
 # 0 - success
@@ -338,26 +336,20 @@ restart_dnsmasq()
 # 254 - lock file already exists
 mk_lock()
 {
-	local me="mk_lock"
-	if [ "${1}" != '-f' ]
-	then
-		check_lock
-		case ${?} in
-			1) return 1 ;;
-			2)
-				report_pid_action
-				log_msg -yellow "Refusing to open another instance."
-				return 254
-		esac
-	else
-		shift
-	fi
+	local me=mk_lock
+	check_lock
+	case ${?} in
+		1) return 1 ;;
+		2)
+			report_curr_action -log
+			log_msg -yellow "Refusing to open another instance."
+			return 254
+	esac
 
-	[ -z "${1%.}" ] && { reg_failure "${me}: pid action is unspecified."; return 1; }
 	[ -z "${PID_FILE}" ] && { reg_failure "${me}: \${PID_FILE} variable is unset."; return 1; }
 
 	try_mkdir -p "${ABL_PID_DIR}" || return 1
-	printf '%s\n' "${$} ${1%.}" > "${PID_FILE}" || { reg_failure "${me}: Failed to write to pid file '${PID_FILE}'."; return 1; }
+	printf '%s\n' "${$}" > "${PID_FILE}" || { reg_failure "${me}: Failed to write to pid file '${PID_FILE}'."; return 1; }
 	:
 }
 
@@ -368,14 +360,14 @@ mk_lock()
 # 3 - lock file belongs to current PID
 check_lock()
 {
-	unset LOCK_PID PID_ABL_CMD
+	unset LOCK_PID
 	[ -z "${PID_FILE}" ] && { reg_failure "\${PID_FILE} variable is unset."; return 1; }
 	[ ! -f "${PID_FILE}" ] && return 0
 
 	local read_failed='' read_attempt=0
 	while :
 	do
-		IFS=" " read -r LOCK_PID PID_ABL_CMD < "${PID_FILE}" && break
+		IFS="" read -r LOCK_PID < "${PID_FILE}" && break
 		read_attempt=$((read_attempt+1))
 		[ "${read_attempt}" -le 3 ] || { read_failed=1; break; }
 		sleep 1
@@ -389,7 +381,7 @@ check_lock()
 
 	case "${LOCK_PID}" in
 		"${$}") return 3 ;;
-		*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; return 1 ;;
+		*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; unset LOCK_PID; return 1 ;;
 		*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
 	esac
 
@@ -409,24 +401,40 @@ rm_lock()
 
 # updates the pid file with a new action
 # 1 - new action
-update_pid_action() {
-	check_lock
-	case ${?} in
-		3) ;;
-		1) return 1 ;;
-		2) reg_failure "update_pid_action(): pid file '${PID_FILE}' has unexpected pid '${LOCK_PID}'."; return 1 ;;
-		0) return 0
-	esac
-	mk_lock -f "${1}"
-	return ${?}
+update_action_file() {
+	local me="update_action_file"
+	[ -z "${1%.}" ] && { reg_failure "${me}: action is unspecified."; return 1; }
+
+	{
+		printf '%s\n' "${1%.}" > "${ACTION_FILE}" || reg_failure "${me}: Failed to write to action file '${ACTION_FILE}'."
+	} & # runs asynchronously
+	:
 }
 
-report_pid_action()
+# 1 (optional): '-log' to log current action as well
+report_curr_action()
 {
-	local reported_pid="unknown PID"
-	[ -n "${LOCK_PID}" ] && reported_pid="PID ${LOCK_PID}"
+	[ "${MSGS_DEST}" = "/dev/null" ] && [ "${1}" != "-log" ] && return 0
+	local reported_pid report_cmd=print_msg
+	[ -n "${ACTION_FILE}" ] || { reg_failure "\$ACTION_FILE var is unset."; return 1; }
+	[ -f "${ACTION_FILE}" ] || return 0
+	if [ -z "${LOCK_PID}" ]
+	then
+		check_lock
+		case ${?} in
+			0) return 0 ;;
+			1) return 1 ;;
+			2|3) ;;
+		esac
+	fi
+	reported_pid="${LOCK_PID:-unknown}"
+
+	IFS="" read -r PID_ABL_CMD < "${ACTION_FILE}"
 	: "${PID_ABL_CMD:="unknown action"}"
-	print_msg "adblock-lean (${reported_pid}) is performing action '${PID_ABL_CMD}'."
+
+	[ "${1}" = -log ] && report_cmd=log_msg
+
+	${report_cmd} "adblock-lean (PID: ${reported_pid}) is performing action '${PID_ABL_CMD}'."
 	luci_pid_action=${PID_ABL_CMD}
 	:
 }
@@ -449,7 +457,7 @@ reg_action()
 	[ -z "${nolog}" ] && log_msg "" ${color} "${msg% }"
 	if [ -n "${LOCK_REQ}" ]
 	then
-		update_pid_action "${msg% }" || return 1
+		update_action_file "${msg% }" || return 1
 	fi
 	:
 }
@@ -738,7 +746,8 @@ init_command()
 	# make lock if needed
 	if [ -n "${LOCK_REQ}" ]
 	then
-		mk_lock "${ABL_CMD}" || { local rv=${?}; unset LOCK_REQ CLEANUP_REQ; exit ${rv}; }
+		mk_lock || { local rv=${?}; unset LOCK_REQ CLEANUP_REQ; exit ${rv}; }
+		update_action_file "${ABL_CMD}"
 	fi
 
 	# enable writing session log if we have the lock
@@ -1175,7 +1184,7 @@ status()
 	case ${?} in
 		1) exit 1 ;;
 		2)
-			report_pid_action
+			report_curr_action
 			exit 2
 	esac
 	get_abl_run_state

--- a/adblock-lean
+++ b/adblock-lean
@@ -371,17 +371,27 @@ check_lock()
 	unset LOCK_PID PID_ABL_CMD
 	[ -z "${PID_FILE}" ] && { reg_failure "\${PID_FILE} variable is unset."; return 1; }
 	[ ! -f "${PID_FILE}" ] && return 0
-	if IFS=" " read -r LOCK_PID PID_ABL_CMD < "${PID_FILE}"
-	then
-		case "${LOCK_PID}" in
-			"${$}") return 3 ;;
-			*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; return 1 ;;
-			*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
-		esac
-	else
+
+	local read_failed='' read_attempt=0
+	while :
+	do
+		IFS=" " read -r LOCK_PID PID_ABL_CMD < "${PID_FILE}" && break
+		read_attempt=$((read_attempt+1))
+		[ "${read_attempt}" -le 3 ] || { read_failed=1; break; }
+		sleep 1
+	done
+
+	[ -n "${read_failed}" ] &&
+	{
 		reg_failure "Failed to read the pid file '${PID_FILE}'."
 		return 1
-	fi
+	}
+
+	case "${LOCK_PID}" in
+		"${$}") return 3 ;;
+		*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; return 1 ;;
+		*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
+	esac
 
 	log_msg -warn "Detected stale pid file '${PID_FILE}' for PID ${LOCK_PID}. Removing."
 	rm_lock || return 1

--- a/adblock-lean
+++ b/adblock-lean
@@ -255,7 +255,7 @@ log_msg()
 	do
 		IFS="${DEFAULT_IFS}"
 		case "${m}" in
-			dummy) printf '\n' ;;
+			dummy) printf '\n' > "${MSGS_DEST}" ;;
 			*)
 				print_msg ${color} "${m}"
 				logger -t adblock-lean -p user."${err_l}" "${m}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -678,7 +678,7 @@ init_command()
 		status) libs_req=1 work_dir_req=1 config_req=1 ;;
 		upd_cron_job) libs_req=1 config_req=1 ;;
 		setup|gen_config) libs_req=1 LOCK_REQ=1 ;;
-		boot) libs_req=1 config_req=1 ;;
+		boot) libs_req=1 config_req=1 LOCK_REQ=1 ;;
 		pause) libs_req=1 work_dir_req=1 config_req=1 LOCK_REQ=1 ;;
 		start|resume) libs_req=1 work_dir_req=1 config_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		stop)
@@ -1070,7 +1070,7 @@ gen_stats()
 boot()
 {
 	init_command boot || exit 1
-	log_msg -purple "Sleeping for ${boot_start_delay_s} seconds."
+	reg_action -purple "Sleeping for ${boot_start_delay_s} seconds."
 	sleep "${boot_start_delay_s}"
 	start "$@"
 }

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -135,7 +135,7 @@ do_setup()
 
 		installed_pkgs="$(get_installed_pkgs "${recomm_pkgs_regex}")" || return 1
 
-		echo
+		echo > "${MSGS_DEST}"
 		for util in ${RECOMMENDED_UTILS}
 		do
 			case "${installed_pkgs}" in
@@ -205,7 +205,7 @@ do_setup()
 			then
 				if [ -z "${free_space_B}" ] || [ -z "${utils_size_B}" ] || [ "${free_space_B}" -gt ${utils_size_B} ]
 				then
-					echo
+					echo > "${MSGS_DEST}"
 					$PKG_MANAGER update && $PKG_INSTALL_CMD ${pkgs2install% } && return 0
 					reg_failure "Failed to automatically install packages. You can install them manually later."
 					return 1
@@ -297,7 +297,7 @@ do_setup()
 		print_msg "" "${purple}Setup is complete.${n_c}" "" "Start adblock-lean now?"
 		pick_opt "y|n" || return 1
 		[ "${REPLY}" != y ] && return 0
-		echo
+		echo > "${MSGS_DEST}"
 		start
 	fi
 	:
@@ -980,7 +980,7 @@ report_utils()
 {
 	local util awk_inst_tip='' sed_inst_tip='' sort_inst_tip=''
 
-	printf '\n'
+	printf '\n' > "${MSGS_DEST}"
 
 	for util in ${RECOMMENDED_UTILS}
 	do

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -223,7 +223,7 @@ schedule_jobs()
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${list_urls}" ] && continue
 
-			log_msg -blue "Starting ${list_format} ${list_type} part(s) download."
+			log_msg -blue "" "Starting ${list_format} ${list_type} part(s) download."
 
 			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -223,7 +223,7 @@ schedule_jobs()
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${list_urls}" ] && continue
 
-			reg_action -blue "Starting ${list_format} ${list_type} part(s) download." || finalize_scheduler 1
+			log_msg -blue "Starting ${list_format} ${list_type} part(s) download." || finalize_scheduler 1
 
 			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"
@@ -491,7 +491,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		reg_action -blue "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
+		log_msg -blue "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -522,7 +522,7 @@ gen_list_parts()
 		use_allowlist=1
 	fi
 
-	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${MAX_PARALLEL_JOBS})."
+	reg_action -blue "Downloading and processing blocklist parts (max parallel jobs: ${MAX_PARALLEL_JOBS})."
 	print_msg ""
 
 	set +m # disable job complete notification

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -491,7 +491,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		log_msg -blue "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
+		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -223,7 +223,7 @@ schedule_jobs()
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${list_urls}" ] && continue
 
-			log_msg -blue "Starting ${list_format} ${list_type} part(s) download." || finalize_scheduler 1
+			log_msg -blue "Starting ${list_format} ${list_type} part(s) download."
 
 			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"
@@ -491,7 +491,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
+		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -31,7 +31,7 @@ try_gunzip()
 # output via optional variable with name $3
 # returns status 0 if the result is null, 1 if not
 subtract_a_from_b() {
-	sab_out="${3:-___dummy}"
+	local sab_out="${3:-___dummy}"
 	case "${2}" in '') unset "${sab_out}"; return 0; esac
 	case "${1}" in '') eval "${sab_out}"='${2}'; [ ! "${2}" ]; return; esac
 	local _fs_su="${4:-"${_NL_}"}"


### PR DESCRIPTION
- remove diagnostic messages
- make multiple attempts when resolving domains
- set correct stop priority (this time actually correct)
- abl_process: improve error handling
- init_command: require lock for action 'boot' (fixes `service adblock lean status` not reporting that adblock-lean is sleeping after boot)
- log_msg(): output empty lines to $MSGS_DEST (fixes empty log entries spam)
- check_lock(): retry reading the PID file if read fails
- abl-process: avoid calling reg_action() for frequent messages (reduces filesystem I/O)
- only use the PID file to store pid. Use a separate file to store current action.
- Write current action to the action file asynchronously in order to not block code execution until write is complete
- log_msg(): fix interleaved messages written to the log file
- write to the log file asynchronously in order to not block code execution until write is complete
- cosmetic improvements to console messages
