### PR TITLE
Some improvements

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -1231,7 +1231,7 @@ stop()
 	done
 	msg="${msg% }"
 
-	init_command stop || exit 1
+	init_command stop || { FAIL_STOP_REQ=''; exit 1; }
 
 	# get DNSMASQ_CONF_D without calling load_config()
 	[ -f "${ABL_CONFIG_FILE}" ] &&
@@ -1247,6 +1247,7 @@ stop()
 	restart_dnsmasq -nostop || stop_rc=1
 	log_msg -purple "" "Stopped adblock-lean."
 	[ -n "$noexit" ] && return "${stop_rc}"
+	FAIL_STOP_REQ=
 	exit "${stop_rc}"
 }
 

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -794,7 +794,7 @@ gen_and_process_blocklist()
 	tee >(wc -c > "${ABL_DIR}/final_list_bytes") |
 
 	# limit size
-	{ head -c "${max_blocklist_file_size_B}"; head -c 1 > "${ABL_DIR}/abl-too-big.tmp"; cat 1>/dev/null; } |
+	{ head -c "${max_blocklist_file_size_B}"; grep . 1>/dev/null && touch "${ABL_DIR}/abl-too-big.tmp"; } |
 	if  [ -n "${final_compress}" ]
 	then
 		busybox gzip
@@ -802,7 +802,7 @@ gen_and_process_blocklist()
 		cat
 	fi > "${out_f}" || { reg_failure "Failed to write to output file '${out_f}'."; rm -f "${out_f}"; return 1; }
 
-	if [ -s "${ABL_DIR}/abl-too-big.tmp" ]; then
+	if [ -f "${ABL_DIR}/abl-too-big.tmp" ]; then
 		rm -f "${out_f}"
 		reg_failure "Final uncompressed blocklist exceeded ${max_blocklist_file_size_KB} kiB set in max_blocklist_file_size_KB config option!"
 		log_msg "Consider either increasing this value in the config or changing the blocklist URLs."


### PR DESCRIPTION
- In current code, final size limiting is implemented in a non-optimal way:
```
{ head -c "${max_blocklist_file_size_B}"; head -c 1 > "${ABL_DIR}/abl-too-big.tmp"; cat 1>/dev/null; }
```

As I discovered recently, when 3 commands are subjected to input pipe (in this case `head`, `head` and `cat`), the 3rd command may not see the input stream. Also there is no need in 3 commands here. This PR implements a better approach to size limiting with `grep . >/dev/null && touch "${ABL_DIR}/abl-too-big.tmp"`

- With current code, in some cases `stop` is called twice under fault conditions. This PR fixes that.