### PR TITLE
Simpler concurrency

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -139,7 +139,7 @@ add2list() {
 	:
 }
 
-# reads first line from file
+# reads first line from file into variables
 # Args:
 # -v <out_var_name>
 # -f <file_path>
@@ -151,15 +151,15 @@ add2list() {
 # Optional: '-V <"[default_val]">'
 read_str_from_file()
 {
-	local me=read_str_from_file rs_del_file='' rs_quiet='' rs_num_bytes='' rs_outvar='' rs_file='' \
-		rs_file_desc='' rs_file_desc_pr='' rs_def_val='' rs_read_failed='' rs_attempts=1 rs_attempt
+	local me=read_str_from_file rs_del_file='' rs_quiet='' rs_num_bytes='' rs_outvars='' rs_file='' \
+		rs_file_desc='' rs_file_desc_pr='' rs_def_val='' rs_read_failed='' rs_attempts=1 rs_attempt rs_var
 	while getopts ":dqn:v:f:a:D:V:" opt
 	do
 		case "${opt}" in
 			d) rs_del_file=1 ;;
 			q) rs_quiet=1 ;;
 			n) rs_num_bytes=-n${OPTARG} ;;
-			v) rs_outvar=${OPTARG} ;;
+			v) rs_outvars=${OPTARG} ;;
 			f) rs_file=${OPTARG} ;;
 			a) rs_attempts=${OPTARG} ;;
 			D) rs_file_desc=${OPTARG} ;;
@@ -168,12 +168,19 @@ read_str_from_file()
 		esac
 	done
 
-	[ -n "${rs_outvar}" ] && [ -n "${rs_file}" ] || { reg_failure "${me}: missing args"; return 1; }
+	[ -n "${rs_outvars}" ] && [ -n "${rs_file}" ] || { reg_failure "${me}: missing args"; return 1; }
 
 	rs_attempt=0
 	while :
 	do
-		[ -f "${rs_file}" ] && IFS="" read -r ${rs_num_bytes?} "${rs_outvar?}" < "${rs_file}" && eval "[ -n \"\${${rs_outvar}}\" ]" && break
+		[ -f "${rs_file}" ] && read -r ${rs_num_bytes?} ${rs_outvars?} < "${rs_file}" &&
+		{
+			for rs_var in ${rs_outvars}
+			do
+				case "${rs_var}" in _) continue; esac
+				eval "[ -n \"\${${rs_var}}\" ]" && break 2
+			done
+		}
 		rs_attempt=$((rs_attempt+1))
 		[ "${rs_attempt}" -le "${rs_attempts}" ] || { rs_read_failed=1; break; }
 		sleep 1
@@ -184,7 +191,14 @@ read_str_from_file()
 
 	[ -n "${rs_file_desc}" ] && rs_file_desc_pr="${rs_file_desc} "
 	[ -n "${rs_quiet}" ] || reg_failure "Failed to read ${rs_file_desc_pr}file '${rs_file}'."
-	eval "${rs_outvar}=\"${rs_def_val}\""
+	[ -n "${rs_def_val}" ] &&
+	{
+		for rs_var in ${rs_outvars}
+		do
+			case "${rs_var}" in _) continue; esac
+			eval "${rs_var}=\"${rs_def_val}\""
+		done
+	}
 	return 1
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -437,7 +437,8 @@ rm_lock()
 
 # updates the pid file with a new action
 # 1 - new action
-update_action_file() {
+update_action_file()
+{
 	local me="update_action_file"
 	[ -z "${1%.}" ] && { reg_failure "${me}: action is unspecified."; return 1; }
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -1107,7 +1107,7 @@ get_active_entries_cnt()
 	fi |
 	$SED_CMD -E "s~^(${list_prefixes%|})\=/~~;" | tr "/${allow_opt}" '\n' | wc -w > "/tmp/abl_entries_cnt"
 
-	read_str_from_file -d cnt "/tmp/abl_entries_cnt" 2 "entries count"
+	read_str_from_file -d -v cnt -f "/tmp/abl_entries_cnt" -a 2 -D "entries count"
 	case "${cnt}" in *[!0-9]*|'') printf 0; return 1; esac
 	local d i=0 IFS="${DEFAULT_IFS}"
 	if [ "${whitelist_mode}" = 1 ]


### PR DESCRIPTION
This fixes a bug introduced in the previous PR and implements the idea of using one `wc` call to count both lines and bytes
- abl-process: fix call to read_str_from_file
- read_str_from_file(): support multiple vars
- fix 'status' command entries count being off
- process_list_part: use one wc call
