### PR TITLE
Bugfixes

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -93,9 +93,14 @@ adblock-lean custom commands:
 
 ### UTILITY FUNCTIONS
 
+# 1 (optional): '-f' to only check for functions
 check_util()
 {
-	command -v "${1}" 1>/dev/null
+	local check_func=
+	[ "${1}" = '-f' ] && { check_func=1; shift; }
+	command -v "${1}" 1>/dev/null && {
+		[ -z "${check_func}" ] || [ "$(type "${1}" 2>/dev/null | head -n1)" = "${1} is a function" ]
+	}
 }
 
 # sets global variables for colors, tab delimiter and cr_lf
@@ -364,12 +369,12 @@ cleanup_and_exit()
 	luci_log="${recent_log}"
 
 	# execute custom script actions
-	if [ -z "${luci_sourced}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_util report_failure
+	if [ -z "${luci_sourced}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_util -f report_failure
 	then
 		[ -n "${recent_log}" ] && failure_msg="${failure_msg}${_NL_}${_NL_}Session log:${_NL_}${recent_log}"
 		report_failure "${failure_msg}"
 	fi
-	if [ -n "${UPD_AVAIL_MSG}" ] && check_util report_update
+	if [ -n "${UPD_AVAIL_MSG}" ] && check_util -f report_update
 	then
 		report_update "${UPD_AVAIL_MSG}${_NL_}${UPD_DIRECTIONS}"
 	fi
@@ -540,7 +545,7 @@ reg_failure()
 
 reg_success()
 {
-	if [ -n "${custom_scr_sourced}" ] && check_util report_success
+	if [ -n "${custom_scr_sourced}" ] && check_util -f report_success
 	then
 		report_success "${1}"
 	fi

--- a/adblock-lean
+++ b/adblock-lean
@@ -303,15 +303,16 @@ print_msg()
 }
 
 # logs each message argument separately and prints to a separate line
-# optional arguments: '-err', '-warn', '-[color]'
+# optional arguments: '-noprint', '-err', '-warn', '-[color]'
 log_msg()
 {
-	local m msgs='' msgs_prefix='' _arg err_l=info color=
+	local m msgs='' msgs_prefix='' _arg err_l=info color='' noprint=''
 
 	local IFS="${DEFAULT_IFS}"
 	for _arg in "$@"
 	do
 		case "${_arg}" in
+			"-noprint") noprint=1 ;;
 			"-err") err_l=err color="${red}" msgs_prefix="Error: " ;;
 			"-warn") err_l=warn color="${yellow}" msgs_prefix="Warning: " ;;
 			-blue|-red|-green|-purple|-yellow) color="${_arg}" ;;
@@ -328,7 +329,7 @@ log_msg()
 		case "${m}" in
 			dummy) printf '\n' > "${MSGS_DEST}" ;;
 			*)
-				print_msg ${color} "${m}"
+				[ -z "${noprint}" ] && print_msg ${color} "${m}"
 				logger -t adblock-lean -p user."${err_l}" "${m}"
 				write_log_file "${m}" "${err_l}"
 		esac

--- a/adblock-lean
+++ b/adblock-lean
@@ -538,9 +538,8 @@ reg_failure()
 	luci_errors="${failure_msg}"
 }
 
-log_success()
+reg_success()
 {
-	log_msg "${1}"
 	if [ -n "${custom_scr_sourced}" ] && check_util report_success
 	then
 		report_success "${1}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -1069,8 +1069,7 @@ install_abl_files()
 			log_msg "File '${file}' did not change - not updating."
 		else
 			log_msg "Copying file '${file##*/}'."
-			{ [ -d "${file%/*}" ] || try_mkdir -p "${file%/*}"; } &&
-				cp "${preinst_path}" "${file}" ||
+			try_mkdir -p "${file%/*}" && cp "${preinst_path}" "${file}" ||
 			{
 				reg_failure "Failed to copy file '${file##*/}'."
 				return 1
@@ -1385,7 +1384,7 @@ update()
 		[ -s "${UCL_ERR_FILE}" ] && fail_msg="${fail_msg} uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'"
 		[ -n "${fail_msg}" ] && reg_failure "${fail_msg}"
 		reg_failure "Failed to update adblock-lean."
-		rm -rf "${ABL_UPD_DIR}" "${ABL_PID_DIR}" "${UCL_ERR_FILE}"
+		rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
 	}
 
 	failsafe_log()
@@ -1416,7 +1415,7 @@ update()
 
 	[ -z "${force_update}" ] && stop -noexit
 
-	rm -rf "${ABL_UPD_DIR}"
+	rm -rf "${ABL_UPD_DIR:-???}"
 	try_mkdir -p "${ABL_UPD_DIR}" || { upd_failed; return 1; }
 
 	if [ -n "${SIM_PATH}" ]
@@ -1480,7 +1479,7 @@ update()
 	) 1>/dev/null || { upd_failed "Failed to source the new version of adblock-lean. Update is cancelled."; return 1; }
 
 	install_abl_files "${dist_dir}" "${upd_channel}_${ref}" || { upd_failed; return 1; }
-	rm -rf "${ABL_UPD_DIR}" "${ABL_PID_DIR}" "${UCL_ERR_FILE}"
+	rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
 
 	# shellcheck disable=SC2031
 	[ -n "${UPD_SOURCED}" ] && return 0
@@ -1527,7 +1526,7 @@ uninstall()
 	if [ "${REPLY}" = y ]
 	then
 		log_msg -purple "" "Deleting the config directory."
-		rm -rf "${ABL_CONFIG_DIR}" || reg_failure "Failed to delete the config directory '${ABL_CONFIG_DIR}'."
+		rm -rf "${ABL_CONFIG_DIR:-???}"
 	fi
 
 	local i="-1" addnmount_deleted=1

--- a/adblock-lean
+++ b/adblock-lean
@@ -93,14 +93,14 @@ adblock-lean custom commands:
 
 ### UTILITY FUNCTIONS
 
-# 1 (optional): '-f' to only check for functions
+check_func()
+{
+	[ "$(type "${1}" 2>/dev/null | head -n1)" = "${1} is a function" ]
+}
+
 check_util()
 {
-	local check_func=
-	[ "${1}" = '-f' ] && { check_func=1; shift; }
-	command -v "${1}" 1>/dev/null && {
-		[ -z "${check_func}" ] || [ "$(type "${1}" 2>/dev/null | head -n1)" = "${1} is a function" ]
-	}
+	command -v "${1}" 1>/dev/null
 }
 
 # sets global variables for colors, tab delimiter and cr_lf
@@ -370,12 +370,12 @@ cleanup_and_exit()
 	luci_log="${recent_log}"
 
 	# execute custom script actions
-	if [ -z "${luci_sourced}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_util -f report_failure
+	if [ -z "${luci_sourced}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_func report_failure
 	then
 		[ -n "${recent_log}" ] && failure_msg="${failure_msg}${_NL_}${_NL_}Session log:${_NL_}${recent_log}"
 		report_failure "${failure_msg}"
 	fi
-	if [ -n "${UPD_AVAIL_MSG}" ] && check_util -f report_update
+	if [ -n "${UPD_AVAIL_MSG}" ] && check_func report_update
 	then
 		report_update "${UPD_AVAIL_MSG}${_NL_}${UPD_DIRECTIONS}"
 	fi
@@ -546,7 +546,7 @@ reg_failure()
 
 reg_success()
 {
-	if [ -n "${custom_scr_sourced}" ] && check_util -f report_success
+	if [ -n "${custom_scr_sourced}" ] && check_func report_success
 	then
 		report_success "${1}"
 	fi
@@ -778,7 +778,7 @@ init_command()
 
 	# detect if sourced from external RPC script for luci, depends on abl_luci_exit() being defined
 	luci_sourced=
-	check_util "abl_luci_exit" && luci_sourced=1
+	check_func "abl_luci_exit" && luci_sourced=1
 
 	DO_DIALOGS=
 	[ -z "${luci_skip_dialogs}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
@@ -984,8 +984,8 @@ abl_post_update_1()
 				unset -f clean_dnsmasq_dir restart_dnsmasq
 				unset action ABL_CMD
 				. "${ABL_SERVICE_PATH}"
-				check_util clean_dnsmasq_dir && clean_dnsmasq_dir &&
-				check_util restart_dnsmasq && restart_dnsmasq
+				check_func clean_dnsmasq_dir && clean_dnsmasq_dir &&
+				check_func restart_dnsmasq && restart_dnsmasq
 			)
 		fi
 		POST_UPDATE_1_DONE=1
@@ -1458,7 +1458,7 @@ update()
 		. "${dist_dir}/adblock-lean" || { failsafe_log "Error: Failed to source the downloaded script."; exit 1; }
 
 		# call abl_post_update_1() in new version
-		check_util abl_post_update_1 && abl_post_update_1
+		check_func abl_post_update_1 && abl_post_update_1
 
 		printf '%s\n' "${ABL_SERVICE_PATH} ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}" > "${curr_dist_dir}/inst_files"
 
@@ -1466,11 +1466,11 @@ update()
 		then
 			failsafe_log "NOTE: config format has changed from v${prev_config_format} to v${upd_config_format}."
 			# load config and call abl_post_update_2() in new version
-			if { ! check_util source_libs || source_libs "${curr_dist_dir}${ABL_LIB_DIR}" "${curr_dist_dir}"; } &&
-					check_util load_config
+			if { ! check_func source_libs || source_libs "${curr_dist_dir}${ABL_LIB_DIR}" "${curr_dist_dir}"; } &&
+					check_func load_config
 			then
 				load_config
-				check_util abl_post_update_2 && abl_post_update_2
+				check_func abl_post_update_2 && abl_post_update_2
 			else
 				failsafe_log "Please run 'service adblock-lean start' to initialize the new config."
 			fi
@@ -1611,10 +1611,10 @@ fi
 
 # shellcheck source=/dev/null
 # this is needed when running via 'sh /etc/init.d/adblock-lean'
-check_util config_load 1>/dev/null || . /lib/functions.sh || { reg_failure "Failed to source /lib/functions.sh"; exit 1; }
+check_func config_load 1>/dev/null || . /lib/functions.sh || { reg_failure "Failed to source /lib/functions.sh"; exit 1; }
 
 # detect when sourced from update() in older versions
-check_util failsafe_log 1>/dev/null && UPD_SOURCED=1
+check_func failsafe_log 1>/dev/null && UPD_SOURCED=1
 
 case "${ABL_CMD}" in
 	enable|disable|uninstall|update|setup) ${ABL_CMD} "${@}"; exit ${?} ;;

--- a/adblock-lean
+++ b/adblock-lean
@@ -233,12 +233,12 @@ pick_opt()
 	update_action_file "Waiting for user input in console" || return 1
 	while :
 	do
-		printf %s "$1: " 1>${MSGS_DEST}
+		printf %s "$1: "
 		read -r REPLY
-		case "$REPLY" in *[!A-Za-z0-9_]*) printf '\n%s\n\n' "Please enter $1" 1>${MSGS_DEST}; continue; esac
+		case "$REPLY" in *[!A-Za-z0-9_]*) printf '\n%s\n\n' "Please enter $1"; continue; esac
 		eval "case \"$REPLY\" in 
 				$1) return 0 ;;
-				*) printf '\n%s\n\n' \"Please enter $1\" 1>${MSGS_DEST}
+				*) printf '\n%s\n\n' \"Please enter $1\"
 			esac"
 	done
 }

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -653,6 +653,8 @@ parse_config()
 
 	[ ! -f "${1}" ] && { reg_failure "Config file '${1}' not found."; return 1; }
 
+	try_mkdir -p "${ABL_CONF_STAGING_DIR}" || return 1
+
 	# extract entries from default config
 	def_config="$(print_def_config)" || return 3
 
@@ -893,8 +895,6 @@ load_config()
 	fi
 
 	local tip_msg="Fix your config file '${ABL_CONFIG_FILE}' or generate default config using 'service adblock-lean gen_config'."
-
-	try_mkdir -p "${ABL_CONF_STAGING_DIR}" || return 1
 
 	# validate config and assign to variables
 	parse_config "${ABL_CONFIG_FILE}"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -874,7 +874,10 @@ gen_and_process_blocklist()
 	fi
 
 	log_msg -green "" "Active blocklist check passed with the new blocklist file."
-	log_success "${green}New blocklist installed with entries count: ${blue}${final_entries_cnt_human}${n_c}."
+
+	print_msg "${green}New blocklist installed with entries count: ${blue}${final_entries_cnt_human}${n_c}."
+	reg_success "New blocklist installed with entries count: ${final_entries_cnt_human}."
+
 	rm -f "${ABL_DIR}/prev_blocklist"*
 
 	:

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -302,7 +302,10 @@ process_list_part()
 		[ -n "${2}" ] && reg_failure "process_list_part: ${2}"
 		case "${1}" in
 			0)
-				log_msg -green "Successfully processed list: ${blue}${list_path}${n_c} (${line_count_human} lines, $(bytes2human "${part_size_B}"))." ;;
+				local list_size_human
+				list_size_human="$(bytes2human "${part_size_B}")"
+				print_msg -green "Successfully processed list: ${blue}${list_path}${n_c} (${line_count_human} lines, ${list_size_human})."
+				log_msg -noprint "Successfully processed list: ${list_path} (${line_count_human} lines, ${list_size_human})." ;;
 			*)
 				rm -f "${dest_file}" "${list_stats_file}"
 				[ "${1}" = 1 ] && handle_fatal "${curr_job_pid}" "${list_path}"
@@ -359,7 +362,8 @@ process_list_part()
 			*) reg_failure "Invalid list origin '${list_origin}'."; finalize_job 1
 		esac
 
-		log_msg "Processing ${list_format} ${list_type}: ${blue}${list_path}${n_c}"
+		print_msg "Processing ${list_format} ${list_type}: ${blue}${list_path}${n_c}"
+		log_msg -noprint "Processing ${list_format} ${list_type}: ${list_path}"
 
 		${fetch_cmd} "${list_path}" |
 		# limit size
@@ -875,7 +879,7 @@ gen_and_process_blocklist()
 
 	log_msg -green "" "Active blocklist check passed with the new blocklist file."
 
-	print_msg "${green}New blocklist installed with entries count: ${blue}${final_entries_cnt_human}${n_c}."
+	print_msg -green "New blocklist installed with entries count: ${blue}${final_entries_cnt_human}${n_c}."
 	reg_success "New blocklist installed with entries count: ${final_entries_cnt_human}."
 
 	rm -f "${ABL_DIR}/prev_blocklist"*


### PR DESCRIPTION
- Fix ANSI colors included in args passed to report_success() in custom script
- Fix ANSI colors included in some logged messages
- pick_opt(): fix options sometimes not printed
- Create `$ABL_CONF_STAGING_DIR` in `parse_config()` rather than in `load_config()` - fixes direct calls to `parse_config()` from the luci app
- Implement `check_func()`, use `check_func()` when checking for functions