### PR TITLE
Tweak limits

### DIFF
--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -355,8 +355,9 @@ gen_preset()
 	final_entry_size_B=20 # assumption
 	source_entry_size_B=20 # assumption for raw domains format. dnsmasq source format not used by default
 
-	# target_lines_cnt / 3
-	min_good_line_count=$((tgt_lines_cnt_k*1000/3/10000*10000))
+	# target_lines_cnt / 3.5
+	min_good_line_count=$((tgt_lines_cnt_k*10000/35))
+	reasonable_round min_good_line_count
 
 	# target_lines_cnt * final_entry_size_B * lim_coeff * 1.25
 	max_blocklist_file_size_KB=$(( (tgt_lines_cnt_k*1250*final_entry_size_B*lim_coeff)/1024 ))

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -317,9 +317,9 @@ mk_preset_arrays()
 	medium_urls="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif.medium-onlydomains.txt" \
 		medium_cnt=450 medium_mem=256
 	large_urls="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" \
-		large_cnt=1000 large_mem=512
+		large_cnt=1200 large_mem=512
 	large_relaxed_urls="${hagezi_dl_url}/pro-onlydomains.txt ${hagezi_dl_url}/tif-onlydomains.txt" \
-		large_relaxed_cnt=1000 large_relaxed_mem=1024 large_relaxed_coeff=2
+		large_relaxed_cnt=1200 large_relaxed_mem=1024 large_relaxed_coeff=2
 }
 
 # 1 - mini|small|medium|large|large_relaxed

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -365,8 +365,8 @@ gen_preset()
 	case "${1}" in
 		mini) max_file_part_size_KB=${max_blocklist_file_size_KB} ;;
 		*)
-			# target_lines_cnt * source_entry_size_B * lim_coeff * 1.1
-			max_file_part_size_KB=$(( (tgt_lines_cnt_k*1100*source_entry_size_B*lim_coeff)/1024 ))
+			# target_lines_cnt * source_entry_size_B * lim_coeff * 1.03
+			max_file_part_size_KB=$(( (tgt_lines_cnt_k*1030*source_entry_size_B*lim_coeff)/1024 ))
 			reasonable_round max_file_part_size_KB
 	esac
 

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -346,8 +346,8 @@ gen_preset()
 	case "${1}" in
 		mini) max_file_part_size_KB=${max_blocklist_file_size_KB} ;;
 		*)
-			# target_lines_cnt * source_entry_size_B * lim_coeff
-			max_file_part_size_KB=$(( ((tgt_lines_cnt_k*1000*source_entry_size_B*lim_coeff)/1024)/1000*1000 ))
+			# target_lines_cnt * source_entry_size_B * lim_coeff * 1.1
+			max_file_part_size_KB=$(( ((tgt_lines_cnt_k*1100*source_entry_size_B*lim_coeff)/1024)/1000*1000 ))
 	esac
 
 	[ "${2}" = '-d' ] && print_msg "" "${purple}${1}${n_c}: recommended for devices with ${mem} MB of memory."


### PR DESCRIPTION
- Increase "expected/max" elements count for presets large and large_relaxed from 1M to 1.2M
- Round calculated values for presets more precisely in order to leave more headroom for parts size in smaller presets
- Slight increase in factor used to calculated `max_file_part_size_KB`
- Minor tweak to min_good_line_count