### PR TITLE
Simpler concurrency

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -83,7 +83,8 @@ adblock-lean custom commands:
 	uninstall                uninstall adblock-lean, remove all adblock-lean-related files and settings"
 
 # silence shellcheck warnings
-: "${action:=}" "${action_rv}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}" "${purple}" "${green}" "${TAB}" "${CR_LF}"
+: "${action:=}" "${action_rv}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}"
+: "${purple}" "${green}" "${TAB}" "${CR}" "${CR_LF}"
 : "${AWK_CMD}" "${SORT_CMD}"
 : "${luci_log}" "${luci_pid_action}" "${luci_errors}" "${luci_dnsmasq_status}"
 : "${luci_good_line_count}" "${luci_update_status}" "${luci_pkgs_install_failed}" "${luci_cron_job_creation_failed}"
@@ -102,7 +103,7 @@ set_ansi()
 	local IFS=" "
 	# shellcheck disable=SC2046
 	set -- $(printf '\033[0;31m \033[0;32m \033[1;34m \033[1;33m \033[0;35m \033[0m \35 \t \r')
-	red="${1}" green="${2}" blue="${3}" yellow="${4}" purple="${5}" n_c="${6}" _DELIM_="${7}" TAB="${8}" CR_LF="${9}${_NL_}"
+	red="${1}" green="${2}" blue="${3}" yellow="${4}" purple="${5}" n_c="${6}" _DELIM_="${7}" TAB="${8}" CR="${9}" CR_LF="${9}${_NL_}"
 }
 
 # checks if string $1 is included in newline-separated list $2


### PR DESCRIPTION
- parse config in awk
- replace option `initial_dnsmasq_restart` with `unload_blocklist_before_update`
- allow setting `unload_blocklist_before_update` and `MAX_PARALLEL_JOBS` to `auto`, default to `auto`
- when `unload_blocklist_before_update` is set to `auto`, enable if system memory is less than 512MiB, disable if higher
- when `MAX_PARALLEL_JOBS` is set to `auto`, set `PARALLEL_JOBS` to the count of detected CPU cores, with fallback to 1
