### PR TITLE
Simpler concurrency

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -417,6 +417,7 @@ mk_lock()
 	:
 }
 
+# assigns lock pid to $LOCK_PID
 # return codes:
 # 0 - no lock
 # 1 - error
@@ -447,6 +448,7 @@ rm_lock()
 	then
 		rm -f "${PID_FILE}" || { reg_failure "Failed to delete the pid file '${PID_FILE}'."; return 1; }
 	fi
+	LOCK_PID=
 	:
 }
 
@@ -535,6 +537,7 @@ kill_abl_pids()
 {
 	local pgrep_ptrn="((/etc/rc.common|sh|/bin/sh) /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
 	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
+	:
 }
 
 # kills specified pid's and their offspring
@@ -722,11 +725,10 @@ rm_cron_job()
 
 
 ### Commands init
-
 init_command()
 {
 	ABL_CMD="${1}"
-	local config_req='' work_dir_req='' kill_req='' init_action_msg=''
+	local config_req='' work_dir_req='' init_action_msg=''
 
 	# detect if sourced from external RPC script for luci, depends on abl_luci_exit() being defined
 	luci_sourced=
@@ -756,7 +758,15 @@ init_command()
 		stop)
 			init_action_msg="Stopping adblock-lean."
 			reg_action -purple "${init_action_msg}" || exit 1
-			libs_req=1 kill_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
+
+			source_libs || exit 1
+			kill_abl_pids
+			check_lock
+			case ${?} in
+				1) exit 1 ;;
+				2) reg_failure "Failed to kill running adblock-lean processes."; exit 1
+			esac
+			CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		select_dnsmasq_instance)
 			libs_req=1 LOCK_REQ=1
 			[ "${action}" = select_dnsmasq_instance ] && config_req=1 # require config when called directly
@@ -777,20 +787,6 @@ init_command()
 	then
 		detect_pkg_manager
 		report_utils
-	fi
-
-	# kill pids if needed
-	if [ -n "${kill_req}" ]
-	then
-		kill_abl_pids
-		check_lock
-		case ${?} in
-			1) exit 1 ;;
-			2)
-				reg_failure "Failed to kill running adblock-lean processes."
-				unset LOCK_REQ CLEANUP_REQ
-				exit 1
-		esac
 	fi
 
 	# register lock status at init
@@ -1528,7 +1524,6 @@ disable()
 	fi
 	return "$rv"
 }
-
 
 set_ansi
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -536,7 +536,7 @@ log_success()
 kill_abl_pids()
 {
 	local pgrep_ptrn="((/etc/rc.common|sh|/bin/sh) /etc/(rc.d/S${START}adblock-lean|init.d/adblock-lean)|luci.adblock-lean)"
-	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
+	kill_pids_recursive "$(pgrep -fa "${pgrep_ptrn}" | grep -v "[ \t]stop$" | ${SED_CMD} -E 's/\s+.*//' | tr '\n' ' ')" "${$}"
 	:
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -469,7 +469,7 @@ update_action_file()
 # 1 (optional): '-log' to log current action as well
 report_curr_action()
 {
-	[ "${MSGS_DEST}" = "/dev/null" ] && [ "${1}" != "-log" ] && return 0
+	[ "${MSGS_DEST}" = "/dev/null" ] && [ -z "${luci_sourced}" ] && [ "${1}" != "-log" ] && return 0
 	local reported_pid report_cmd=print_msg
 	[ -n "${ACTION_FILE}" ] || { reg_failure "\$ACTION_FILE var is unset."; return 1; }
 	[ -f "${ACTION_FILE}" ] || return 0

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -670,6 +670,7 @@ parse_config()
 		BEGIN{
 			rv=0
 			missing[1]="key"
+			missing[2]="value"
 			missing[3]="allowed values"
 
 			# create def_lines_arr
@@ -681,7 +682,6 @@ parse_config()
 				n=split(def_lines_arr[ind],def_line_parts,"[=@]")
 				if (n!=3) {print "Internal error in default config: invalid line " q def_lines_arr[ind] q "." > "/dev/stderr"; rv=1; exit}
 				for (i in def_line_parts) {
-					if (i==2){continue} # ignore empty default value
 					if (! def_line_parts[i]) {
 						print "Internal error in default config: line " q def_lines_arr[ind] q " is missing the " missing[i] "." > "/dev/stderr"
 						rv=1

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -182,7 +182,7 @@ schedule_job()
 	RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT+1))
 	process_list_part "${@}" &
 
-	add2list RUNNING_PIDS "${!}" " "
+	RUNNING_PIDS="${RUNNING_PIDS}${!} "
 
 	:
 }
@@ -196,7 +196,7 @@ schedule_jobs()
 		[ "${1}" != 0 ] && [ -n "${RUNNING_PIDS}" ] &&
 		{
 			log_msg "" "Stopping unfinished jobs (PIDS: ${RUNNING_PIDS})."
-			kill "${RUNNING_PIDS}" 2>/dev/null
+			kill_pids_recursive "${RUNNING_PIDS}"
 			rm -rf "${PROCESSED_PARTS_DIR}" 2>/dev/null
 		}
 		rm -f "${SCHED_CB_FIFO}"
@@ -528,8 +528,6 @@ gen_list_parts()
 
 	reg_action -blue "Downloading and processing blocklist parts (max parallel jobs: ${PARALLEL_JOBS})."
 	print_msg ""
-
-	set +m # disable job complete notification
 
 	# Asynchronously download and process parts, allowlist must be processed separately and first
 	for list_types in allowlist "blocklist blocklist_ipv4"


### PR DESCRIPTION
- kill_abl_pids(): exclude processes which have the string `adblock-lean stop` in their command line from pids which will be killed
- Use kill_pids_recursive() when scheduler errors are encountered
- report_curr_action(): don't skip reporting if sourced from luci
- parse_config: error out if default config is missing the value