### PR TITLE
kill_abl_pids: use check_lock() for verification

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -558,6 +558,8 @@ kill_abl_pids()
 	local i=0
 	while [ -f "${PID_FILE}" ] && [ ${i} -lt 10 ]
 	do
+		check_lock
+		[ ${?} != 2 ] && break
 		sleep 1
 		i=$((i+1))
 	done


### PR DESCRIPTION
This fixes `stop` action being unnecessarily slow during version updates.