### PR TITLE
Fix upgrading from older versions

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -429,7 +429,7 @@ check_lock()
 	[ -z "${PID_FILE}" ] && { reg_failure "\${PID_FILE} variable is unset."; return 1; }
 	[ ! -f "${PID_FILE}" ] && return 0
 
-	read_str_from_file -v LOCK_PID -f "${PID_FILE}" -a 3 -D PID || return 1
+	read_str_from_file -v "LOCK_PID _" -f "${PID_FILE}" -a 3 -D PID || return 1
 
 	case "${LOCK_PID}" in
 		"${$}") return 3 ;;


### PR DESCRIPTION
This fixes the error when updating from older versions to current master:

`pid file '/tmp/adblock-lean/adblock-lean.pid' contains unexpected string`.

The error was caused by the fact that the current master is no longer writing the current action to the PID file, and so the code was not expecting the PID file to have anything but the PID.

The fixed code ignores anything after the first word in the PID file.