### PR TITLE
Bugfixes

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -346,14 +346,13 @@ cleanup_and_exit()
 	then
 		[ "${1}" != 0 ] && print_msg "" "Cleaning up..."
 		[ -n "${SCHEDULER_PID}" ] && kill -s USR1 "${SCHEDULER_PID}" 2>/dev/null
-		rm -rf "${ABL_DIR}"
 	fi
 
 	if [ -n "${FAIL_STOP_REQ}" ]
 	then
 		ABL_NOTRAPS=1 stop "${1}" -noexit
-		rm -rf "${ABL_DIR}"
 	fi
+	rm -rf "${ABL_DIR}"
 
 	[ -n "${LOCK_REQ}" ] && rm_lock
 	local recent_log=

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -893,6 +893,8 @@ load_config()
 
 	local tip_msg="Fix your config file '${ABL_CONFIG_FILE}' or generate default config using 'service adblock-lean gen_config'."
 
+	mkdir -p "${ABL_DIR}"
+
 	# validate config and assign to variables
 	parse_config "${ABL_CONFIG_FILE}"
 	case ${?} in

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -1516,6 +1516,13 @@ check_dnsmasq_instance()
 		}
 	}
 
+	# check if config section exists in /etc/config/dhcp
+	uci show "dhcp.${1}" &>/dev/null ||
+	{
+		reg_failure "dnsmasq instance '${1}' is running but not registered in /etc/config/dhcp. Use the command 'service dnsmasq restart' and then re-try."
+		return 1
+	}
+
 	eval "dnsmasq_conf_dirs=\"\${${1}_CONF_DIRS}\""
 	is_included "${DNSMASQ_CONF_D}" "${dnsmasq_conf_dirs}" ||
 	{


### PR DESCRIPTION
- address the issue reported by **[d687r02j8g](https://forum.openwrt.org/u/d687r02j8g)** on the forum: always create ${ABL_DIR} before calling `parse_config()`
- unconditionally remove ${ABL_DIR} in `cleanup_and_exit()`
- `check_dnsmasq_instance()`: verify that currently selected and running instance exists in `/etc/config/dhcp` (otherwise changing that option in /etc/config/dhcp without restarting the dnsmasq service may cause errors)