### PR TITLE
Simpler concurrency

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -608,11 +608,13 @@ kill_pids_recursive()
 
 # return codes:
 # 0 - running
-# 1,2 - (reserved)
+# 1 - error
+# 2 - (reserved)
 # 3 - paused
 # 4 - stopped
 get_abl_run_state()
 {
+	[ -n "${DNSMASQ_CONF_D}" ] || { reg_failure "\$DNSMASQ_CONF_D is not set"; return 1; }
 	local f
 	for f in "${DNSMASQ_CONF_D}/.abl-blocklist.gz" "${DNSMASQ_CONF_D}/abl-blocklist"
 	do
@@ -1241,6 +1243,7 @@ status()
 	log_msg -purple "" "adblock-lean (${version}) status:"
 	case ${run_state} in
 		0) ;;
+		1) reg_failure "Failed to check adblock-lean run state." ;;
 		3) log_msg -yellow "" "adblock-lean is paused." ;;
 		4) log_msg -yellow "" "adblock-lean is stopped."
 	esac
@@ -1263,7 +1266,7 @@ status()
 			luci_good_line_count=${active_entries_cnt}
 			int2human active_entries_cnt_human "${active_entries_cnt}"
 			log_msg "The dnsmasq check passed and the presently installed blocklist has entries count: ${active_entries_cnt_human}."
-			log_msg -green "adblock-lean is active."
+			log_msg -green "" "adblock-lean is active."
 			gen_stats -noexit
 		else
 			reg_failure "The dnsmasq check failed with existing blocklist file."
@@ -1300,6 +1303,7 @@ resume()
 	get_abl_run_state
 	case ${?} in
 		0) log_msg -err "adblock-lean is already running."; exit 1 ;;
+		1) exit 1 ;;
 		3) ;;
 		4) log_msg -err "adblock-lean is currently stopped, not paused. Can not resume."; exit 1;
 	esac

--- a/adblock-lean
+++ b/adblock-lean
@@ -1161,7 +1161,7 @@ start()
 	try_export_existing_blocklist
 	[ ${?} = 1 ] && exit 1
 
-	if ! generate_and_process_blocklist_file
+	if ! gen_and_process_blocklist
 	then
 		reg_failure "Failed to generate new blocklist."
 		restore_saved_blocklist || stop 1

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -704,21 +704,21 @@ parse_config()
 
 		{
 			# handle double or missing =
-			if ($0 !~ /^[^=]+=[^=]+$/) {
+			if ( $0 !~ /^[^=]+=[^=]+([ \t]+(#.*){0,1})*$/ ) {
 				print $0 > A"/bad_entry"
 				rv=254
 				exit
 			}
 
 			# key must be non-empty and alphanumeric
-			if ($1 !~ /^[a-zA-Z0-9_]+$/) {
+			if ( $1 !~ /^[a-zA-Z0-9_]+$/ ) {
 				print $0 > A"/bad_entry"
 				rv=254
 				exit
 			}
 
 			# line must have exactly 2 double-quotes after = and no characters before #
-			if ($0 !~ /^[^"]+="[^"]*"([ \t](#.*))*$/) {
+			if ( $0 !~ /^[^"]+="[^"]*"([ \t]+(#[^"]*){0,1}){0,1}$/ ) {
 				print $0 > A"/bad_entry"
 				rv=253
 				exit

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -607,7 +607,7 @@ gen_list_parts()
 	:
 }
 
-generate_and_process_blocklist_file()
+gen_and_process_blocklist()
 {
 	convert_entries()
 	{

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -701,6 +701,12 @@ generate_and_process_blocklist_file()
 		esac
 	fi
 
+	get_abl_run_state
+	case ${?} in
+		1) unload_blocklist_before_update=1 ;;
+		4) unload_blocklist_before_update=0 ;;
+	esac
+
 	if [ "${unload_blocklist_before_update}" = auto ]
 	then
 		local totalmem

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -515,9 +515,9 @@ gen_list_parts()
 					PARALLEL_JOBS=1 ;;
 				*)
 					# cap PARALLEL_JOBS to 4 in 'auto' mode
-					if [ ${cpu_cnt} -ge 4 ]
+					if [ "${cpu_cnt}" -ge 4 ]
 					then
-						PARALLEL_JOBS=${cpu_cnt}
+						PARALLEL_JOBS=4
 					else
 						PARALLEL_JOBS=${cpu_cnt}
 					fi


### PR DESCRIPTION
- parse_config(): improve validation regexes to account for edge cases
- handle errors when detecting the current run state fails
- abl_process: skip dnsmasq restart if adblock-lean run state is stopped
- shorten function name from `generate_and_process_blocklist_file()` to `gen_and_process_blocklist()`
- abl-process: cap parallel jobs to 4 when `MAX_PARALLEL_JOBS` is set to `auto`