### PR TITLE
Parallel processing and other improvements

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -279,6 +279,7 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
+		[ -n "${WATCHDOG_PID}" ] && kill -9 "${WATCHDOG_PID}" 2>/dev/null
 		[ -n "${SCHEDULER_PID}" ] && [ ! -f "${SCHEDULE_DIR}/scheduler_done_${SCHEDULER_PID}" ] &&
 		{
 			log_msg -warn "Killing unfinished processing jobs."

--- a/adblock-lean
+++ b/adblock-lean
@@ -608,11 +608,13 @@ kill_pids_recursive()
 
 # return codes:
 # 0 - running
-# 1,2 - (reserved)
+# 1 - error
+# 2 - (reserved)
 # 3 - paused
 # 4 - stopped
 get_abl_run_state()
 {
+	[ -n "${DNSMASQ_CONF_D}" ] || { reg_failure "\$DNSMASQ_CONF_D is not set"; return 1; }
 	local f
 	for f in "${DNSMASQ_CONF_D}/.abl-blocklist.gz" "${DNSMASQ_CONF_D}/abl-blocklist"
 	do
@@ -1241,6 +1243,7 @@ status()
 	log_msg -purple "" "adblock-lean (${version}) status:"
 	case ${run_state} in
 		0) ;;
+		1) reg_failure "Failed to check adblock-lean run state." ;;
 		3) log_msg -yellow "" "adblock-lean is paused." ;;
 		4) log_msg -yellow "" "adblock-lean is stopped."
 	esac
@@ -1263,7 +1266,7 @@ status()
 			luci_good_line_count=${active_entries_cnt}
 			int2human active_entries_cnt_human "${active_entries_cnt}"
 			log_msg "The dnsmasq check passed and the presently installed blocklist has entries count: ${active_entries_cnt_human}."
-			log_msg -green "adblock-lean is active."
+			log_msg -green "" "adblock-lean is active."
 			gen_stats -noexit
 		else
 			reg_failure "The dnsmasq check failed with existing blocklist file."
@@ -1300,6 +1303,7 @@ resume()
 	get_abl_run_state
 	case ${?} in
 		0) log_msg -err "adblock-lean is already running."; exit 1 ;;
+		1) exit 1 ;;
 		3) ;;
 		4) log_msg -err "adblock-lean is currently stopped, not paused. Can not resume."; exit 1;
 	esac

--- a/adblock-lean
+++ b/adblock-lean
@@ -442,6 +442,7 @@ update_action_file() {
 	[ -z "${1%.}" ] && { reg_failure "${me}: action is unspecified."; return 1; }
 
 	{
+		try_mkdir -p "${ABL_PID_DIR}" &&
 		printf '%s\n' "${1%.}" > "${ACTION_FILE}" || reg_failure "${me}: Failed to write to action file '${ACTION_FILE}'."
 	} & # runs asynchronously
 	:

--- a/adblock-lean
+++ b/adblock-lean
@@ -139,6 +139,55 @@ add2list() {
 	:
 }
 
+# reads first line from file
+# Args:
+# -v <out_var_name>
+# -f <file_path>
+# Optional: '-a <attempts_num>'
+# Optional: '-d' to delete the file after reading
+# Optional: '-q' to quiet error message
+# Optional: '-n X' to limit number of bytes read
+# Optional: '-D <"[file_desc]">'
+# Optional: '-V <"[default_val]">'
+read_str_from_file()
+{
+	local me=read_str_from_file rs_del_file='' rs_quiet='' rs_num_bytes='' rs_outvar='' rs_file='' \
+		rs_file_desc='' rs_file_desc_pr='' rs_def_val='' rs_read_failed='' rs_attempts=1 rs_attempt
+	while getopts ":dqn:v:f:a:D:V:" opt
+	do
+		case "${opt}" in
+			d) rs_del_file=1 ;;
+			q) rs_quiet=1 ;;
+			n) rs_num_bytes=-n${OPTARG} ;;
+			v) rs_outvar=${OPTARG} ;;
+			f) rs_file=${OPTARG} ;;
+			a) rs_attempts=${OPTARG} ;;
+			D) rs_file_desc=${OPTARG} ;;
+			V) rs_def_val=${OPTARG} ;;
+			*) reg_failure "${me}: unexpected option '${opt}'."; return 1;
+		esac
+	done
+
+	[ -n "${rs_outvar}" ] && [ -n "${rs_file}" ] || { reg_failure "${me}: missing args"; return 1; }
+
+	rs_attempt=0
+	while :
+	do
+		[ -f "${rs_file}" ] && IFS="" read -r ${rs_num_bytes?} "${rs_outvar?}" < "${rs_file}" && eval "[ -n \"\${${rs_outvar}}\" ]" && break
+		rs_attempt=$((rs_attempt+1))
+		[ "${rs_attempt}" -le "${rs_attempts}" ] || { rs_read_failed=1; break; }
+		sleep 1
+	done
+
+	[ -n "${rs_del_file}" ] && rm -f "${rs_file}"
+	[ -z "${rs_read_failed}" ] && return 0
+
+	[ -n "${rs_file_desc}" ] && rs_file_desc_pr="${rs_file_desc} "
+	[ -n "${rs_quiet}" ] || reg_failure "Failed to read ${rs_file_desc_pr}file '${rs_file}'."
+	eval "${rs_outvar}=\"${rs_def_val}\""
+	return 1
+}
+
 get_md5()
 {
 	md5sum "${1}" | cut -d' ' -f1
@@ -364,20 +413,7 @@ check_lock()
 	[ -z "${PID_FILE}" ] && { reg_failure "\${PID_FILE} variable is unset."; return 1; }
 	[ ! -f "${PID_FILE}" ] && return 0
 
-	local read_failed='' read_attempt=0
-	while :
-	do
-		IFS="" read -r LOCK_PID < "${PID_FILE}" && break
-		read_attempt=$((read_attempt+1))
-		[ "${read_attempt}" -le 3 ] || { read_failed=1; break; }
-		sleep 1
-	done
-
-	[ -n "${read_failed}" ] &&
-	{
-		reg_failure "Failed to read the pid file '${PID_FILE}'."
-		return 1
-	}
+	read_str_from_file -v LOCK_PID -f "${PID_FILE}" -a 3 -D PID || return 1
 
 	case "${LOCK_PID}" in
 		"${$}") return 3 ;;
@@ -429,8 +465,7 @@ report_curr_action()
 	fi
 	reported_pid="${LOCK_PID:-unknown}"
 
-	IFS="" read -r PID_ABL_CMD < "${ACTION_FILE}"
-	: "${PID_ABL_CMD:="unknown action"}"
+	read_str_from_file -v PID_ABL_CMD -f "${ACTION_FILE}" -a 2 -D action -V "unknown action"
 
 	[ "${1}" = -log ] && report_cmd=log_msg
 
@@ -936,11 +971,7 @@ install_abl_files()
 	local dist_dir="${1}" version="${2}"
 
 	# read new files list
-	read -r new_files < "${dist_dir}/inst_files" ||
-	{
-		reg_failure "Failed to read file '${dist_dir}/inst_files'."
-		return 1
-	}
+	read_str_from_file -d -v new_files -f "${dist_dir}/inst_files" -a 2 || return 1
 
 	# compile current files list
 	curr_files="${ABL_SERVICE_PATH}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -139,7 +139,7 @@ add2list() {
 	:
 }
 
-# reads first line from file
+# reads first line from file into variables
 # Args:
 # -v <out_var_name>
 # -f <file_path>
@@ -151,15 +151,15 @@ add2list() {
 # Optional: '-V <"[default_val]">'
 read_str_from_file()
 {
-	local me=read_str_from_file rs_del_file='' rs_quiet='' rs_num_bytes='' rs_outvar='' rs_file='' \
-		rs_file_desc='' rs_file_desc_pr='' rs_def_val='' rs_read_failed='' rs_attempts=1 rs_attempt
+	local me=read_str_from_file rs_del_file='' rs_quiet='' rs_num_bytes='' rs_outvars='' rs_file='' \
+		rs_file_desc='' rs_file_desc_pr='' rs_def_val='' rs_read_failed='' rs_attempts=1 rs_attempt rs_var
 	while getopts ":dqn:v:f:a:D:V:" opt
 	do
 		case "${opt}" in
 			d) rs_del_file=1 ;;
 			q) rs_quiet=1 ;;
 			n) rs_num_bytes=-n${OPTARG} ;;
-			v) rs_outvar=${OPTARG} ;;
+			v) rs_outvars=${OPTARG} ;;
 			f) rs_file=${OPTARG} ;;
 			a) rs_attempts=${OPTARG} ;;
 			D) rs_file_desc=${OPTARG} ;;
@@ -168,12 +168,19 @@ read_str_from_file()
 		esac
 	done
 
-	[ -n "${rs_outvar}" ] && [ -n "${rs_file}" ] || { reg_failure "${me}: missing args"; return 1; }
+	[ -n "${rs_outvars}" ] && [ -n "${rs_file}" ] || { reg_failure "${me}: missing args"; return 1; }
 
 	rs_attempt=0
 	while :
 	do
-		[ -f "${rs_file}" ] && IFS="" read -r ${rs_num_bytes?} "${rs_outvar?}" < "${rs_file}" && eval "[ -n \"\${${rs_outvar}}\" ]" && break
+		[ -f "${rs_file}" ] && read -r ${rs_num_bytes?} ${rs_outvars?} < "${rs_file}" &&
+		{
+			for rs_var in ${rs_outvars}
+			do
+				case "${rs_var}" in _) continue; esac
+				eval "[ -n \"\${${rs_var}}\" ]" && break 2
+			done
+		}
 		rs_attempt=$((rs_attempt+1))
 		[ "${rs_attempt}" -le "${rs_attempts}" ] || { rs_read_failed=1; break; }
 		sleep 1
@@ -184,7 +191,14 @@ read_str_from_file()
 
 	[ -n "${rs_file_desc}" ] && rs_file_desc_pr="${rs_file_desc} "
 	[ -n "${rs_quiet}" ] || reg_failure "Failed to read ${rs_file_desc_pr}file '${rs_file}'."
-	eval "${rs_outvar}=\"${rs_def_val}\""
+	[ -n "${rs_def_val}" ] &&
+	{
+		for rs_var in ${rs_outvars}
+		do
+			case "${rs_var}" in _) continue; esac
+			eval "${rs_var}=\"${rs_def_val}\""
+		done
+	}
 	return 1
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -417,6 +417,7 @@ mk_lock()
 	:
 }
 
+# assigns lock pid to $LOCK_PID
 # return codes:
 # 0 - no lock
 # 1 - error
@@ -447,6 +448,7 @@ rm_lock()
 	then
 		rm -f "${PID_FILE}" || { reg_failure "Failed to delete the pid file '${PID_FILE}'."; return 1; }
 	fi
+	LOCK_PID=
 	:
 }
 
@@ -535,6 +537,7 @@ kill_abl_pids()
 {
 	local pgrep_ptrn="((/etc/rc.common|sh|/bin/sh) /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
 	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
+	:
 }
 
 # kills specified pid's and their offspring
@@ -722,11 +725,10 @@ rm_cron_job()
 
 
 ### Commands init
-
 init_command()
 {
 	ABL_CMD="${1}"
-	local config_req='' work_dir_req='' kill_req='' init_action_msg=''
+	local config_req='' work_dir_req='' init_action_msg=''
 
 	# detect if sourced from external RPC script for luci, depends on abl_luci_exit() being defined
 	luci_sourced=
@@ -756,7 +758,15 @@ init_command()
 		stop)
 			init_action_msg="Stopping adblock-lean."
 			reg_action -purple "${init_action_msg}" || exit 1
-			libs_req=1 kill_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
+
+			source_libs || exit 1
+			kill_abl_pids
+			check_lock
+			case ${?} in
+				1) exit 1 ;;
+				2) reg_failure "Failed to kill running adblock-lean processes."; exit 1
+			esac
+			CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		select_dnsmasq_instance)
 			libs_req=1 LOCK_REQ=1
 			[ "${action}" = select_dnsmasq_instance ] && config_req=1 # require config when called directly
@@ -777,20 +787,6 @@ init_command()
 	then
 		detect_pkg_manager
 		report_utils
-	fi
-
-	# kill pids if needed
-	if [ -n "${kill_req}" ]
-	then
-		kill_abl_pids
-		check_lock
-		case ${?} in
-			1) exit 1 ;;
-			2)
-				reg_failure "Failed to kill running adblock-lean processes."
-				unset LOCK_REQ CLEANUP_REQ
-				exit 1
-		esac
 	fi
 
 	# register lock status at init
@@ -1528,7 +1524,6 @@ disable()
 	fi
 	return "$rv"
 }
-
 
 set_ansi
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -280,7 +280,6 @@ cleanup_and_exit()
 	if [ -n "${CLEANUP_REQ}" ]
 	then
 		[ "${1}" != 0 ] && print_msg "" "Cleaning up..."
-		[ -n "${WATCHDOG_PID}" ] && kill -9 "${WATCHDOG_PID}" 2>/dev/null
 		[ -n "${SCHEDULER_PID}" ] && [ -d "/proc/${SCHEDULER_PID}" ] && kill -s USR1 "${SCHEDULER_PID}"
 		rm -rf "${ABL_DIR}"
 	fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -280,7 +280,7 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
-		[ -n "${SCHEDULER_PID}" ] &&
+		[ -n "${SCHEDULER_PID}" ] && [ ! -f "${SCHEDULE_DIR}/scheduler_done_${SCHEDULER_PID}" ] &&
 		{
 			log_msg -warn "Killing unfinished processing jobs."
 			kill_pids_recursive "${SCHEDULER_PID}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -853,7 +853,7 @@ update_version()
 abl_post_update_1()
 {
 	# fix incorrect rc.d symlink from older versions
-	[ -f /etc/rc.d/K4adblock-lean ] && mv /etc/rc.d/K4adblock-lean /etc/rc.d/K${START}adblock-lean
+	[ -f /etc/rc.d/K4adblock-lean ] || [ -f /etc/rc.d/k99adblock-lean ] && mv /etc/rc.d/K*adblock-lean /etc/rc.d/K${STOP}adblock-lean
 
 	# @temp_workaround - remove a few months from now
 	# when upgrading from older versions, fetch and install latest release

--- a/adblock-lean
+++ b/adblock-lean
@@ -270,7 +270,7 @@ log_msg()
 # 2 - err level
 write_log_file()
 {
-	[ -n "${LOG_FILE}" ] && { printf '['; date +'%b %d %Y, %H:%M:%S' | tr -d '\n'; printf '] %s\n' "${2:-info}: ${1}"; } >> "${LOG_FILE}"
+	[ -n "${LOG_FILE}" ] && date +"[%b %d %Y, %H:%M:%S] ${2:-info}: ${1}" >> "${LOG_FILE}"
 }
 
 # exit with code ${1}

--- a/adblock-lean
+++ b/adblock-lean
@@ -83,7 +83,8 @@ adblock-lean custom commands:
 	uninstall                uninstall adblock-lean, remove all adblock-lean-related files and settings"
 
 # silence shellcheck warnings
-: "${action:=}" "${action_rv}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}" "${purple}" "${green}" "${TAB}" "${CR_LF}"
+: "${action:=}" "${action_rv}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}"
+: "${purple}" "${green}" "${TAB}" "${CR}" "${CR_LF}"
 : "${AWK_CMD}" "${SORT_CMD}"
 : "${luci_log}" "${luci_pid_action}" "${luci_errors}" "${luci_dnsmasq_status}"
 : "${luci_good_line_count}" "${luci_update_status}" "${luci_pkgs_install_failed}" "${luci_cron_job_creation_failed}"
@@ -102,7 +103,7 @@ set_ansi()
 	local IFS=" "
 	# shellcheck disable=SC2046
 	set -- $(printf '\033[0;31m \033[0;32m \033[1;34m \033[1;33m \033[0;35m \033[0m \35 \t \r')
-	red="${1}" green="${2}" blue="${3}" yellow="${4}" purple="${5}" n_c="${6}" _DELIM_="${7}" TAB="${8}" CR_LF="${9}${_NL_}"
+	red="${1}" green="${2}" blue="${3}" yellow="${4}" purple="${5}" n_c="${6}" _DELIM_="${7}" TAB="${8}" CR="${9}" CR_LF="${9}${_NL_}"
 }
 
 # checks if string $1 is included in newline-separated list $2

--- a/adblock-lean
+++ b/adblock-lean
@@ -536,7 +536,7 @@ log_success()
 kill_abl_pids()
 {
 	local pgrep_ptrn="((/etc/rc.common|sh|/bin/sh) /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
-	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
+	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | grep -v "[ \t]stop$" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
 	:
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -270,7 +270,7 @@ log_msg()
 # 2 - err level
 write_log_file()
 {
-	[ -n "${LOG_FILE}" ] && date +"[%b %d %Y, %H:%M:%S] ${2:-info}: ${1}" >> "${LOG_FILE}"
+	[ -n "${LOG_FILE}" ] && date +"[%b %d %Y, %H:%M:%S] ${2:-info}: ${1}" >> "${LOG_FILE}" &
 }
 
 # exit with code ${1}

--- a/adblock-lean
+++ b/adblock-lean
@@ -1161,7 +1161,7 @@ start()
 	try_export_existing_blocklist
 	[ ${?} = 1 ] && exit 1
 
-	if ! generate_and_process_blocklist_file
+	if ! gen_and_process_blocklist
 	then
 		reg_failure "Failed to generate new blocklist."
 		restore_saved_blocklist || stop 1

--- a/adblock-lean
+++ b/adblock-lean
@@ -255,7 +255,7 @@ log_msg()
 	do
 		IFS="${DEFAULT_IFS}"
 		case "${m}" in
-			dummy) echo ;;
+			dummy) printf '\n' ;;
 			*)
 				print_msg ${color} "${m}"
 				logger -t adblock-lean -p user."${err_l}" "${m}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -51,6 +51,7 @@ ABL_CONFIG_FILE=${ABL_CONFIG_DIR}/config
 CONFIG_FORMAT=v7
 
 PID_FILE="${ABL_PID_DIR}/adblock-lean.pid"
+ACTION_FILE="${ABL_PID_DIR}/adblock-lean.action"
 
 ABL_UPDATE_LOG_FILE=/var/log/abl_update.log
 ABL_SESSION_LOG_FILE=/var/log/abl_session.log
@@ -159,7 +160,7 @@ try_mkdir()
 # output via $REPLY
 pick_opt()
 {
-	update_pid_action "Waiting for user input in console" || return 1
+	update_action_file "Waiting for user input in console" || return 1
 	while :
 	do
 		printf %s "$1: " 1>${MSGS_DEST}
@@ -328,9 +329,6 @@ restart_dnsmasq()
 	:
 }
 
-# args:
-# 1 - (optional) -f to skip check for existing lock
-# 1/2 - action to write to the pid file
 #
 # return codes:
 # 0 - success
@@ -338,26 +336,20 @@ restart_dnsmasq()
 # 254 - lock file already exists
 mk_lock()
 {
-	local me="mk_lock"
-	if [ "${1}" != '-f' ]
-	then
-		check_lock
-		case ${?} in
-			1) return 1 ;;
-			2)
-				report_pid_action
-				log_msg -yellow "Refusing to open another instance."
-				return 254
-		esac
-	else
-		shift
-	fi
+	local me=mk_lock
+	check_lock
+	case ${?} in
+		1) return 1 ;;
+		2)
+			report_curr_action -log
+			log_msg -yellow "Refusing to open another instance."
+			return 254
+	esac
 
-	[ -z "${1%.}" ] && { reg_failure "${me}: pid action is unspecified."; return 1; }
 	[ -z "${PID_FILE}" ] && { reg_failure "${me}: \${PID_FILE} variable is unset."; return 1; }
 
 	try_mkdir -p "${ABL_PID_DIR}" || return 1
-	printf '%s\n' "${$} ${1%.}" > "${PID_FILE}" || { reg_failure "${me}: Failed to write to pid file '${PID_FILE}'."; return 1; }
+	printf '%s\n' "${$}" > "${PID_FILE}" || { reg_failure "${me}: Failed to write to pid file '${PID_FILE}'."; return 1; }
 	:
 }
 
@@ -368,14 +360,14 @@ mk_lock()
 # 3 - lock file belongs to current PID
 check_lock()
 {
-	unset LOCK_PID PID_ABL_CMD
+	unset LOCK_PID
 	[ -z "${PID_FILE}" ] && { reg_failure "\${PID_FILE} variable is unset."; return 1; }
 	[ ! -f "${PID_FILE}" ] && return 0
 
 	local read_failed='' read_attempt=0
 	while :
 	do
-		IFS=" " read -r LOCK_PID PID_ABL_CMD < "${PID_FILE}" && break
+		IFS="" read -r LOCK_PID < "${PID_FILE}" && break
 		read_attempt=$((read_attempt+1))
 		[ "${read_attempt}" -le 3 ] || { read_failed=1; break; }
 		sleep 1
@@ -389,7 +381,7 @@ check_lock()
 
 	case "${LOCK_PID}" in
 		"${$}") return 3 ;;
-		*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; return 1 ;;
+		*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; unset LOCK_PID; return 1 ;;
 		*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
 	esac
 
@@ -409,24 +401,40 @@ rm_lock()
 
 # updates the pid file with a new action
 # 1 - new action
-update_pid_action() {
-	check_lock
-	case ${?} in
-		3) ;;
-		1) return 1 ;;
-		2) reg_failure "update_pid_action(): pid file '${PID_FILE}' has unexpected pid '${LOCK_PID}'."; return 1 ;;
-		0) return 0
-	esac
-	mk_lock -f "${1}"
-	return ${?}
+update_action_file() {
+	local me="update_action_file"
+	[ -z "${1%.}" ] && { reg_failure "${me}: action is unspecified."; return 1; }
+
+	{
+		printf '%s\n' "${1%.}" > "${ACTION_FILE}" || reg_failure "${me}: Failed to write to action file '${ACTION_FILE}'."
+	} & # runs asynchronously
+	:
 }
 
-report_pid_action()
+# 1 (optional): '-log' to log current action as well
+report_curr_action()
 {
-	local reported_pid="unknown PID"
-	[ -n "${LOCK_PID}" ] && reported_pid="PID ${LOCK_PID}"
+	[ "${MSGS_DEST}" = "/dev/null" ] && [ "${1}" != "-log" ] && return 0
+	local reported_pid report_cmd=print_msg
+	[ -n "${ACTION_FILE}" ] || { reg_failure "\$ACTION_FILE var is unset."; return 1; }
+	[ -f "${ACTION_FILE}" ] || return 0
+	if [ -z "${LOCK_PID}" ]
+	then
+		check_lock
+		case ${?} in
+			0) return 0 ;;
+			1) return 1 ;;
+			2|3) ;;
+		esac
+	fi
+	reported_pid="${LOCK_PID:-unknown}"
+
+	IFS="" read -r PID_ABL_CMD < "${ACTION_FILE}"
 	: "${PID_ABL_CMD:="unknown action"}"
-	print_msg "adblock-lean (${reported_pid}) is performing action '${PID_ABL_CMD}'."
+
+	[ "${1}" = -log ] && report_cmd=log_msg
+
+	${report_cmd} "adblock-lean (PID: ${reported_pid}) is performing action '${PID_ABL_CMD}'."
 	luci_pid_action=${PID_ABL_CMD}
 	:
 }
@@ -449,7 +457,7 @@ reg_action()
 	[ -z "${nolog}" ] && log_msg "" ${color} "${msg% }"
 	if [ -n "${LOCK_REQ}" ]
 	then
-		update_pid_action "${msg% }" || return 1
+		update_action_file "${msg% }" || return 1
 	fi
 	:
 }
@@ -738,7 +746,8 @@ init_command()
 	# make lock if needed
 	if [ -n "${LOCK_REQ}" ]
 	then
-		mk_lock "${ABL_CMD}" || { local rv=${?}; unset LOCK_REQ CLEANUP_REQ; exit ${rv}; }
+		mk_lock || { local rv=${?}; unset LOCK_REQ CLEANUP_REQ; exit ${rv}; }
+		update_action_file "${ABL_CMD}"
 	fi
 
 	# enable writing session log if we have the lock
@@ -1175,7 +1184,7 @@ status()
 	case ${?} in
 		1) exit 1 ;;
 		2)
-			report_pid_action
+			report_curr_action
 			exit 2
 	esac
 	get_abl_run_state

--- a/adblock-lean
+++ b/adblock-lean
@@ -279,12 +279,9 @@ cleanup_and_exit()
 	trap - INT TERM EXIT
 	if [ -n "${CLEANUP_REQ}" ]
 	then
+		[ "${1}" != 0 ] && print_msg "" "Cleaning up..."
 		[ -n "${WATCHDOG_PID}" ] && kill -9 "${WATCHDOG_PID}" 2>/dev/null
-		[ -n "${SCHEDULER_PID}" ] && [ ! -f "${SCHEDULE_DIR}/scheduler_done_${SCHEDULER_PID}" ] &&
-		{
-			log_msg -warn "Killing unfinished processing jobs."
-			kill_pids_recursive "${SCHEDULER_PID}"
-		}
+		[ -n "${SCHEDULER_PID}" ] && [ -d "/proc/${SCHEDULER_PID}" ] && kill -s USR1 "${SCHEDULER_PID}"
 		rm -rf "${ABL_DIR}"
 	fi
 	[ -n "${LOCK_REQ}" ] && rm_lock
@@ -467,8 +464,8 @@ log_success()
 # kills any running adblock-lean instances
 kill_abl_pids()
 {
-	local pgrep_ptrn="(/etc/rc.common /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
-	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} 's/\s+.*//' | tr '\n' ' ')" "${$}"
+	local pgrep_ptrn="((/etc/rc.common|sh|/bin/sh) /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
+	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
 }
 
 # kills specified pid's and their offspring
@@ -512,8 +509,7 @@ kill_pids_recursive()
 	done
 	[ -n "${initial_pids}" ] || return 0
 
-	kill ${initial_pids} 2>/dev/null
-
+	kill "${initial_pids}" 2>/dev/null
 	local running_pids="${initial_pids}" k_attempt=0
 	while :
 	do
@@ -525,7 +521,7 @@ kill_pids_recursive()
 			add_child_pids running_pids "${pid}"
 		done
 
-		kill ${running_pids} 2>/dev/null
+		kill "${running_pids}" 2>/dev/null
 
 		local alive_pids=''
 		for pid in ${running_pids}
@@ -537,7 +533,7 @@ kill_pids_recursive()
 
 		sleep 1
 	done
-	kill -9 ${running_pids} 2>/dev/null
+	kill -9 "${running_pids}" 2>/dev/null
 	:
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -437,7 +437,8 @@ rm_lock()
 
 # updates the pid file with a new action
 # 1 - new action
-update_action_file() {
+update_action_file()
+{
 	local me="update_action_file"
 	[ -z "${1%.}" ] && { reg_failure "${me}: action is unspecified."; return 1; }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -371,17 +371,27 @@ check_lock()
 	unset LOCK_PID PID_ABL_CMD
 	[ -z "${PID_FILE}" ] && { reg_failure "\${PID_FILE} variable is unset."; return 1; }
 	[ ! -f "${PID_FILE}" ] && return 0
-	if IFS=" " read -r LOCK_PID PID_ABL_CMD < "${PID_FILE}"
-	then
-		case "${LOCK_PID}" in
-			"${$}") return 3 ;;
-			*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; return 1 ;;
-			*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
-		esac
-	else
+
+	local read_failed='' read_attempt=0
+	while :
+	do
+		IFS=" " read -r LOCK_PID PID_ABL_CMD < "${PID_FILE}" && break
+		read_attempt=$((read_attempt+1))
+		[ "${read_attempt}" -le 3 ] || { read_failed=1; break; }
+		sleep 1
+	done
+
+	[ -n "${read_failed}" ] &&
+	{
 		reg_failure "Failed to read the pid file '${PID_FILE}'."
 		return 1
-	fi
+	}
+
+	case "${LOCK_PID}" in
+		"${$}") return 3 ;;
+		*[!0-9]*) reg_failure "pid file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; return 1 ;;
+		*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
+	esac
 
 	log_msg -warn "Detected stale pid file '${PID_FILE}' for PID ${LOCK_PID}. Removing."
 	rm_lock || return 1

--- a/adblock-lean
+++ b/adblock-lean
@@ -60,8 +60,7 @@ ABL_CRON_CMD="/etc/init.d/adblock-lean start"
 
 ABL_GH_URL_API=https://api.github.com/repos/lynxthecat/adblock-lean
 
-DL_SCHEDULER_PID=
-PROCESS_SCHEDULER_PID=
+SCHEDULER_PID=
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -255,7 +255,7 @@ log_msg()
 	do
 		IFS="${DEFAULT_IFS}"
 		case "${m}" in
-			dummy) printf '\n' ;;
+			dummy) printf '\n' > "${MSGS_DEST}" ;;
 			*)
 				print_msg ${color} "${m}"
 				logger -t adblock-lean -p user."${err_l}" "${m}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -469,7 +469,7 @@ update_action_file()
 # 1 (optional): '-log' to log current action as well
 report_curr_action()
 {
-	[ "${MSGS_DEST}" = "/dev/null" ] && [ "${1}" != "-log" ] && return 0
+	[ "${MSGS_DEST}" = "/dev/null" ] && [ -z "${luci_sourced}" ] && [ "${1}" != "-log" ] && return 0
 	local reported_pid report_cmd=print_msg
 	[ -n "${ACTION_FILE}" ] || { reg_failure "\$ACTION_FILE var is unset."; return 1; }
 	[ -f "${ACTION_FILE}" ] || return 0

--- a/adblock-lean
+++ b/adblock-lean
@@ -678,7 +678,7 @@ init_command()
 		status) libs_req=1 work_dir_req=1 config_req=1 ;;
 		upd_cron_job) libs_req=1 config_req=1 ;;
 		setup|gen_config) libs_req=1 LOCK_REQ=1 ;;
-		boot) libs_req=1 config_req=1 ;;
+		boot) libs_req=1 config_req=1 LOCK_REQ=1 ;;
 		pause) libs_req=1 work_dir_req=1 config_req=1 LOCK_REQ=1 ;;
 		start|resume) libs_req=1 work_dir_req=1 config_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		stop)
@@ -1070,7 +1070,7 @@ gen_stats()
 boot()
 {
 	init_command boot || exit 1
-	log_msg -purple "Sleeping for ${boot_start_delay_s} seconds."
+	reg_action -purple "Sleeping for ${boot_start_delay_s} seconds."
 	sleep "${boot_start_delay_s}"
 	start "$@"
 }

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -135,7 +135,7 @@ do_setup()
 
 		installed_pkgs="$(get_installed_pkgs "${recomm_pkgs_regex}")" || return 1
 
-		echo
+		echo > "${MSGS_DEST}"
 		for util in ${RECOMMENDED_UTILS}
 		do
 			case "${installed_pkgs}" in
@@ -205,7 +205,7 @@ do_setup()
 			then
 				if [ -z "${free_space_B}" ] || [ -z "${utils_size_B}" ] || [ "${free_space_B}" -gt ${utils_size_B} ]
 				then
-					echo
+					echo > "${MSGS_DEST}"
 					$PKG_MANAGER update && $PKG_INSTALL_CMD ${pkgs2install% } && return 0
 					reg_failure "Failed to automatically install packages. You can install them manually later."
 					return 1
@@ -297,7 +297,7 @@ do_setup()
 		print_msg "" "${purple}Setup is complete.${n_c}" "" "Start adblock-lean now?"
 		pick_opt "y|n" || return 1
 		[ "${REPLY}" != y ] && return 0
-		echo
+		echo > "${MSGS_DEST}"
 		start
 	fi
 	:
@@ -980,7 +980,7 @@ report_utils()
 {
 	local util awk_inst_tip='' sed_inst_tip='' sort_inst_tip=''
 
-	printf '\n'
+	printf '\n' > "${MSGS_DEST}"
 
 	for util in ${RECOMMENDED_UTILS}
 	do

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -679,7 +679,7 @@ parse_config()
 				sub(/[ \t]+@/,"@",def_lines_arr[ind])
 				sub(/@[ \t]+/,"@",def_lines_arr[ind])
 				n=split(def_lines_arr[ind],def_line_parts,"[=@]")
-				if (n!=3) {print "Internal error in default config: invalid line " q line_ind q "." > "/dev/stderr"; rv=1; exit}
+				if (n!=3) {print "Internal error in default config: invalid line " q def_lines_arr[ind] q "." > "/dev/stderr"; rv=1; exit}
 				for (i in def_line_parts) {
 					if (i==2){continue} # ignore empty default value
 					if (! def_line_parts[i]) {

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -670,6 +670,7 @@ parse_config()
 		BEGIN{
 			rv=0
 			missing[1]="key"
+			missing[2]="value"
 			missing[3]="allowed values"
 
 			# create def_lines_arr
@@ -681,7 +682,6 @@ parse_config()
 				n=split(def_lines_arr[ind],def_line_parts,"[=@]")
 				if (n!=3) {print "Internal error in default config: invalid line " q def_lines_arr[ind] q "." > "/dev/stderr"; rv=1; exit}
 				for (i in def_line_parts) {
-					if (i==2){continue} # ignore empty default value
 					if (! def_line_parts[i]) {
 						print "Internal error in default config: line " q def_lines_arr[ind] q " is missing the " missing[i] "." > "/dev/stderr"
 						rv=1

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -481,9 +481,8 @@ print_def_config()
 	# Start delay in seconds when service is started from system boot
 	boot_start_delay_s="120" @ integer
 
-	# Number of parallel download and processing threads
-	DL_THREADS="1" @ integer
-	PROCESS_THREADS="1" @ integer
+	# Maximal count of download and processing jobs run in parallel
+	MAX_PARALLEL_JOBS="1" @ integer
 
 	# If a path to custom script is specified and that script defines functions 'report_success()' and 'report_failure()'',
 	# one of these functions will be executed when adblock-lean completes the execution of some commands,

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -654,13 +654,13 @@ parse_config()
 	def_config_format="$(printf %s "${def_config}" | get_config_format)"
 	luci_def_config_format=${def_config_format}
 
-	local parse_res valid_lines def_lines_arr
+	local parse_vars valid_lines def_lines_arr
 	# extract valid values from default config
 	valid_lines="$(print_def_config -d | ${SED_CMD} "${sed_conf_san_exp}")"
 	# parse config
 	local parser_error_file="${ABL_DIR}/parser_error"
 	rm -f "${parser_error_file}" "${ABL_DIR}/unexp_entries" "${ABL_DIR}/bad_val_entries" "${ABL_DIR}/missing_entries"
-	parse_res="$(
+	parse_vars="$(
 		printf '%s\n' "${curr_config}" |
 		${AWK_CMD} -F"=" -v q="'" -v V="${valid_lines}" -v A="${ABL_DIR}" '
 		# return codes: 0=OK, 1=awk or default config error, 253=check double-quotes, 254=Invalid entry detected
@@ -791,7 +791,7 @@ parse_config()
 		return 1
 	}
 
-	eval "${parse_res}" || return 1
+	eval "${parse_vars}" || return 1
 
 	if [ -n "${unexp_keys}" ]
 	then

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -659,6 +659,7 @@ parse_config()
 	valid_lines="$(print_def_config -d | ${SED_CMD} "${sed_conf_san_exp}")"
 	# parse config
 	local parser_error_file="${ABL_DIR}/parser_error"
+	rm -f "${parser_error_file}" "${ABL_DIR}/unexp_entries" "${ABL_DIR}/bad_val_entries" "${ABL_DIR}/missing_entries"
 	parse_res="$(
 		printf '%s\n' "${curr_config}" |
 		${AWK_CMD} -F"=" -v q="'" -v V="${valid_lines}" -v A="${ABL_DIR}" '
@@ -712,21 +713,21 @@ parse_config()
 		{
 			# handle double or missing =
 			if ( $0 !~ /^[^=]+=[^=]+([ \t]+(#.*){0,1})*$/ ) {
-				print $0 > A"/bad_entry"
+				print $0 > "/dev/stderr"
 				rv=254
 				exit
 			}
 
 			# key must be non-empty and alphanumeric
 			if ( $1 !~ /^[a-zA-Z0-9_]+$/ ) {
-				print $0 > A"/bad_entry"
+				print $0 > "/dev/stderr"
 				rv=254
 				exit
 			}
 
 			# line must have exactly 2 double-quotes after = and no characters before #
 			if ( $0 !~ /^[^"]+="[^"]*"([ \t]+(#[^"]*){0,1}){0,1}$/ ) {
-				print $0 > A"/bad_entry"
+				print $0 > "/dev/stderr"
 				rv=253
 				exit
 			}

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -751,7 +751,7 @@ parse_config()
 			if (val !~ regex) {
 				bad_val_keys=bad_val_keys $1 " "
 				print $1 "=" $2 " (should be " valid_values_print_arr[$1] ")" >> A"/bad_val_entries"
-				print $1 "=\"" def_arr[$1] "\"" >> A"/corrected_entries"
+				print $1 "=" def_arr[$1] >> A"/corrected_entries"
 				next
 			}
 
@@ -761,7 +761,7 @@ parse_config()
 			if (rv != 0) {exit rv}
 			for (key in def_arr) {
 				if (key in config_keys) {} else {
-					print key "=\"" def_arr[key] "\"" >> A"/missing_entries"
+					print key "=" def_arr[key] >> A"/missing_entries"
 					missing_keys=missing_keys key " "
 				}
 			}

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -704,21 +704,21 @@ parse_config()
 
 		{
 			# handle double or missing =
-			if ($0 !~ /^[^=]+=[^=]+$/) {
+			if ( $0 !~ /^[^=]+=[^=]+([ \t]+(#.*){0,1})*$/ ) {
 				print $0 > A"/bad_entry"
 				rv=254
 				exit
 			}
 
 			# key must be non-empty and alphanumeric
-			if ($1 !~ /^[a-zA-Z0-9_]+$/) {
+			if ( $1 !~ /^[a-zA-Z0-9_]+$/ ) {
 				print $0 > A"/bad_entry"
 				rv=254
 				exit
 			}
 
 			# line must have exactly 2 double-quotes after = and no characters before #
-			if ($0 !~ /^[^"]+="[^"]*"([ \t](#.*))*$/) {
+			if ( $0 !~ /^[^"]+="[^"]*"([ \t]+(#[^"]*){0,1}){0,1}$/ ) {
 				print $0 > A"/bad_entry"
 				rv=253
 				exit

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -774,19 +774,19 @@ parse_config()
 	{
 		local awk_rv=${?} err_print=''
 		[ -s "${parser_error_file}" ] && err_print="$(cat "${parser_error_file}")"
-		case "${awk_rv}" in
-			253|254) ;;
-			*)
-				[ -n "${err_print}" ] && err_print=" Errors:${_NL_}${err_print}${_NL_}"
-				reg_failure "Failed to parse config.${err_print}"
-				return 1
-		esac
 
-		[ -n "${err_print}" ] && err_print=": '${err_print}'"
+		[ -n "${err_print}" ] &&
+			case "${awk_rv}" in
+				253|254) err_print=": '${err_print}'" ;;
+				*) err_print=" Errors:${_NL_}${err_print}"
+			esac
+
 		case "${awk_rv}" in
 			253) reg_failure "Invalid entry in config (check double-quotes)${err_print}." ;;
-			254) reg_failure "Invalid entry in config${err_print}."
+			254) reg_failure "Invalid entry in config${err_print}." ;;
+			*) reg_failure "Failed to parse config.${err_print}${_NL_}"
 		esac
+
 		return 1
 	}
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -182,7 +182,7 @@ schedule_job()
 	RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT+1))
 	process_list_part "${@}" &
 
-	add2list RUNNING_PIDS "${!}" " "
+	RUNNING_PIDS="${RUNNING_PIDS}${!} "
 
 	:
 }
@@ -196,7 +196,7 @@ schedule_jobs()
 		[ "${1}" != 0 ] && [ -n "${RUNNING_PIDS}" ] &&
 		{
 			log_msg "" "Stopping unfinished jobs (PIDS: ${RUNNING_PIDS})."
-			kill "${RUNNING_PIDS}" 2>/dev/null
+			kill_pids_recursive "${RUNNING_PIDS}"
 			rm -rf "${PROCESSED_PARTS_DIR}" 2>/dev/null
 		}
 		rm -f "${SCHED_CB_FIFO}"
@@ -528,8 +528,6 @@ gen_list_parts()
 
 	reg_action -blue "Downloading and processing blocklist parts (max parallel jobs: ${PARALLEL_JOBS})."
 	print_msg ""
-
-	set +m # disable job complete notification
 
 	# Asynchronously download and process parts, allowlist must be processed separately and first
 	for list_types in allowlist "blocklist blocklist_ipv4"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -164,7 +164,7 @@ print_timed_msg -yellow "Scheduling $list_origin job (running jobs: $RUNNING_JOB
 	handle_done_jobs || return 1
 
 	# wait for job vacancy
-	while [ "${RUNNING_JOBS_CNT}" -ge "${PROCESS_THREADS}" ]
+	while [ "${RUNNING_JOBS_CNT}" -ge "${MAX_PARALLEL_JOBS}" ]
 	do
 print_timed_msg -yellow "Waiting for vacancy (running jobs: $RUNNING_JOBS_CNT, running PIDS: $RUNNING_PIDS)"
 		[ -n "${RUNNING_PIDS}" ] ||
@@ -528,7 +528,7 @@ gen_list_parts()
 		use_allowlist=1
 	fi
 
-	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${PROCESS_THREADS})."
+	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${MAX_PARALLEL_JOBS})."
 	print_msg ""
 
 	set +m # disable job complete notification

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -317,16 +317,6 @@ process_list_part()
 		exit "${1}"
 	}
 
-	rm_ucl_err_file()
-	{
-		rm -f "${ucl_err_file}"
-	}
-
-	rm_rogue_el_file()
-	{
-		rm -f "${rogue_el_file}"
-	}
-
 	# shellcheck disable=SC2317
 	dl_list()
 	{
@@ -366,14 +356,14 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 
 	while :
 	do
-		rm_rogue_el_file
+		rm -f "${rogue_el_file}"
 		rm -f "${list_part_size_file}" "${list_part_line_cnt_file}"
 
 		# Download or cat the list
 		local fetch_cmd lines_cnt_low='' dl_completed=''
 		case "${list_origin}" in
 			DL)
-				rm_ucl_err_file
+				rm -f "${ucl_err_file}"
 				fetch_cmd=dl_list ;;
 			LOCAL) fetch_cmd="cat"
 		esac
@@ -454,7 +444,7 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 		if [ -s "${rogue_el_file}" ]
 		then
 			read -r -n512 rogue_element < "${rogue_el_file}"
-			rm_rogue_el_file
+			rm -f "${rogue_el_file}"
 			local rogue_el_print
 			if [ -n "${rogue_element}" ]
 			then
@@ -487,9 +477,9 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 		then
 			reg_failure "Failed to download list part from URL '${list_url}'."
 			[ -s "${ucl_err_file}" ] && reg_failure "uclient-fetch errors: '$(cat "${ucl_err_file}")'."
-			rm_ucl_err_file
+			rm -f "${ucl_err_file}"
 		else
-			rm_ucl_err_file
+			rm -f "${ucl_err_file}"
 			finalize_job 0
 		fi
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -459,7 +459,7 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 						"This file needs to be converted to Unix newline format (LF)." ;;
 				*) log_msg -warn "${rogue_el_print} identified in ${list_type} file from: ${list_path}."
 			esac
-			finalize_job 2
+			finalize_job 3
 		fi
 
 		[ -f "${list_part_line_cnt_file}" ] && read -r part_line_count _ < "${list_part_line_cnt_file}"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -223,7 +223,7 @@ schedule_jobs()
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${list_urls}" ] && continue
 
-			log_msg -blue "Starting ${list_format} ${list_type} part(s) download."
+			log_msg -blue "" "Starting ${list_format} ${list_type} part(s) download."
 
 			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -223,7 +223,7 @@ schedule_jobs()
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${list_urls}" ] && continue
 
-			reg_action -blue "Starting ${list_format} ${list_type} part(s) download." || finalize_scheduler 1
+			log_msg -blue "Starting ${list_format} ${list_type} part(s) download." || finalize_scheduler 1
 
 			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"
@@ -491,7 +491,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		reg_action -blue "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
+		log_msg -blue "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -522,7 +522,7 @@ gen_list_parts()
 		use_allowlist=1
 	fi
 
-	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${MAX_PARALLEL_JOBS})."
+	reg_action -blue "Downloading and processing blocklist parts (max parallel jobs: ${MAX_PARALLEL_JOBS})."
 	print_msg ""
 
 	set +m # disable job complete notification

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -504,7 +504,9 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 		fi
 
 		reg_action -blue "Sleeping for 5 seconds after failed download attempt." || finalize_job 1
-		sleep 5
+		sleep 5 &
+		local sleep_pid=${!}
+		wait ${sleep_pid}
 	done
 }
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -491,7 +491,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		log_msg -blue "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
+		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -474,7 +474,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt."
+		log_msg -yellow "" "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -1107,7 +1107,7 @@ get_active_entries_cnt()
 	fi |
 	$SED_CMD -E "s~^(${list_prefixes%|})\=/~~;" | tr "/${allow_opt}" '\n' | wc -w > "/tmp/abl_entries_cnt"
 
-	read_str_from_file -d cnt "/tmp/abl_entries_cnt" 2 "entries count"
+	read_str_from_file -d -v cnt -f "/tmp/abl_entries_cnt" -a 2 -D "entries count"
 	case "${cnt}" in *[!0-9]*|'') printf 0; return 1; esac
 	local d i=0 IFS="${DEFAULT_IFS}"
 	if [ "${whitelist_mode}" = 1 ]

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -607,7 +607,7 @@ gen_list_parts()
 	:
 }
 
-generate_and_process_blocklist_file()
+gen_and_process_blocklist()
 {
 	convert_entries()
 	{

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -223,7 +223,7 @@ schedule_jobs()
 			eval "list_urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${list_urls}" ] && continue
 
-			log_msg -blue "Starting ${list_format} ${list_type} part(s) download." || finalize_scheduler 1
+			log_msg -blue "Starting ${list_format} ${list_type} part(s) download."
 
 			invalid_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 				log_msg -warn "" "Invalid URLs detected:" "${invalid_urls}"
@@ -491,7 +491,7 @@ process_list_part()
 			finalize_job 2 "${max_download_retries} download attempts failed for URL '${list_url}'."
 		fi
 
-		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt." || finalize_job 1 "Failed to register action."
+		log_msg -yellow "Processing job for URL '${list_url}' is sleeping for 5 seconds after failed download attempt."
 		sleep 5 &
 		local sleep_pid=${!}
 		wait ${sleep_pid}

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -528,6 +528,9 @@ gen_list_parts()
 		use_allowlist=1
 	fi
 
+	reg_action -blue "Starting download and processing of blocklist parts (max parallel jobs: ${PROCESS_THREADS})."
+	print_msg ""
+
 	set +m # disable job complete notification
 
 	touch "${SCHEDULE_DIR}/nonfatal" || return 1 # serves as flag that no fatal error occured

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -489,7 +489,7 @@ print_timed_msg -yellow "Starting processing job (PID: $curr_job_pid)"
 
 		if [ "${list_origin}" = DL ] && { [ -z "${dl_completed}" ] || [ -n "${lines_cnt_low}" ]; }
 		then
-			reg_failure "Failed to download list part from URL '${list_url}'."
+			reg_failure "Failed download attempt for URL '${list_url}'."
 			[ -s "${ucl_err_file}" ] && log_msg "uclient-fetch output: ${_NL_}'$(cat "${ucl_err_file}")'."
 			rm -f "${ucl_err_file}"
 		else

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -701,6 +701,12 @@ generate_and_process_blocklist_file()
 		esac
 	fi
 
+	get_abl_run_state
+	case ${?} in
+		1) unload_blocklist_before_update=1 ;;
+		4) unload_blocklist_before_update=0 ;;
+	esac
+
 	if [ "${unload_blocklist_before_update}" = auto ]
 	then
 		local totalmem

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -515,9 +515,9 @@ gen_list_parts()
 					PARALLEL_JOBS=1 ;;
 				*)
 					# cap PARALLEL_JOBS to 4 in 'auto' mode
-					if [ ${cpu_cnt} -ge 4 ]
+					if [ "${cpu_cnt}" -ge 4 ]
 					then
-						PARALLEL_JOBS=${cpu_cnt}
+						PARALLEL_JOBS=4
 					else
 						PARALLEL_JOBS=${cpu_cnt}
 					fi

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -31,7 +31,7 @@ try_gunzip()
 # output via optional variable with name $3
 # returns status 0 if the result is null, 1 if not
 subtract_a_from_b() {
-	sab_out="${3:-___dummy}"
+	local sab_out="${3:-___dummy}"
 	case "${2}" in '') unset "${sab_out}"; return 0; esac
 	case "${1}" in '') eval "${sab_out}"='${2}'; [ ! "${2}" ]; return; esac
 	local _fs_su="${4:-"${_NL_}"}"


### PR DESCRIPTION
This PR contains all the accumulated commits in the `simpler_concurrency` branch (after I managed to rebase it on the current master). Short version, in no particular order:

- Implement parallel downloads and processing
- Add option `MAX_PARALLEL_JOBS`, default to `auto`
- Replace option `initial_dnsmasq_restart` with `unload_blocklist_before_update`, default to `auto`
- parse_config(): rewrite parser in awk
- abl_process: skip dnsmasq restart if adblock-lean run state is stopped
- abl_process: process_list_part(): use one `wc` call
- Multiple commits improving error detection and handling across scripts
- fix `status` command reported entries count being off by 1
- Use a separate file for registering and checking current action (previously the PID file was used for that)
- Write to log file asynchronously
- Multiple changes to console output messages across scripts
- log_msg(): output empty lines to $MSGS_DEST (fixes empty log entries spam at boot)
- check_lock(): retry reading the PID file if read fails
- init_command: require lock for action boot (fixes `status` command not reporting that adblock-lean is sleeping after boot)
- abl_post_update_1: set actually correct stop priority
- Make multiple attempts when resolving domains
- abl-process: cope with filesystem delays
- abl-install: offer setup if conf file not present
- Avoid subshell when calling int2human
- Print uclient-fetch errors where relevant
- explicitly call busybox applets gzip, gunzip, zcat
