### PR TITLE
Improve update

### DIFF
--- a/adblock-lean
+++ b/adblock-lean
@@ -3,7 +3,8 @@
 
 # adblock-lean - powerful and ultra efficient adblocking with dnsmasq on OpenWrt
 # Project homepage: https://github.com/lynxthecat/adblock-lean
-# ABL_VERSION=dev
+ABL_VERSION=dev
+UPD_CHANNEL=release
 
 START=99
 STOP=04
@@ -30,6 +31,8 @@ _NL_='
 '
 IFS="${DEFAULT_IFS}"
 
+CONFIG_FORMAT=v8
+
 if [ -t 0 ]
 then
 	MSGS_DEST=/dev/tty
@@ -45,11 +48,18 @@ ABL_UPD_DIR="/var/run/adblock-lean-update"
 ABL_CONF_STAGING_DIR="/tmp/abl-conf-staging"
 
 ABL_SERVICE_PATH=/etc/init.d/adblock-lean
-ABL_LIB_FILES="${ABL_LIB_DIR}/abl-lib.sh ${ABL_LIB_DIR}/abl-process.sh"
+
+ABL_FILE_TYPES="GEN LIB EXTRA"
+
+ABL_GEN_FILES="${ABL_SERVICE_PATH}"
+ABL_LIB_FILES="${ABL_LIB_DIR}/abl-lib.sh
+	${ABL_LIB_DIR}/abl-process.sh"
 ABL_EXTRA_FILES="" # may be useful in the future
+ABL_EXEC_FILES="${ABL_SERVICE_PATH}"
+
+ABL_FILES_REG_PATH=/etc/adblock-lean/abl-reg.md5
 
 ABL_CONFIG_FILE=${ABL_CONFIG_DIR}/config
-CONFIG_FORMAT=v7
 
 PID_FILE="${ABL_PID_DIR}/adblock-lean.pid"
 ACTION_FILE="${ABL_PID_DIR}/adblock-lean.action"
@@ -61,6 +71,7 @@ UCL_ERR_FILE="${ABL_DIR}/uclient-fetch_err"
 ABL_CRON_CMD="/etc/init.d/adblock-lean start"
 
 ABL_GH_URL_API=https://api.github.com/repos/lynxthecat/adblock-lean
+ABL_MAIN_BRANCH=master
 
 SCHEDULER_PID=
 
@@ -87,11 +98,22 @@ adblock-lean custom commands:
 : "${action:=}" "${action_rv}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}"
 : "${purple}" "${green}" "${TAB}" "${CR}" "${CR_LF}"
 : "${AWK_CMD}" "${SORT_CMD}"
+: "${ABL_GEN_FILES}" "${ABL_LIB_FILES}" "${ABL_EXEC_FILES}"
 : "${luci_log}" "${luci_pid_action}" "${luci_errors}" "${luci_dnsmasq_status}"
 : "${luci_good_line_count}" "${luci_update_status}" "${luci_pkgs_install_failed}" "${luci_cron_job_creation_failed}"
 
 
 ### UTILITY FUNCTIONS
+
+# check if var names are safe to use with eval
+are_var_names_safe() {
+	local var_name
+	for var_name in "${@}"
+	do
+		case "${var_name}" in *[!a-zA-Z_]*) reg_failure "Invalid var name '${var_name}'."; return 1; esac
+	done
+	:
+}
 
 check_func()
 {
@@ -674,53 +696,79 @@ get_abl_run_state()
 	return 4
 }
 
-# 1 (optional) - libs directory
-# 2 (optional) - service directory
-check_libs()
+# 1 - types: 'ALL' (doesn't print executable files) or any combination (space-separated) of 'GEN', 'LIB', 'EXTRA', 'EXEC'
+print_file_list()
 {
-	local lib_file service_file service_version lib_version
-	local libs_dir="${1:-"${ABL_LIB_DIR}"}" service_dir="${2:-"${ABL_SERVICE_PATH%/*}"}"
-	service_file="${service_dir}/adblock-lean"
-	get_abl_version "${service_file}" service_version
-	for lib_file in ${ABL_LIB_FILES}
+	local me=print_file_list file_type files='' IFS="${DEFAULT_IFS}" \
+		file_types="${1}"
+
+	[ -n "$1" ] || { reg_failure "${me}: missing args."; return 1; }
+
+	if [ "${file_types}" = ALL ]
+	then
+		file_types="${ABL_FILE_TYPES}"
+	fi
+
+	for file_type in ${file_types}
 	do
-		lib_file="${libs_dir}/${lib_file##*/}"
-		if [ -s "${lib_file}" ]
-		then
-			get_abl_version "${lib_file}" lib_version
-			if [ "${lib_version}" = "${service_version}" ]
-			then
-				continue
-			else
-				log_msg -warn "Version mismatch between ${service_file} ('${service_version}') and ${lib_file} ('${lib_version}')."
-			fi
-		else
-			log_msg -warn "adblock-lean library files are missing."
-		fi
-		return 1
+		case "${file_type}" in
+			GEN|LIB|EXTRA|EXEC)
+				eval "files=\"${files}\${ABL_${file_type}_FILES}${_NL_}\"" ;;
+			*) reg_failure "${me}: invalid type '${file_type}'"; return 1
+		esac
 	done
+
+	# remove extra newlines, leading and trailing whitespaces and tabs
+	printf '%s\n' "${files}" | ${SED_CMD} "s/^\s*//;s/\s*$//;/^$/d"
 	:
 }
 
-# 1 (optional) - libs directory
-# 2 (optional) - service directory
+# return codes:
+# 0 - OK
+# 1 - general error
+# 2 - missing files
+# 3 - non-matching md5sums
+check_libs()
+{
+	local reg_file file files='' file_types
+
+	eval "file_types=\"\${ABL_FILE_TYPES}\"
+		reg_file=\"\${ABL_FILES_REG_PATH}\""
+
+	files="$(print_file_list ALL)" && [ -n "${files}" ] ||
+		{ reg_failure "Failed to get file list."; return 1; }
+	
+	local IFS="${_NL_}"
+	for file in ${reg_file}${_NL_}${files}
+	do
+		[ -n "$file" ] || continue
+		[ -f "$file" ] || { reg_failure "Missing file: '$file'."; return 2; }
+	done
+
+	IFS="${DEFAULT_IFS}"
+	md5sum -c "${reg_file}" &>/dev/null || return 3
+	:
+}
+
 source_libs()
 {
 	[ -n "${LIBS_SOURCED}" ] && return 0
 
-	local file libs_dir="${1:-"${ABL_LIB_DIR}"}" service_dir="${2:-"${ABL_SERVICE_PATH%/*}"}" libs_missing='' libs_source_failed=''
-	if ! check_libs "${libs_dir}" "${service_dir}"
-	then
-		log_msg "Please run 'sh /etc/init.d/adblock-lean update -f' to fetch required files."
-		return 1
-	fi
+	local file libs_missing='' libs_source_failed=''
+	check_libs
+	case ${?} in
+		0|3) ;;
+		*)
+			log_msg "Please run 'sh /etc/init.d/adblock-lean update -f' to fetch required files."
+			return 1
+	esac
 
 	# source libs
 	for file in ${ABL_LIB_FILES}
 	do
 		file="${file##*/}"
-		[ -f "${libs_dir}/${file}" ] || { libs_source_failed=1 libs_missing=1; break; }
-		. "${libs_dir}/${file}" || { libs_source_failed=1; break; }
+		[ -f "${ABL_LIB_DIR}/${file}" ] || { libs_source_failed=1 libs_missing=1; break; }
+		. "${ABL_LIB_DIR}/${file}" || { libs_source_failed=1; break; }
 	done
 
 	[ -n "${libs_source_failed}" ] &&
@@ -778,7 +826,7 @@ init_command()
 
 	# detect if sourced from external RPC script for luci, depends on abl_luci_exit() being defined
 	luci_sourced=
-	check_func "abl_luci_exit" && luci_sourced=1
+	check_func abl_luci_exit && luci_sourced=1
 
 	DO_DIALOGS=
 	[ -z "${luci_skip_dialogs}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
@@ -884,87 +932,197 @@ init_command()
 	:
 }
 
-# get version of adblock-lean file $1
-# assign version to var $2, update channel to var $3
-get_abl_version()
-{
-	unset "${2}" "${3:-dummy}"
-	local gv_ver_string gv_version gv_upd_channel
-	gv_ver_string="$(${SED_CMD} -n '/^\s*#\s*ABL_VERSION=/{s/^\s*#\s*ABL_VERSION=//;s/\s*$//;p;q;}' "${1}")"
-	gv_version="${gv_ver_string##*_}"
-	gv_upd_channel="${gv_ver_string%"_${gv_version}"}"
-	: "${gv_upd_channel}" # silence shellcheck warning
-	eval "${2}"='${gv_version}'
-	[ -n "${3}" ] && eval "${3}"='${gv_upd_channel}'
-}
-
-# Get GitHub ref and tarball url for specified version
-# 1 - [latest|snapshot|v<version>|tag=<github_tag>|commit=<commit_hash>]
+# Get GitHub ref and tarball url for specified component, update channel, branch and version
+# 1 - update channel: release|snapshot|branch=<github_branch>|commit=<commit_hash>
+# 2 - version (optional): [version|commit_hash]
 # Output via variables:
-#   $2 - github ref, $3 - tarball url, $4 - update channel
-get_gh_ref_data()
+#   $3 - github ref (version/commit hash), $4 - tarball url, $5 - version type ('version' or 'commit')
+get_ref()
 {
-	local me=get_gh_ref_data ref_fetch_url jsonfilter_ptrn commit version="${1}"
-	local gh_ref=''  gh_channel=''
-	unset "${2}" "${3}" "${4}"
+	set_res_vars()
+	{
+		# validate resulting ref
+		case "${gr_ref}" in
+			*[^"${_NL_}"]*"${_NL_}"*[^"${_NL_}"]*)
+				reg_failure "Got multiple download URLs for version '${gr_version}'." \
+					"If using commit hash, please specify the complete commit hash string."
+				return 1 ;;
+			''|*[!a-zA-Z0-9._-]*)
+				reg_failure "Failed to get GitHub download URL for ${gr_ver_type} '${gr_version}' (update channel: '${gr_channel}')."
+				return 1
+		esac
 
-	case "${version}" in
-		snapshot)
-			ref_fetch_url="${ABL_GH_URL_API}/commits/master"
-			jsonfilter_ptrn='@.sha' # latest commit is first on the list
-			gh_channel=snapshot ;;
-		latest)
-			ref_fetch_url="${ABL_GH_URL_API}/releases"
-			jsonfilter_ptrn='@[@.prerelease=false]' # ignore pre-releases
-			gh_channel=release ;;
-		v[0-9]*)
-			gh_ref="${version}"
-			gh_channel=release ;;
-		tag=*)
-			gh_ref="${version#tag=}"
-			gh_channel=tag ;;
-		commit=*)
-			commit="${version#commit=}"
-			gh_ref="${commit%"${commit#???????}"}" # trim commit hash to 7 characters
-			gh_channel=commit ;;
-		*) reg_failure "${me}: invalid version '${version}'."; return 1
+		case "${gr_channel}" in
+			release) gr_version="${gr_ref#v}" ;;
+			*) gr_version="${gr_ref}"
+		esac
+
+		eval "${3}"='${gr_version}' "${4}"='${ABL_GH_URL_API}/tarball/${gr_ref}' "${5}"='${gr_ver_type}' \
+			"prev_ref"='${gr_ref}' "prev_ver_type"='${gr_ver_type}' \
+			"prev_upd_channel"='${gr_channel}' "prev_version"='${gr_version}'
+	}
+
+	local gr_branch gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
+		gr_fetch_tmp_dir="${ABL_UPD_DIR}/ref_fetch" \
+		prev_ref prev_ver_type prev_upd_channel prev_version \
+		gr_channel="${1}" gr_version="${2}"
+
+	[ "$gr_channel" = release ] && gr_version="${gr_version#v}"
+
+	local gr_ucl_err_file="${gr_fetch_tmp_dir}/ucl_err"
+
+	are_var_names_safe "${3}" "${4}" "${5}" || return 1
+	eval "${3}='' ${4}='' ${5}=''"
+
+	eval "prev_ref=\"\${prev_ref}\"
+		prev_ver_type=\"\${prev_ver_type}\"
+		prev_upd_channel=\"\${prev_upd_channel}\"
+		prev_version=\"\${prev_version}\""
+
+	# if commit hash is specified and it's 40-char long, use it directly without API query or cache check
+	case "${gr_channel}" in
+		snapshot|branch=*|commit=*) [ "${#gr_version}" = 40 ] && gr_ref="${gr_version}"
 	esac
 
-	if [ -n "${ref_fetch_url}" ]
+	# if previously stored data exists, use it without API query or cache check
+	if [ -z "${gr_ref}" ] && [ -n "${prev_ref}" ] && [ -n "${prev_ver_type}" ] && \
+		[ "${prev_upd_channel}" = "${gr_channel}" ] && [ "${gr_version}" = "${prev_version}" ]
 	then
-		# Get ref for latest/snapshot
-		log_msg -blue "Getting GitHub ref for ${version} version of adblock-lean."
-		gh_ref="$(
-			uclient-fetch -q "${ref_fetch_url}" -O - 2> "${UCL_ERR_FILE}" |
-			jsonfilter -e "${jsonfilter_ptrn}" |
-			{
-				case "${version}" in
-					snapshot) head -c7 ;;
-					latest)
-						jsonfilter -a -e '@[@.target_commitish="master"].tag_name' | # get latest tag for master
-						head -n1
-				esac
-				cat 1>/dev/null
-			}
-		)"
+			gr_ref="${prev_ref}" gr_ver_type="${prev_ver_type}"
+	elif [ -z "${gr_ref}" ]
+	then
+		# ref cache
+		local cache_ttl cache_file cache_filename="${gr_version}_${gr_channel}" gr_cache_dir="/tmp/abl_cache"
+		case "${gr_channel}" in
+			commit=*) cache_ttl=2880 ;; # 48 hours
+			*) cache_ttl=10 # 10 minutes
+		esac
+
+		# clean up old cache
+		find "${gr_cache_dir:-?}" -maxdepth 1 -type f -mmin +"${cache_ttl}" -exec rm -f {} \; 2>/dev/null
+
+		# check if the query is cached
+		cache_file="$(find "${gr_cache_dir:-?}" -maxdepth 1 -type f -name "${cache_filename}" -print 2>/dev/null)"
+		case "${cache_file}" in
+			'') ;; # found nothing
+			*[^"${_NL_}"]*"${_NL_}"*[^"${_NL_}"]*)
+				# found multiple files - delete them
+				local file IFS="${_NL_}"
+				for file in ${cache_file}
+				do
+					[ -n "${file}" ] || continue
+					rm -f "${file}"
+				done
+				IFS="${DEFAULT_IFS}" ;;
+			*)
+				# found cached query
+				if [ -z "${IGNORE_CACHE}" ] && [ -f "${cache_file}" ] &&
+					read -r prev_ref prev_ver_type < "${cache_file}" &&
+					[ -n "${prev_ref}" ] && [ -n "${prev_ver_type}" ]
+				then
+					gr_ref="${prev_ref}" gr_ver_type="${prev_ver_type}"
+				else
+					rm -f "${cache_file:-???}"
+				fi
+		esac
 	fi
 
-	# validate resulting ref
-	case "${gh_ref}" in
-		''|*[!a-zA-Z0-9._-]*) reg_failure "${me}: failed to get GitHub ref for version '${version}'."; return 1
+	if [ -n "${gr_ref}" ]
+	then
+		set_res_vars "${@}" || return 1
+		return 0
+	fi
+
+	try_mkdir -p "${gr_fetch_tmp_dir}" || return 1
+	rm -f "${gr_ucl_err_file}"
+
+	case "${gr_channel}" in
+		release)
+			gr_ver_type=version
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^v${gr_version#v}$" ;;
+		snapshot)
+			gr_ver_type=commit
+			gr_branches="${ABL_MAIN_BRANCH}"
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^${gr_version}$" ;;
+		branch=*)
+			gr_ver_type=commit
+			gr_branches="${gr_channel#*=}"
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^${gr_version}$" ;;
+		commit=*)
+			gr_ver_type=commit
+			local gr_hash="${gr_channel#*=}"
+
+			if [ "${#gr_hash}" = 40 ]
+			then
+				# if upd. ch. is 'commit', the upd. ch. string includes commit hash -
+				#    if it's 40-char long, use it directly without API query
+				gr_ref="${gr_hash}"
+			else
+				gr_branches="$(
+					uclient-fetch "${ABL_GH_URL_API}/branches" -O-  2> "${gr_ucl_err_file}" |
+						{ jsonfilter -e '@[@]["name"]'; cat 1>/dev/null; }
+				)"
+				[ -n "${gr_branches}" ] || {
+					reg_failure "Failed to get adblock-lean branches via GH API (url: '${ABL_GH_URL_API}/branches')."
+					[ -f "${gr_ucl_err_file}" ] &&
+						log_msg "uclient-fetch log:${_NL_}$(cat "${gr_ucl_err_file}")"
+						rm -f "${gr_ucl_err_file}"
+					return 1
+				}
+				rm -f "${gr_ucl_err_file}"
+				gr_grep_ptrn="^${gr_hash}"
+			fi ;;
+		*)
+			reg_failure "Invalid update channel '${gr_channel}'."
+			return 1
 	esac
 
-	eval "${2}"='${gh_ref}' "${3}"='${ABL_GH_URL_API}/tarball/${gh_ref}' "${4}"='${gh_channel}'
-	: "${gh_channel}" # silence shellcheck warning
+	# Get GH ref
+	[ -z "${gr_ref}" ] && gr_ref="$(
+		case "${gr_channel}" in
+			release)
+				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${gr_ucl_err_file}" | {
+					jsonfilter -e '@[@.prerelease=false]' |
+					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
+					cat 1>/dev/null
+				} ;;
+			snapshot|branch=*|commit=*)
+				for gr_branch in ${gr_branches}
+				do
+					ref_fetch_url="${ABL_GH_URL_API}/commits?sha=${gr_branch}"
+					uclient-fetch "${ref_fetch_url}" -O- 2> "${gr_ucl_err_file}" | {
+						jsonfilter -e '@[@.commit]["url"]' |
+						${SED_CMD} 's/.*\///' # only leave the commit hash
+						cat 1>/dev/null
+					}
+				done
+		esac |
+		{
+			if [ -n "${gr_grep_ptrn}" ]
+			then
+				grep "${gr_grep_ptrn}"
+			else
+				head -n1 # get latest version or commit
+			fi
+			cat 1>/dev/null
+		}
+	)"
 
+	if [ -z "${gr_ref}" ]
+	then
+		gr_fetch_rv=1
+		reg_failure "Failed to get GitHub download URL for ${gr_ver_type} '${gr_version}' (update channel: '${gr_channel}')."
+		[ -f "${gr_ucl_err_file}" ] && log_msg "uclient-fetch output:${_NL_}$(cat "${gr_ucl_err_file}")"
+	fi
+	rm -rf "${gr_fetch_tmp_dir:-?}"
+	[ "$gr_fetch_rv" = 0 ] || return 1
+
+	# write query result to cache
+	try_mkdir -p "${gr_cache_dir}" &&
+	printf '%s\n' "${gr_ref} ${gr_ver_type}" > "${gr_cache_dir}/${cache_filename}"
+
+	set_res_vars "${@}" || return 1
 	:
-}
-
-# 1 - new version
-# 2 - path to file
-update_version()
-{
-	${SED_CMD} -i "/^\s*#\s*ABL_VERSION=/{s/.*/# ABL_VERSION=${1}/;:1 n;b1;}" "${2}"
 }
 
 # will be executed upon update from the old version of the script, before new version is installed
@@ -995,89 +1153,214 @@ abl_post_update_1()
 	:
 }
 
-# assigns path to extracted distribution directory to $1
-# (optional) 1 - '-n' to quiet
-# 1 - var name for output
-# 2 - tarball url
-# 3 - github ref
+abl_post_update_2()
+{
+	# workaround for upgrading from versions older than v0.7.2
+	local dist_dir="${curr_dist_dir:-"${ABL_UPD_DIR}"}"
+	[ -s "${dist_dir}/inst_files" ] || { set +x; return 0; }
+	busybox sed -i ':a;N;$!ba;s/\n/ /g;s/\s\s*/ /g' "${curr_dist_dir}/inst_files" # replace newlines with whitespaces
+}
+
+# Fetches and unpacks adblock-lean distribution
+# 1 - tarball url
 fetch_abl_dist()
 {
-	if [ "${1}" = '-n' ]
-	then
-		shift
-	else
-		reg_action -blue "Downloading adblock-lean, version '${3}'." || return 1
-	fi
+	[ -n "$1" ] || { reg_failure "fetch URL not specified."; return 1; }
 
-	local fetch_tarball_url="${2}"
-	local fetch_dir fetch_rv tarball="${ABL_UPD_DIR}/remote_abl.tar.gz"
+	local fetch_rv extract_dir fetch_dir="${ABL_UPD_DIR}/fetch" dist_dir="${ABL_UPD_DIR}/dist"
+	local  tarball="${fetch_dir}/remote_abl.tar.gz" ucl_err_file="${fetch_dir}/ucl_err" \
+		fetch_tarball_url="$1"
 
-	rm -rf "${UCL_ERR_FILE}" "${ABL_UPD_DIR}/lynxthecat-adblock-lean-"*
-	uclient-fetch "${fetch_tarball_url}" -O "${tarball}" 2> "${UCL_ERR_FILE}" &&
-	grep -q "Download completed" "${UCL_ERR_FILE}" &&
-	tar -C "${ABL_UPD_DIR}" -xzf "${tarball}" &&
-	fetch_dir="$(find "${ABL_UPD_DIR}/" -type d -name "lynxthecat-adblock-lean-*")"
+	rm -f "${ucl_err_file}" "${tarball}"
+	rm -rf "${fetch_dir}/lynxthecat-adblock-lean-"*
+	try_mkdir -p "${fetch_dir}" || return 1
+
+	uclient-fetch "${fetch_tarball_url}" -O "${tarball}" 2> "${ucl_err_file}" &&
+	grep -q "Download completed" "${ucl_err_file}" &&
+	tar -C "${fetch_dir}" -xzf "${tarball}" &&
+	extract_dir="$(find "${fetch_dir}/" -type d -name "lynxthecat-adblock-lean-*")" &&
+		[ -n "${extract_dir}" ] && [ "${extract_dir}" != "/" ]
 	fetch_rv=${?}
+	rm -f "${tarball}"
 
-	[ "${fetch_rv}" != 0 ] && [ -s "${UCL_ERR_FILE}" ] && ! grep -q "Download completed" "${UCL_ERR_FILE}" &&
-		reg_failure "uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'."
-	rm -f "${UCL_ERR_FILE}"
-	eval "${1}"='${fetch_dir}'
-	: "${fetch_dir}" # silence shellcheck warning
+	[ "${fetch_rv}" != 0 ] && [ -s "${ucl_err_file}" ] &&
+		log_msg "uclient-fetch output: ${_NL_}$(cat "${ucl_err_file}")."
+	rm -f "${ucl_err_file}"
+
+	[ "${fetch_rv}" = 0 ] && {
+		mv "${extract_dir:-?}"/* "${dist_dir:-?}/" ||
+			{ rm -rf "${extract_dir:-?}"; reg_failure "Failed to move files to dist dir."; return 1; }
+	}
+	rm -rf "${extract_dir:-?}"
+
 	return ${fetch_rv}
 }
 
 # 1 - path to distribution dir
-# 2 - version string to write to files
-install_abl_files()
+# 2 - version
+# 3 - update channel
+install_abl_files_2()
 {
-	local file preinst_path new_files curr_files
-	local dist_dir="${1}" version="${2}"
+	inst_failed()
+	{
+		[ -n "${1}" ] && reg_failure "${1}"
+		reg_failure "Failed to install new files."
+	}
 
-	# read new files list
-	read_str_from_file -d -v new_files -f "${dist_dir}/inst_files" -a 2 || return 1
+	local file preinst_path new_file_list exec_files='' \
+		preinst_reg_file="${dist_dir}/preinst_reg.md5" \
+		dist_dir="${1}" version="${2}" upd_channel="${3}"
 
-	# compile current files list
-	curr_files="${ABL_SERVICE_PATH}"
-	for file in ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}
+	[ -n "${1}" ] && [ -n "${2}" ] && [ -n "${3}" ] || { inst_failed "Missing arguments."; return 1; }
+	log_msg "" "Installing new files..."
+
+	# get the new file list
+	print_file_list ALL > "${curr_dist_dir}/new_file_list" &&
+	exec_files="$(print_file_list EXEC)" &&
+	new_file_list="$(cat "${dist_dir}/new_file_list")" && [ -n "${new_file_list}" ] ||
+	{
+		rm -f "${dist_dir}/new_file_list"
+		inst_failed "Failed to read new file list."
+		return 1
+	}
+
+	## set version and update channel in component's main file
+
+	# version and update channel string replacement
+	busybox sed -i "
+		/^\s*ABL_VERSION\s*=/{s/.*/ABL_VERSION=\"${version}\"/;}
+		/^\s*UPD_CHANNEL\s*=/{s/.*/UPD_CHANNEL=\"${upd_channel}\"/;}" \
+			"${dist_dir}/adblock-lean"
+	
+	# Check for changed files
+	local changed_files='' unchanged_files='' man_changed_files=''
+
+	if [ -s "${ABL_FILES_REG_PATH}" ]
+	then
+		# prefix file paths in the reg file for md5sum comparison
+		${SED_CMD} -E "/^$/d;s~([^ 	]+$)~${dist_dir}\\1~;s~${ABL_SERVICE_PATH}~/adblock-lean~" "${ABL_FILES_REG_PATH}" > \
+			"${preinst_reg_file}"
+
+		# Detect unchanged files
+		md5sum -c "${preinst_reg_file}" 2>/dev/null |
+			${SED_CMD} -n "/:\s*OK\s*$/{s/\s*:\s*OK\s*$//;s~^\s*${dist_dir}~~;s~^/adblock-lean~${ABL_SERVICE_PATH}~;p;}" > \
+				"${dist_dir}/unchanged"
+		rm -f "${preinst_reg_file}"
+
+		# Detect manually modified files
+		man_changed_files="$(md5sum -c "${ABL_FILES_REG_PATH}" 2>/dev/null |
+			${SED_CMD} -n "/:\s*FAILED\s*$/{s/\s*:\s*FAILED\s*$//;p;}")"
+
+		# Remove manually modified files from unchanged files
+		if [ -n "${man_changed_files}" ]
+		then
+			unchanged_files="$(
+				printf '%s\n' "${man_changed_files}" | busybox awk '
+					NR==FNR {man_ch[$0];next}
+					{
+						if ($0=="" || $0 in man_ch) {next}
+						print $0
+					}
+				' - "${dist_dir}/unchanged"
+			)"
+		else
+			unchanged_files="$(cat "${dist_dir}/unchanged")"
+		fi
+		rm -f "${dist_dir}/unchanged"
+
+		# remove unchanged files from ${new_file_list} to reliably get a list of files to copy
+		changed_files="$(
+			printf '%s\n' "${unchanged_files}" | busybox awk '
+				NR==FNR {unch[$0];next}
+				{
+					if ($0=="" || $0 in unch) {next}
+					print $0
+				}
+			' - "${dist_dir}/new_file_list"
+		)"
+	else
+		changed_files="${new_file_list}"
+	fi
+
+	local IFS="${_NL_}"
+	for file in ${unchanged_files}
 	do
-		add2list curr_files "${file}" " "
+		[ -n "${file}" ] || continue
+		log_msg "File '${file}' did not change - not updating."
 	done
 
-	# delete obsolete files
-	for file in ${curr_files}
+	local mod_files_bk_dir="/tmp/abl_old_modified_files"
+	for file in ${man_changed_files}
 	do
-		if [ -f "${file}" ] && ! is_included "${file}" "${new_files}" " "
+		[ -n "${file}" ] && [ -f "${file}" ] || continue
+		log_msg -warn "File '${file}' was manually modified - overwriting."
+		if try_mkdir -p "${mod_files_bk_dir}" && cp "${file}" "${mod_files_bk_dir}/${file##*/}"
 		then
-			log_msg "Deleting obsolete file ${file}."
-			rm -f "${file}"
+			log_msg "Saved a backup copy of manually modified file to ${mod_files_bk_dir}/${file##*/}"
+		else
+			log_msg -warn "Can not create a backup copy of manually modified file '${file}' - overwriting anyway."
 		fi
 	done
 
-	for file in ${new_files}
+	# clean up obsolete files
+	if [ -n "$new_file_list" ]
+	then
+		for file in $(print_file_list ALL)
+		do
+			case "${file}" in /*) ;; *) continue; esac # only accept absolute paths
+			if [ -f "${file}" ] && ! is_included "${file}" "${new_file_list}" "${_NL_}"
+			then
+				log_msg "Deleting obsolete file ${file}."
+				rm -f "${file}"
+			fi
+		done
+	else
+		reg_failure "Failed to get new file list for post-install cleanup."
+	fi
+
+	# Copy changed files
+	for file in ${changed_files}
 	do
-		case "${file##*/}" in
-			adblock-lean) preinst_path="${dist_dir}/adblock-lean" ;;
-			*) preinst_path="${dist_dir}/${file}"
+		case "${file}" in
+			'') continue ;;
+			"${ABL_SERVICE_PATH}") preinst_path="${dist_dir}/adblock-lean" ;;
+			*) preinst_path="${dist_dir}${file}"
 		esac
 
-		# set new ABL_VERSION
-		update_version "${version}" "${preinst_path}"
-
-		if [ -f "${file}" ] && check_util md5sum && [ "$(get_md5 "${preinst_path}")" = "$(get_md5 "${file}")" ]
-		then
-			log_msg "File '${file}' did not change - not updating."
-		else
-			log_msg "Copying file '${file##*/}'."
-			try_mkdir -p "${file%/*}" && cp "${preinst_path}" "${file}" ||
-			{
-				reg_failure "Failed to copy file '${file##*/}'."
-				return 1
-			}
-		fi
+		log_msg "Copying file '${file}'."
+		try_mkdir -p "${file%/*}" && cp "${preinst_path}" "${file}" ||
+			{ inst_failed "Failed to copy file '${preinst_path}' to '${file}'."; return 1; }
 	done
 
-	chmod +x "${ABL_SERVICE_PATH}"
+	# make files executable
+	[ -n "${exec_files}" ] && {
+		set -- ${exec_files} # relying on IFS=$repl_IFS
+		for file in "${@}"
+		do
+			[ -n "${file}" ] || continue
+			chmod +x "${file}" || { inst_failed "Failed to make file '$file' executable."; return 1; }
+		done
+	}
+
+	# save the md5sum registry file if needed
+	if [ -n "${changed_files}" ] || [ ! -s "${ABL_FILES_REG_PATH}" ]
+	then
+		# make md5sum registry of new files
+		# relying on IFS=$repl_IFS
+		# shellcheck disable=SC2046
+		set -- $(
+			printf '%s\n' "${new_file_list}" |
+			busybox sed "/^$/d;s~^\s*${ABL_SERVICE_PATH}\s*$~/adblock-lean~;s~^\s*~${dist_dir}~"
+		)
+		IFS="${DEFAULT_IFS}"
+		md5sums="$(md5sum "$@")" && [ -n "${md5sums}" ] &&
+		try_mkdir -p "${ABL_FILES_REG_PATH%/*}" &&
+		printf '%s\n' "${md5sums}" |
+			busybox sed "s~\s${dist_dir}~ ~;s~\s/adblock-lean$~ ${ABL_SERVICE_PATH}~" > "${ABL_FILES_REG_PATH}" ||
+				{ inst_failed "Failed to register new files."; return 1; }
+	fi
+	IFS="${DEFAULT_IFS}"
+
 	:
 }
 
@@ -1100,9 +1383,7 @@ get_config_format()
 
 version()
 {
-	local version='' upd_channel=''
-	get_abl_version "${ABL_SERVICE_PATH}" version upd_channel
-	print_msg "adblock-lean version: '${version}', update channel: '${upd_channel}'."
+	print_msg "adblock-lean version: '${ABL_VERSION}', update channel: '${UPD_CHANNEL}'."
 }
 
 gen_config()
@@ -1190,9 +1471,7 @@ boot()
 
 start()
 {
-	local version
-	get_abl_version "${ABL_SERVICE_PATH}" version
-	reg_action -purple "Starting adblock-lean, version ${version}."
+	reg_action -purple "Starting adblock-lean, version ${ABL_VERSION}."
 	init_command start || exit 1
 
 	if [ "${RANDOM_DELAY}" = "1" ]
@@ -1200,6 +1479,12 @@ start()
 		random_delay_mins=$(($(hexdump -n 1 -e '"%u"' </dev/urandom)%60))
 		reg_action -purple "Delaying adblock-lean by: ${random_delay_mins} minutes (thundering herd prevention)." || exit 1
 		sleep "${random_delay_mins}m"
+	fi
+
+	if [ "${ABL_VERSION}" = dev ]
+	then
+		reg_action -purple "Completing adblock-lean version upgrade or initial setup..."
+		update || exit 1
 	fi
 
 	try_export_existing_blocklist
@@ -1276,7 +1561,7 @@ reload()
 # 4 - adblock-lean is stopped
 status()
 {
-	local run_state version active_entries_cnt=0 active_entries_cnt_human dnsmasq_status=''
+	local run_state active_entries_cnt=0 active_entries_cnt_human dnsmasq_status=''
 	init_command status || exit 1
 	check_lock
 	case ${?} in
@@ -1287,8 +1572,7 @@ status()
 	esac
 	get_abl_run_state
 	run_state=${?}
-	get_abl_version "${ABL_SERVICE_PATH}" version
-	log_msg -purple "" "adblock-lean (${version}) status:"
+	log_msg -purple "" "adblock-lean (${ABL_VERSION}) status:"
 	case ${run_state} in
 		0) ;;
 		1) reg_failure "Failed to check adblock-lean run state." ;;
@@ -1367,15 +1651,15 @@ resume()
 }
 
 # optional: '-s <path>' to simulate update (intended for testing: service adblock-lean update -s <path_to_new_ver> -v <version>)
-# optional: -v [latest|snapshot|v<version>|tag=<github_tag>|commit=<commit_hash>]
+# optional: -v [latest|snapshot|<version>|branch=<github_branch>|commit=<commit_hash>]
 # optional: '-f' to skip calling stop()
 update()
 {
 	# unset vars and functions from current version to have a clean slate with the new version
 	clean_abl_env()
 	{
-		unset ABL_LIB_FILES ABL_EXTRA_FILES LIBS_SOURCED CONFIG_FORMAT libs_missing
-		unset -f abl_post_update_1 abl_post_update_2 load_config update source_libs
+		unset ABL_LIB_FILES ABL_EXTRA_FILES ABL_EXEC_FILES LIBS_SOURCED CONFIG_FORMAT
+		unset -f abl_post_update_1 abl_post_update_2 load_config update source_libs install_abl_files install_abl_files_2
 	}
 
 	upd_failed()
@@ -1400,14 +1684,21 @@ update()
 
 	init_command update || { upd_failed; return 1; }
 
-	local file version='' force_update='' dist_dir='' ref='' tarball_url='' upd_channel='' prev_config_format upd_config_format
+	local file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
+		upd_channel='' req_upd_channel='' force_upd_channel='' force_update='' \
+		prev_config_format upd_config_format
 
-	while getopts ":s:v:f" opt; do
+	IGNORE_CACHE=
+	while getopts ":s:v:U:W:fi" opt
+	do
 		case ${opt} in
-			s) SIM_PATH=${OPTARG} ;;
-			v) version=${OPTARG} ;;
+			s) export sim_path="$OPTARG" ;;
+			v) ver_str_arg=$OPTARG force_update=1 ;;
+			U) force_upd_channel=$OPTARG force_update=1 ;;
+			W) req_ver=$OPTARG force_update=1 ;;
 			f) force_update=1 ;;
-			*) unexp_arg "-${OPTARG}"; return 1
+			i) IGNORE_CACHE=1 ;; # global var
+			*) unexp_arg "$OPTARG"; return 1
 		esac
 	done
 	shift $((OPTIND-1))
@@ -1415,33 +1706,63 @@ update()
 
 	[ -z "${force_update}" ] && stop -noexit
 
+	# parse version string from arguments into $req_upd_channel, $req_ver
+	case "${ver_str_arg}" in
+		'') ;;
+		release)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		snapshot)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		commit=*)
+			req_upd_channel="${ver_str_arg}" req_ver="${ver_str_arg#*=}" ;;
+		branch=*)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		[0-9]*|v[0-9]*)
+			req_upd_channel=release
+			req_ver="${ver_str_arg#*=}"
+			req_ver="${req_ver#v}"
+			;;
+		*)
+			upd_failed "Invalid version string '${ver_str_arg}'."
+			return 1
+	esac
+
 	rm -rf "${ABL_UPD_DIR:-???}"
 	try_mkdir -p "${ABL_UPD_DIR}" || { upd_failed; return 1; }
 
-	if [ -n "${SIM_PATH}" ]
+	upd_channel="${req_upd_channel:-"${UPD_CHANNEL}"}"
+	upd_channel="${force_upd_channel:-"${upd_channel}"}"
+	upd_channel="${upd_channel:-"release"}"
+
+	dist_dir="${ABL_UPD_DIR}/dist"
+	try_mkdir -p "${dist_dir}" || { upd_failed; return 1; }
+
+	if [ -n "${sim_path}" ]
 	then
-		print_msg -yellow "Running in simulation mode."
-		[ -d "${SIM_PATH}" ] || { upd_failed "Directory '${SIM_PATH}' does not exist."; return 1; }
-		[ -n "${version}" ] || { upd_failed "Specify new version."; return 1; }
-		upd_channel=release ref="${version}"
-		dist_dir="${ABL_UPD_DIR}/simulation"
-		try_mkdir -p "${dist_dir}" || { upd_failed; return 1; }
-		cp -rT "${SIM_PATH}" "${dist_dir}"
+		print_msg -yellow "Updating in simulation mode."
+		[ -d "${sim_path}" ] || { upd_failed "Update simulation directory '${sim_path}' does not exist."; return 1; }
+		[ -n "${ver_str_arg}" ] || { upd_failed "Specify new version string."; return 1; }
+		upd_ver="${ver_str_arg}"
+
+		[ -d "${sim_path}" ] || { upd_failed "Simulation source directory doesn't exist."; return 1; }
+		cp -rT "${sim_path}" "${dist_dir}"
+		log_msg "" "Updating adblock-lean to version '${upd_ver}' (update channel: '${upd_channel}')."
 	else
-		get_abl_version "${ABL_SERVICE_PATH}" _ upd_channel
-		local def_version
+		get_ref "${upd_channel}" "${req_ver}" upd_ver tarball_url ver_type || { upd_failed; return 1; }
 		case "${upd_channel}" in
-			release) def_version=latest ;;
-			snapshot) def_version=snapshot ;;
-			*) def_version=latest
+			commit=*)
+				# set update channel to 'commit=<full_commit_hash>'
+				upd_channel="${upd_channel%=*}=${upd_ver}"
 		esac
-		: "${version:="${def_version}"}"
-		get_gh_ref_data "${version}" ref tarball_url upd_channel &&
-		fetch_abl_dist dist_dir "${tarball_url}" "${ref}" || { upd_failed; return 1; }
+		log_msg "" "Downloading adblock-lean, ${ver_type} '${upd_ver}' (update channel: '${upd_channel}')."
+		fetch_abl_dist "${tarball_url}" || { upd_failed; return 1; }
 	fi
 
+	local config_format_changed=
 	prev_config_format="${CONFIG_FORMAT#v}"
 	upd_config_format="$(get_config_format < "${dist_dir}/adblock-lean")"
+	[ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && [ "${upd_config_format}" != "${prev_config_format}" ] &&
+		config_format_changed=1
 
 	unset action ABL_CMD # prevents infinite loop
 
@@ -1460,32 +1781,42 @@ update()
 		# call abl_post_update_1() in new version
 		check_func abl_post_update_1 && abl_post_update_1
 
-		printf '%s\n' "${ABL_SERVICE_PATH} ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}" > "${curr_dist_dir}/inst_files"
-
-		if [ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && [ "${upd_config_format}" != "${prev_config_format}" ]
-		then
+		[ -n "${config_format_changed}" ] &&
 			failsafe_log "NOTE: config format has changed from v${prev_config_format} to v${upd_config_format}."
-			# load config and call abl_post_update_2() in new version
-			if { ! check_func source_libs || source_libs "${curr_dist_dir}${ABL_LIB_DIR}" "${curr_dist_dir}"; } &&
-					check_func load_config
-			then
-				load_config
-				check_func abl_post_update_2 && abl_post_update_2
-			else
-				failsafe_log "Please run 'service adblock-lean start' to initialize the new config."
-			fi
-		fi
-		:
-	) 1>/dev/null || { upd_failed "Failed to source the new version of adblock-lean. Update is cancelled."; return 1; }
 
-	install_abl_files "${dist_dir}" "${upd_channel}_${ref}" || { upd_failed; return 1; }
+		# install v0.6.0 or newer via a call to function in fetched script
+		if check_func install_abl_files_2
+		then
+			install_abl_files_2 "${curr_dist_dir}" "${upd_ver}" "${upd_channel}" || exit 2
+		elif check_func install_abl_files
+		then
+			printf '%s\n' "${ABL_SERVICE_PATH} ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}" > "${curr_dist_dir}/inst_files"
+			install_abl_files "${curr_dist_dir}" "${upd_channel}_${upd_ver}" || exit 2
+		else
+			cp "${curr_dist_dir}/adblock-lean" "${ABL_SERVICE_PATH}" || exit 2
+		fi
+
+		# call abl_post_update_2() in new version
+		check_func abl_post_update_2 && abl_post_update_2
+
+		:
+	) 1>/dev/null
+
+	case $? in
+		0) ;;
+		1)
+			upd_failed "Failed to source the new version of adblock-lean. Update is cancelled."
+			return 1 ;;
+		2) upd_failed; return 1 ;;
+	esac
+
 	rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
 
 	# shellcheck disable=SC2031
 	[ -n "${UPD_SOURCED}" ] && return 0
 
 	enable || return 1
-	log_msg -green "adblock-lean has been updated to version '${version}'."
+	log_msg -green "adblock-lean has been updated to version '${upd_ver}'."
 
 	if [ -n "${DO_DIALOGS}" ]
 	then


### PR DESCRIPTION
This implements lessons learned from porting the update system to qosmate:
- Rather than storing version string in all installed files, only store it in the main script and use md5sum to verify files integrity
- This way, when updating to following versions, only files which actually changed will be written to flash
- Store the update channel and the version in separate variables
- Support `-v branch=<branch>` option when calling `update`

The implementation is not yet complete - creating this branch for testing in the meantime.