### PR TITLE
Improve update and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wil
 ### Blocklist compression
 - By default, adblock-lean uses compression while processing downloaded blocklist/allowlist parts, and compresses the final blocklist before loading it into dnsmasq. This helps to reduce memory use.
 - Supported compression utilities: Busybox gzip (every OpenWrt system has this built-in), GNU gzip, pigz and zstd. The latter two utilities support multithreaded compression.
-- adblock-lean automatically sets parameters for any of the supported utilities for reasonable balance between speed and memory usage. You can specify your preferred compression utility in the `compression_util` option (default is `gzip`). You can also specify parameters to pass to the compression utility, separately for intermediate compression (`intermediate_compression_options`) and for the final blocklist compression (`final_compression_options`).
+- adblock-lean automatically sets parameters for any of the supported utilities to provide a reasonable balance between speed and memory usage. You can specify your preferred compression utility in the `compression_util` option (default is `gzip`). You can also specify parameters to pass to the compression utility, separately for intermediate compression (`intermediate_compression_options`) and for the final blocklist compression (`final_compression_options`).
 - Final blocklist compression depends on appropriate addnmount entries existing in `/etc/config/dhcp`. After changing the compression utility in the config file, make sure to run `service adblock-lean setup` in order to update the addnmount entries (answer `e` when asked whether to create new config or use existing config).
 
 ## Whitelist mode

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ blocklist_urls="https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wil
 
 ### Blocklist compression
 - By default, adblock-lean uses compression while processing downloaded blocklist/allowlist parts, and compresses the final blocklist before loading it into dnsmasq. This helps to reduce memory use.
-- Supported compression utilities: Busybox gzip (every OpenWrt system has this built-in), GNU gzip, pigz and zstd. The latter 2 utilities support multithreaded compression.
+- Supported compression utilities: Busybox gzip (every OpenWrt system has this built-in), GNU gzip, pigz and zstd. The latter two utilities support multithreaded compression.
 - adblock-lean automatically sets parameters for any of the supported utilities for reasonable balance between speed and memory usage. You can specify your preferred compression utility in the `compression_util` option (default is `gzip`). You can also specify parameters to pass to the compression utility, separately for intermediate compression (`intermediate_compression_options`) and for the final blocklist compression (`final_compression_options`).
 - Final blocklist compression depends on appropriate addnmount entries existing in `/etc/config/dhcp`. After changing the compression utility in the config file, make sure to run `service adblock-lean setup` in order to update the addnmount entries (answer `e` when asked whether to create new config or use existing config).
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,9 @@ service adblock-lean start
 adblock-lean implements a flexible update system which supports following options (use with `service adblock-lean update`):
 - `-y` : pre-approve any configuration changes suggested by the version update mechanism and automatically start the updated adblock-lean version
 - `-f` : update without calling the `stop` command first and do not load adblock-lean library scripts - this is mainly useful to fix a broken installation
-- `-v < [version]|[update_channel]|commit=[commit_hash] >` : either install a specific adblock-lean version (for example `-v 0.7.2`); or specify an update channel (either `-v release` or `-v snapshot` or `-v branch=<branch_name>`) - this will install the latest version from the corresponding update channel and change the version update behavior so it checks in that update channel for future updates; or install a version corresponding to a specific commit to the `master` branch. These options are mainly helpful for testing. Most users should be fine with the default update behavior which is following the `release` update channel.
+- `-v < [version]|[update_channel]|commit=[commit_hash] >` : either install a specific adblock-lean version (for example `-v 0.7.2`); or specify an update channel (either `-v release` or `-v snapshot` or `-v branch=<branch_name>`) - this will install the latest version from the corresponding update channel and change the version update behavior so it checks in that update channel for future updates; or install a version corresponding to a specific commit to the `master` branch. 
+
+These options are mainly helpful for testing. Most users should be fine with the default update behaviour which follows the `release` update channel.
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚔ adblock-lean
 
-adblock-lean is a low maintenance (almost set and forget), powerful and ultra-efficient adblocking solution for OpenWrt that **does not mandate any external dependencies** or introduce unecessary bloat. It is  **highly optimized for RAM & CPU efficiency** during blocklist download & processing, and does not remain running in memory after execution.  adblock-lean is designed to leverage the [major rewrite of the DNS server and domain handling code](https://thekelleys.org.uk/dnsmasq/CHANGELOG) associated with dnsmasq 2.86, which drastically improves dnsmasq performance and reduces memory footprint. This **facilitates the use of very large blocklists even for low spec, low performance devices.**
+adblock-lean is a low maintenance (almost set and forget), powerful and ultra-efficient adblocking solution for OpenWrt that **does not mandate any external dependencies** or introduce unnecessary bloat. It is  **highly optimized for RAM & CPU efficiency** during blocklist download & processing, and does not remain running in memory after execution.  adblock-lean is designed to leverage the [major rewrite of the DNS server and domain handling code](https://thekelleys.org.uk/dnsmasq/CHANGELOG) associated with dnsmasq 2.86, which drastically improves dnsmasq performance and reduces memory footprint. This **facilitates the use of very large blocklists even for low spec, low performance devices.**
 
 If you like adblock-lean and can benefit from it, then please leave a ⭐ (top right) and become a [stargazer](https://github.com/lynxthecat/adblock-lean/stargazers)! And feel free to post any feedback on the official OpenWrt thread [here](https://forum.openwrt.org/t/adblock-lean-set-up-adblock-using-dnsmasq-blocklist/157076). Thank you for your support.
 
@@ -18,6 +18,7 @@ If you like adblock-lean and can benefit from it, then please leave a ⭐ (top r
 - [Testing advert blocking](#testing-advert-blocking)
 - [Preserve adblock-lean files and config across OpenWrt upgrades](#preserve-adblock-lean-files-and-config-across-openwrt-upgrades)
 - [adblock-lean version updates](#adblock-lean-version-updates)
+- [Advanced version update options](#advanced_version_update_options)
 - [Uninstalling](#uninstalling)
 
 ## Features
@@ -413,6 +414,13 @@ After updating adblock-lean, run the command:
 ```bash
 service adblock-lean start
 ```
+
+## Advanced version update options
+
+adblock-lean implements a flexible update system which supports following options (use with `service adblock-lean update`):
+- `-y` : pre-approve any configuration changes suggested by the version update mechanism and automatically start the updated adblock-lean version
+- `-f` : update without calling the `stop` command first and do not load adblock-lean library scripts - this is mainly useful to fix a broken installation
+- `-v < [version]|[update_channel]|commit=[commit_hash] >` : either install a specific adblock-lean version (for example `-v 0.7.2`); or specify an update channel (either `-v release` or `-v snapshot` or `-v branch=<branch_name>`) - this will install the latest version from the corresponding update channel and change the version update behavior so it checks in that update channel for future updates; or install a version corresponding to a specific commit to the `master` branch. These options are mainly helpful for testing. Most users should be fine with the default update behavior which is following the `release` update channel.
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -25,25 +25,21 @@ If you like adblock-lean and can benefit from it, then please leave a ⭐ (top r
 
 adblock-lean includes the following features:
 
+- automated interactive setup with presets for devices with different memory capacity (64MiB/128MiB/256MiB/512MiB/1024MiB and higher)
 - supports multiple blocklist files downloaded from user-specified urls
-- supports local blocklist
+- supports local user-specified blocklist
 - supports multiple allowlist files downloaded from user-specified urls
-- supports local allowlist
+- supports local user-specified allowlist
 - supports blocklist compression (which significantly reduces memory consumption) by leveraging the new conf-script functionality of dnsmasq
 - removal of domains found in the allowlist from the blocklist files
 - combining all downloaded and local lists into one final blocklist file
-- check that each individual blocklist and allowlist file does not exceed configurable maximum size
-- check that the total blocklist size does not exceeed configurable maximum file size
-- check for rogue entries in blocklist file parts (e.g. check for redirection to specific IP)
-- check that line count in blocklist file exceeds configurable minimum (default: 100,000)
-- save a compressed copy of the previous blocklist file, then load the new combined blocklist file into dnsmasq
-- perform checks on restarted dnsmasq with new blocklist file
-- revert to previous blocklist file if checks fail
-- if checks on previous blocklist file also fail then revert to not using any blocklist file
-- implements optional calls to user-configurable script on success or failure (for example to send an email report)
-- automatically check for application updates and self update functionality
-- config keys and values validation and optional automatic config repair when problems are detected
-- automated interactive setup
+- configurable minimum and maximum blocklist/allowlist parts and final blocklist size and lines count constraints designed to prevent memory over-use and minimize the chance of loading incomplete blocklist because of a download error
+- various checks and sanitization of downloaded blocklist/allowlist parts designed to avoid loading incompatible, corrupted or malicious data
+- during blocklist update, a compressed copy of the previous blocklist file is kept until the new blocklist passes all checks. If checks fail, adblock-lean restores the previous blocklist.
+- supports optional calls to user-configurable script on success or failure (for example to send an email report)
+- automatic check for application updates and self update functionality (when authorized by the user)
+- config validation and optional automatic config repair when problems are detected
+- strong emphasis on reliability, error checking and reporting, code quality and readability
 
 ## Installation on OpenWrt
 

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
-# shellcheck disable=SC3043,SC1090
+# shellcheck disable=SC3043,SC1090,SC3044
 
 # silence shellcheck warnings
 : "${LIBS_SOURCED}"
 
+ABL_INSTALLER_VER=2
+ABL_UPD_DIR="/var/run/adblock-lean-update"
 ABL_CONFIG_DIR=/etc/adblock-lean
 ABL_PID_DIR=/tmp/adblock-lean
 ABL_CONFIG_FILE=${ABL_CONFIG_DIR}/config
@@ -12,7 +14,12 @@ ABL_DIR=/var/run/adblock-lean
 ABL_INST_DIR="${ABL_DIR}/remote_abl"
 UCL_ERR_FILE="${ABL_DIR}/uclient-fetch_err"
 : "${ABL_REPO_AUTHOR:=lynxthecat}"
-ABL_GH_URL_API=https://api.github.com/repos/${ABL_REPO_AUTHOR}/adblock-lean
+ABL_GH_URL_API="https://api.github.com/repos/${ABL_REPO_AUTHOR}/adblock-lean"
+ABL_MAIN_BRANCH=master
+ABL_FILES_REG_PATH=/etc/adblock-lean/abl-reg.md5
+
+# silence shellcheck warnings
+: "${ABL_INSTALLER_VER}" "${ABL_CONFIG_FILE}"
 
 LC_ALL=C
 DEFAULT_IFS='	 
@@ -22,15 +29,21 @@ _NL_='
 IFS="${DEFAULT_IFS}"
 _DELIM_="$(printf '\35')"
 
-if [ -z "${MSGS_DEST}" ] && [ -t 0 ]
+if [ -z "${MSGS_DEST}" ]
 then
-	MSGS_DEST=/dev/tty
-else
-	MSGS_DEST=/dev/null
+	if [ -t 0 ]
+	then
+		export MSGS_DEST=/dev/tty
+	else
+		export MSGS_DEST=/dev/null
+	fi
 fi
 
+# $luci_skip_dialogs is set if sourced from external RPC script for luci
+[ -n "${luci_skip_dialogs}" ] && export ABL_LUCI_SOURCED=1
+
 DO_DIALOGS=
-[ -z "${luci_skip_dialogs}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
+[ -z "${ABL_LUCI_SOURCED}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
 
 if sed --version 2>/dev/null | grep -qe '(GNU sed)'
 then
@@ -46,8 +59,23 @@ cleanup_and_exit()
 {
 	trap - INT TERM EXIT
 	rm -rf "${ABL_DIR}" "${ABL_PID_DIR}"
-	[ -n "${luci_sourced}" ] && abl_inst_luci_exit "${1}"
+	[ -n "${ABL_LUCI_SOURCED}" ] && abl_inst_luci_exit "${1}"
 	exit "${1}"
+}
+
+# check if var names are safe to use with eval
+are_var_names_safe() {
+	local var_name
+	for var_name in "${@}"
+	do
+		case "${var_name}" in *[!a-zA-Z_]*) reg_falure "Invalid var name '${var_name}'."; return 1; esac
+	done
+	:
+}
+
+check_func()
+{
+	[ "$(type "${1}" 2>/dev/null | head -n1)" = "${1} is a function" ]
 }
 
 check_util()
@@ -62,19 +90,14 @@ pick_opt()
 {
 	while :
 	do
-		printf %s "$1: " 1>${MSGS_DEST}
+		printf %s "${1}: " 1>${MSGS_DEST}
 		read -r REPLY
-		case "$REPLY" in *[!A-Za-z0-9_]*) printf '\n%s\n\n' "Please enter $1" 1>${MSGS_DEST}; continue; esac
-		eval "case \"$REPLY\" in 
-				$1) return 0 ;;
-				*) printf '\n%s\n\n' \"Please enter $1\" 1>${MSGS_DEST}
+		case "${REPLY}" in *[!A-Za-z0-9_]*) printf '\n%s\n\n' "Please enter ${1}" 1>${MSGS_DEST}; continue; esac
+		eval "case \"${REPLY}\" in 
+				${1}) return 0 ;;
+				*) printf '\n%s\n\n' \"Please enter ${1}\" 1>${MSGS_DEST}
 			esac"
 	done
-}
-
-get_md5()
-{
-	md5sum "${1}" | cut -d' ' -f1
 }
 
 # checks if string $1 is included in newline-separated list $2
@@ -92,8 +115,8 @@ is_included() {
 
 try_mv()
 {
-	[ -z "${1}" ] || [ -z "${2}" ] && { reg_failure "try_mv(): bad arguments."; return 1; }
-	mv -f "${1}" "${2}" || { reg_failure "Failed to move '${1}' to '${2}'."; return 1; }
+	[ -z "${1}" ] || [ -z "${2}" ] && { reg_falure "try_mv(): bad arguments."; return 1; }
+	mv -f "${1}" "${2}" || { reg_falure "Failed to move '${1}' to '${2}'."; return 1; }
 	:
 }
 
@@ -104,7 +127,7 @@ try_mkdir()
 	local p=
 	[ "${1}" = '-p' ] && { p='-p'; shift; }
 	[ -d "${1}" ] && return 0
-	mkdir ${p} "${1}" || { reg_failure "Failed to create directory '${1}'."; return 1; }
+	mkdir ${p} "${1}" || { reg_falure "Failed to create directory '${1}'."; return 1; }
 	:
 }
 
@@ -147,10 +170,79 @@ log_msg()
 	:
 }
 
-reg_failure()
+reg_falure()
 {
 	log_msg -err "" "${1}"
 	luci_errors="${luci_errors}${1}${_NL_}"
+}
+
+# Get version and update channel of adblock-lean file
+# Assigns vars $2 = version, $3 = update channel
+# 1 - path to adblock-lean service file
+# Return codes:
+# 1 - error
+# 2 - no version found
+# 3 - new version format
+# 4 - old version format
+get_abl_version()
+{
+	get_ver_str()
+	{
+		local key_ptrn='' migr_ptrn=''
+		case "${1}" in
+			version)
+				key_ptrn="\\s*ABL_VERSION"
+				[ "${3}" = '-o' ] && migr_ptrn='s/^[^_]*_//;' ;;
+			upd_channel)
+				key_ptrn="\\s*ABL_UPD_CHANNEL"
+				[ "${3}" = '-o' ] && { key_ptrn="\\s*ABL_VERSION" migr_ptrn='s/_.*//;'; }
+		esac
+		[ "${3}" = '-o' ] && key_ptrn="\\s*#${key_ptrn}"
+
+		${SED_CMD} -n "/^${key_ptrn}=/{s/^${key_ptrn}=//;s/#.*$//;s/\"//g;${migr_ptrn}p;:1 n;b1;}" "${2}"
+	}
+
+	local gv_ver='' gv_upd_ch='' gv_rv=''
+	if [ -n "${2}${3}" ]
+	then
+		are_var_names_safe "${2}" "${3}" || return 1
+		eval "${2}"='' "${3}"=''
+	fi
+	# version format in v0.7.2 and later
+	if grep -q '^\s*ABL_UPD_CHANNEL=' "${1}" &&
+		gv_upd_ch="$(get_ver_str upd_channel "${1}")" &&
+		gv_ver="$(get_ver_str version "${1}")" &&
+		[ -n "${gv_upd_ch}" ] && [ -n "${gv_ver}" ]
+	then
+		gv_rv=3
+	# version format in v0.6.0 - v0.7.1
+	elif grep -q '^\s*#\s*ABL_VERSION=' "${1}" &&	
+		gv_upd_ch="$(get_ver_str upd_channel "${1}" -o)" &&
+		gv_ver="$(get_ver_str version "${1}" -o)" &&
+		[ -n "${gv_upd_ch}" ] && [ -n "${gv_ver}" ]
+	then
+		gv_rv=4
+	else
+		gv_rv=2
+	fi
+	[ -n "${2}${3}" ] && eval "${2}"='${gv_ver}' "${3}"='${gv_upd_ch}'
+	return ${gv_rv}
+}
+
+inst_failed()
+{
+	local fail_msg="${1}"
+	[ -s "${UCL_ERR_FILE}" ] && fail_msg="${fail_msg} uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'"
+	[ -n "${fail_msg}" ] && reg_falure "${fail_msg}"
+	reg_falure "Failed to install adblock-lean."
+	rm -rf "${ABL_INST_DIR}" "${UCL_ERR_FILE}"
+	exit 1
+}
+
+failsafe_log()
+{
+	printf '%s\n' "${1}" > "${MSGS_DEST:-/dev/tty}"
+	logger -t adblock-lean "${1}"
 }
 
 # shellcheck disable=SC2120
@@ -161,327 +253,653 @@ get_config_format()
 	local conf_form_sed_expr='/^[ \t]*(CONFIG_FORMAT|#[ \t]*config_format)=v/{s/.*=v//;p;:1 n;b1;}'
 	if [ -n "${1}" ]
 	then
-		$SED_CMD -En "${conf_form_sed_expr}" "${1}"
+		${SED_CMD} -En "${conf_form_sed_expr}" "${1}"
 	else
-		$SED_CMD -En "${conf_form_sed_expr}"
+		${SED_CMD} -En "${conf_form_sed_expr}"
 	fi
 }
 
-# 1 - new version
-# 2 - path to file
-update_version()
-{
-	${SED_CMD} -i "/^\s*#\s*ABL_VERSION=/{s/.*/# ABL_VERSION=${1}/;:1 n;b1;}" "${2}"
-}
-
-# Get GitHub ref and tarball url for specified version
-# 1 - [latest|snapshot|v<version>|tag=<github_tag>|commit=<commit_hash>]
+# Get GitHub ref and tarball url for specified component, update channel, branch and version
+# 1 - update channel: release|snapshot|branch=<github_branch>|commit=<commit_hash>
+# 2 - version (optional): [version|commit_hash]
 # Output via variables:
-#   $2 - github ref, $3 - tarball url, $4 - update channel
-get_gh_ref_data()
+#   $3 - github ref (version/commit hash), $4 - tarball url, $5 - version type ('version' or 'commit')
+get_gh_ref()
 {
-	local me=get_gh_ref_data ref_fetch_url jsonfilter_ptrn commit version="${1}"
-	local gh_ref=''  gh_channel=''
-	unset "${2}" "${3}" "${4}"
+	set_res_vars()
+	{
+		# validate resulting ref
+		case "${gr_ref}" in
+			*[^"${_NL_}"]*"${_NL_}"*[^"${_NL_}"]*)
+				reg_falure "Got multiple download URLs for version '${gr_version}'." \
+					"If using commit hash, please specify the complete commit hash string."
+				return 1 ;;
+			''|*[!a-zA-Z0-9._-]*)
+				reg_falure "Failed to get GitHub download URL for ${gr_ver_type} '${gr_version}' (update channel: '${gr_channel}')."
+				return 1
+		esac
 
-	case "${version}" in
-		snapshot)
-			ref_fetch_url="${ABL_GH_URL_API}/commits/master"
-			jsonfilter_ptrn='@.sha' # latest commit is first on the list
-			gh_channel=snapshot ;;
-		latest)
-			ref_fetch_url="${ABL_GH_URL_API}/releases"
-			jsonfilter_ptrn='@[@.prerelease=false]' # ignore pre-releases
-			gh_channel=release ;;
-		v[0-9]*)
-			gh_ref="${version}"
-			gh_channel=release ;;
-		tag=*)
-			gh_ref="${version#tag=}"
-			gh_channel=tag ;;
-		commit=*)
-			commit="${version#commit=}"
-			gh_ref="${commit%"${commit#???????}"}" # trim commit hash to 7 characters
-			gh_channel=commit ;;
-		*) reg_failure "${me}: invalid version '${version}'."; return 1
+		case "${gr_channel}" in
+			release|latest) gr_channel=release gr_version="${gr_ref#v}" ;;
+			*) gr_version="${gr_ref}"
+		esac
+
+		eval "${3}"='${gr_version}' "${4}"='${ABL_GH_URL_API}/tarball/${gr_ref}' "${5}"='${gr_ver_type}' \
+			"prev_ref"='${gr_ref}' "prev_ver_type"='${gr_ver_type}' \
+			"prev_upd_channel"='${gr_channel}' "prev_version"='${gr_version}'
+	}
+
+	local gr_branch gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
+		gr_fetch_tmp_dir="${ABL_UPD_DIR}/ref_fetch" \
+		prev_ref prev_ver_type prev_upd_channel prev_version \
+		gr_channel="${1}" gr_version="${2}"
+
+	[ "$gr_channel" = release ] && gr_version="${gr_version#v}"
+
+	local gr_ucl_err_file="${gr_fetch_tmp_dir}/ucl_err"
+
+	are_var_names_safe "${3}" "${4}" "${5}" || return 1
+	eval "${3}='' ${4}='' ${5}=''"
+
+	eval "prev_ref=\"\${prev_ref}\"
+		prev_ver_type=\"\${prev_ver_type}\"
+		prev_upd_channel=\"\${prev_upd_channel}\"
+		prev_version=\"\${prev_version}\""
+
+	# if commit hash is specified and it's 40-char long, use it directly without API query or cache check
+	case "${gr_channel}" in
+		snapshot|branch=*|commit=*) [ "${#gr_version}" = 40 ] && gr_ref="${gr_version}"
 	esac
 
-	if [ -n "${ref_fetch_url}" ]
+	# if previously stored data exists, use it without API query or cache check
+	if [ -z "${gr_ref}" ] && [ -n "${prev_ref}" ] && [ -n "${prev_ver_type}" ] && \
+		[ "${prev_upd_channel}" = "${gr_channel}" ] && [ "${gr_version}" = "${prev_version}" ]
 	then
-		# Get ref for latest/snapshot
-		log_msg "Getting GitHub ref for ${version} version of adblock-lean from GitHub."
-		gh_ref="$(
-			uclient-fetch -q "${ref_fetch_url}" -O - 2> "${UCL_ERR_FILE}" |
-			jsonfilter -e "${jsonfilter_ptrn}" |
-			{
-				case "${version}" in
-					snapshot) head -c7 ;;
-					latest)
-						jsonfilter -a -e '@[@.target_commitish="master"].tag_name' | # get latest tag for master
-						head -n1
-				esac
-				cat 1>/dev/null
-			}
-		)"
+			gr_ref="${prev_ref}" gr_ver_type="${prev_ver_type}"
+	elif [ -z "${gr_ref}" ]
+	then
+		# ref cache
+		local cache_ttl cache_file cache_filename="${gr_version}_${gr_channel}" gr_cache_dir="/tmp/abl_cache"
+		case "${gr_channel}" in
+			commit=*) cache_ttl=2880 ;; # 48 hours
+			*) cache_ttl=10 # 10 minutes
+		esac
+
+		# clean up old cache
+		find "${gr_cache_dir:-?}" -maxdepth 1 -type f -mmin +"${cache_ttl}" -exec rm -f {} \; 2>/dev/null
+
+		# check if the query is cached
+		cache_file="$(find "${gr_cache_dir:-?}" -maxdepth 1 -type f -name "${cache_filename}" -print 2>/dev/null)"
+		case "${cache_file}" in
+			'') ;; # found nothing
+			*[^"${_NL_}"]*"${_NL_}"*[^"${_NL_}"]*)
+				# found multiple files - delete them
+				local file IFS="${_NL_}"
+				for file in ${cache_file}
+				do
+					[ -n "${file}" ] || continue
+					rm -f "${file}"
+				done
+				IFS="${DEFAULT_IFS}" ;;
+			*)
+				# found cached query
+				if [ -z "${IGNORE_CACHE}" ] && [ -f "${cache_file}" ] &&
+					read -r prev_ref prev_ver_type < "${cache_file}" &&
+					[ -n "${prev_ref}" ] && [ -n "${prev_ver_type}" ]
+				then
+					gr_ref="${prev_ref}" gr_ver_type="${prev_ver_type}"
+				else
+					rm -f "${cache_file:-???}"
+				fi
+		esac
 	fi
 
-	# validate resulting ref
-	case "${gh_ref}" in
-		''|*[!a-zA-Z0-9._-]*) reg_failure "${me}: failed to get GitHub ref for version '${version}'."; return 1
+	if [ -n "${gr_ref}" ]
+	then
+		set_res_vars "${@}" || return 1
+		return 0
+	fi
+
+	try_mkdir -p "${gr_fetch_tmp_dir}" || return 1
+	rm -f "${gr_ucl_err_file}"
+
+	case "${gr_channel}" in
+		release)
+			gr_ver_type=version
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^v${gr_version#v}$" ;;
+		snapshot)
+			gr_ver_type=commit
+			gr_branches="${ABL_MAIN_BRANCH}"
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^${gr_version}$" ;;
+		branch=*)
+			gr_ver_type=commit
+			gr_branches="${gr_channel#*=}"
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^${gr_version}$" ;;
+		commit=*)
+			gr_ver_type=commit
+			local gr_hash="${gr_channel#*=}"
+
+			if [ "${#gr_hash}" = 40 ]
+			then
+				# if upd. ch. is 'commit', the upd. ch. string includes commit hash -
+				#    if it's 40-char long, use it directly without API query
+				gr_ref="${gr_hash}"
+			else
+				gr_branches="$(
+					uclient-fetch "${ABL_GH_URL_API}/branches" -O-  2> "${gr_ucl_err_file}" |
+						{ jsonfilter -e '@[@]["name"]'; cat 1>/dev/null; }
+				)"
+				[ -n "${gr_branches}" ] || {
+					reg_falure "Failed to get adblock-lean branches via GH API (url: '${ABL_GH_URL_API}/branches')."
+					[ -f "${gr_ucl_err_file}" ] &&
+						log_msg "uclient-fetch log:${_NL_}$(cat "${gr_ucl_err_file}")"
+						rm -f "${gr_ucl_err_file}"
+					return 1
+				}
+				rm -f "${gr_ucl_err_file}"
+				gr_grep_ptrn="^${gr_hash}"
+			fi ;;
+		*)
+			reg_falure "Invalid update channel '${gr_channel}'."
+			return 1
 	esac
 
-	eval "${2}"='${gh_ref}' "${3}"='${ABL_GH_URL_API}/tarball/${gh_ref}' "${4}"='${gh_channel}'
-	: "${gh_channel}" # silence shellcheck warning
+	# Get GH ref
+	[ -z "${gr_ref}" ] && gr_ref="$(
+		case "${gr_channel}" in
+			release)
+				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${gr_ucl_err_file}" | {
+					jsonfilter -e '@[@.prerelease=false]' |
+					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
+					cat 1>/dev/null
+				} ;;
+			snapshot|branch=*|commit=*)
+				for gr_branch in ${gr_branches}
+				do
+					ref_fetch_url="${ABL_GH_URL_API}/commits?sha=${gr_branch}"
+					uclient-fetch "${ref_fetch_url}" -O- 2> "${gr_ucl_err_file}" | {
+						jsonfilter -e '@[@.commit]["url"]' |
+						${SED_CMD} 's/.*\///' # only leave the commit hash
+						cat 1>/dev/null
+					}
+				done
+		esac |
+		{
+			if [ -n "${gr_grep_ptrn}" ]
+			then
+				grep "${gr_grep_ptrn}"
+			else
+				head -n1 # get latest version or commit
+			fi
+			cat 1>/dev/null
+		}
+	)"
 
+	if [ -z "${gr_ref}" ]
+	then
+		gr_fetch_rv=1
+		reg_falure "Failed to get GitHub download URL for ${gr_ver_type} '${gr_version}' (update channel: '${gr_channel}')."
+		[ -f "${gr_ucl_err_file}" ] && log_msg "uclient-fetch output:${_NL_}$(cat "${gr_ucl_err_file}")"
+	fi
+	rm -rf "${gr_fetch_tmp_dir:-?}"
+	[ "$gr_fetch_rv" = 0 ] || return 1
+
+	# write query result to cache
+	try_mkdir -p "${gr_cache_dir}" &&
+	printf '%s\n' "${gr_ref} ${gr_ver_type}" > "${gr_cache_dir}/${cache_filename}"
+
+	set_res_vars "${@}" || return 1
 	:
 }
 
-
-# assigns path to extracted distribution directory to $1
-# 1 - var name for output
-# 2 - tarball url
-# 3 - github ref
+# Fetches and unpacks adblock-lean distribution
+# 1 - tarball url
+# 2 - distribution directory
 fetch_abl_dist()
 {
-	local fetch_tarball_url="${2}" fetch_ref="${3}"
-	local fetch_dir fetch_rv tarball="${ABL_INST_DIR}/remote_abl.tar.gz"
-	log_msg "Downloading adblock-lean, version '${fetch_ref}'."
-	rm -rf "${UCL_ERR_FILE}" "${ABL_INST_DIR}/${ABL_REPO_AUTHOR}-adblock-lean-"*
-	uclient-fetch "${fetch_tarball_url}" -O "${tarball}" 2> "${UCL_ERR_FILE}" &&
-	grep -q "Download completed" "${UCL_ERR_FILE}" &&
-	tar -C "${ABL_INST_DIR}" -xzf "${tarball}" &&
-	fetch_dir="$(find "${ABL_INST_DIR}/" -type d -name "${ABL_REPO_AUTHOR}-adblock-lean-*")"
-	fetch_rv=${?}
+	[ -n "${1}" ] && [ -n "${2}" ] || { reg_failure "fetch_abl_dist: missing arguments."; return 1; }
 
-	[ "${fetch_rv}" != 0 ] && [ -s "${UCL_ERR_FILE}" ] && ! grep -q "Download completed" "${UCL_ERR_FILE}" &&
-		reg_failure "uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'."
-	rm -f "${UCL_ERR_FILE}"
-	eval "${1}"='${fetch_dir}'
-	: "${fetch_dir}" # silence shellcheck warning
+	local tarball_url_fetch="${1}" dist_dir_fetch="${2}"
+
+	local fetch_rv extract_dir fetch_dir="${dist_dir_fetch}/fetch"
+	local  tarball="${fetch_dir}/remote_abl.tar.gz" ucl_err_file="${fetch_dir}/ucl_err" \
+
+
+	rm -f "${ucl_err_file}" "${tarball}"
+	rm -rf "${fetch_dir}/${ABL_REPO_AUTHOR}-adblock-lean-"*
+	try_mkdir -p "${fetch_dir}" || return 1
+
+	uclient-fetch "${tarball_url_fetch}" -O "${tarball}" 2> "${ucl_err_file}" &&
+	grep -q "Download completed" "${ucl_err_file}" &&
+	tar -C "${fetch_dir}" -xzf "${tarball}" &&
+	extract_dir="$(find "${fetch_dir}/" -type d -name "${ABL_REPO_AUTHOR}-adblock-lean-*")" &&
+		[ -n "${extract_dir}" ] && [ "${extract_dir}" != "/" ]
+	fetch_rv=${?}
+	rm -f "${tarball}"
+
+	[ "${fetch_rv}" != 0 ] && [ -s "${ucl_err_file}" ] &&
+		log_msg "uclient-fetch output: ${_NL_}$(cat "${ucl_err_file}")."
+	rm -f "${ucl_err_file}"
+
+	[ "${fetch_rv}" = 0 ] && {
+		mv "${extract_dir:-?}"/* "${dist_dir_fetch:-?}/" ||
+			{ rm -rf "${extract_dir:-?}"; reg_failure "Failed to move files to dist dir."; return 1; }
+	}
+	rm -rf "${extract_dir:-?}" "${fetch_dir:-?}"
+
 	return ${fetch_rv}
 }
 
-# 1 - path to distribution dir
-# 2 - version string to write to files
-install_abl_files()
+clean_abl_env()
 {
-	local file preinst_path new_files curr_files
-	local dist_dir="${1}" version="${2}"
-
-	# read new files list
-	read -r new_files < "${dist_dir}/new_files" ||
-	{
-		reg_failure "Failed to read file '${dist_dir}/new_files'."
-		return 1
-	}
-
-	# read current files list
-	if [ -f "${dist_dir}/curr_files" ]
-	then
-		read -r curr_files < "${dist_dir}/curr_files" ||
-		{
-			reg_failure "Failed to read file '${dist_dir}/curr_files'."
-			return 1
-		}
-	fi
-
-	# delete obsolete files
-	for file in ${curr_files}
-	do
-		if [ -f "${file}" ] && ! is_included "${file}" "${new_files}" " "
-		then
-			log_msg "Deleting obsolete file ${file}."
-			rm -f "${file}"
-		fi
-	done
-
-	for file in ${new_files}
-	do
-		case "${file##*/}" in
-			adblock-lean) preinst_path="${dist_dir}/adblock-lean" ;;
-			*) preinst_path="${dist_dir}/${file}"
-		esac
-
-		# set new ABL_VERSION
-		update_version "${version}" "${preinst_path}"
-
-		if [ -f "${file}" ] && check_util md5sum && [ "$(get_md5 "${preinst_path}")" = "$(get_md5 "${file}")" ]
-		then
-			log_msg "File '${file}' did not change - not updating."
-		else
-			log_msg "Copying file '${file##*/}'."
-			{ [ -d "${file%/*}" ] || try_mkdir -p "${file%/*}"; } &&
-				cp "${preinst_path}" "${file}" ||
-			{
-				reg_failure "Failed to copy file '${file##*/}'."
-				return 1
-			}
-		fi
-	done
-
-	chmod +x "${ABL_SERVICE_PATH}"
-	:
+	unset action ABL_CMD ABL_LIB_FILES ABL_EXTRA_FILES ABL_EXEC_FILES LIBS_SOURCED CONFIG_FORMAT
+	unset -f abl_post_update_1 abl_post_update_2 load_config update source_libs check_libs install_abl_files cleanup_and_exit
 }
 
-inst_failed()
+# Prints file list from adblock-lean service file
+# 1 - file path
+# 2 - file types (EXEC|ALL)
+get_file_list()
 {
-	local fail_msg="${1}"
-	[ -s "${UCL_ERR_FILE}" ] && fail_msg="${fail_msg} uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'"
-	[ -n "${fail_msg}" ] && reg_failure "${fail_msg}"
-	reg_failure "Failed to install adblock-lean."
-	rm -rf "${ABL_INST_DIR}" "${UCL_ERR_FILE}"
-}
-
-failsafe_log()
-{
-	printf '%s\n' "${1}" > "${MSGS_DEST:-/dev/tty}"
-	logger -t adblock-lean "${1}"
-}
-
-unexp_arg()
-{
-	inst_failed "abl-install: unexpected argument '${1}'."
-}
-
-
-if ${ABL_SERVICE_PATH} enabled 2>/dev/null
-then
-	${ABL_SERVICE_PATH} stop
-fi
-
-trap 'cleanup_and_exit 1' INT TERM
-trap 'cleanup_and_exit ${?}' EXIT
-
-try_mkdir -p "${ABL_DIR}" || exit 1
-
-unset VERSION DIST_DIR REF TARBALL_URL UPD_CHANNEL
-
-while getopts ":s:v:" opt; do
-	case ${opt} in
-		s) SIM_PATH=${OPTARG} ;;
-		v) VERSION=${OPTARG} ;;
-		*) unexp_arg "-${OPTARG}"; exit 1
-	esac
-done
-shift $((OPTIND-1))
-[ -z "${*}" ] || { unexp_arg "${*}"; exit 1; }
-
-rm -rf "${ABL_INST_DIR}"
-try_mkdir -p "${ABL_INST_DIR}" || { inst_failed; exit 1; }
-
-if [ -n "${SIM_PATH}" ]
-then
-	print_msg "" "Running in simulation mode."
-	[ -d "${SIM_PATH}" ] || { inst_failed "Directory '${SIM_PATH}' does not exist."; exit 1; }
-	[ -n "${VERSION}" ] || { inst_failed "Specify new version."; exit 1; }
-	UPD_CHANNEL=dev REF="${VERSION}"
-	DIST_DIR="${ABL_INST_DIR}/simulation"
-	try_mkdir -p "${DIST_DIR}" || { inst_failed; exit 1; }
-	cp -rT "${SIM_PATH}" "${DIST_DIR}"
-else
-	: "${VERSION:=latest}"
-	get_gh_ref_data "${VERSION}" REF TARBALL_URL UPD_CHANNEL &&
-	fetch_abl_dist DIST_DIR "${TARBALL_URL}" "${REF}" || { inst_failed; exit 1; }
-fi
-
-(
-	# unset vars and functions from current version to have a clean slate with the new version
-	clean_abl_env()
-	{
-		unset ABL_LIB_FILES ABL_EXTRA_FILES
-		unset -f abl_post_update_1 abl_post_update_2 get_config_format load_config
-	}
-
-	unset is_update prev_config_format
-	export pid_file=/tmp/adblock-lean/adblock-lean.pid # for compatibility with older versions
-
-	# register config format in the installed adblock-lean version
-	if [ -s "${ABL_CONFIG_FILE}" ]
-	then
-		prev_config_format="$(get_config_format < "${ABL_CONFIG_FILE}")"
-	fi
-
-	# register files list in the installed adblock-lean version
-	if [ -s "${ABL_SERVICE_PATH}" ]
-	then
-		clean_abl_env
-		is_update=1
-		touch "${DIST_DIR}/is_update"
-		curr_abl_files="${ABL_SERVICE_PATH}"
-		# shellcheck source=/dev/null
-		if . "${ABL_SERVICE_PATH}"
-		then
-			for file in ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}
-			do
-				curr_abl_files="${curr_abl_files} ${file}"
-			done
-			printf '%s\n' "${curr_abl_files}" > "${DIST_DIR}/curr_files"
-		fi
-	fi
-
 	clean_abl_env
 	# shellcheck source=/dev/null
-	. "${DIST_DIR}/adblock-lean" || { failsafe_log "Error: Failed to source the downloaded script."; exit 1; }
-
-	# if updating, call abl_post_update_1() in new version
-	[ -n "${is_update}" ] && check_util abl_post_update_1 && abl_post_update_1
-
-	# register files included in the new version
-	new_abl_files="${ABL_SERVICE_PATH}"
-	for file in ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}
-	do
-		new_abl_files="${new_abl_files} ${file}"
-	done
-	printf '%s\n' "${new_abl_files}" > "${DIST_DIR}/new_files"
-
-	# register config format in the new adblock-lean version
-	check_util get_config_format && upd_config_format="$(get_config_format < "${DIST_DIR}/adblock-lean")"
-
-	if [ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && [ "${upd_config_format}" != "${prev_config_format}" ]
+	[ -f "${1}" ] && . "${1}" || return 1
+	if check_func print_file_list # v0.7.2 and later
 	then
-		failsafe_log "NOTE: config format has changed from v${prev_config_format} to v${upd_config_format}."
-		# load config and call abl_post_update_2() in new version
-		if { ! check_util source_libs || source_libs "${DIST_DIR}${ABL_LIB_DIR}" "${DIST_DIR}"; } &&
-				check_util load_config
-		then
-			load_config
-			check_util abl_post_update_2 && abl_post_update_2
-		else
-			failsafe_log "Please run 'service adblock-lean start' to initialize the new config."
-		fi
+		print_file_list "${2}"
+	elif check_func install_abl_files # v0.6.0-v0.7.1
+	then
+		case "${2}" in
+			EXEC) printf '%s\n' "${ABL_SERVICE_PATH}" ;;
+			*)
+				printf '%s\n' "${ABL_SERVICE_PATH}${_NL_}${ABL_LIB_FILES}${_NL_}${ABL_EXTRA_FILES}" |
+					${SED_CMD} 's/\s\s*/\n/g' | ${SED_CMD} '/^$/d'
+		esac
+	else # v0.5.4 and earlier
+		printf '%s\n' "${ABL_SERVICE_PATH}"
 	fi
 	:
-) 1>/dev/null || { inst_failed "Failed to source the new version of adblock-lean. Update is cancelled."; exit 1; }
+}
 
-print_msg ""
+# 1 - path to distribution dir
+# 2 - version
+# 3 - update channel
+# 4 - force file list
+install_abl_files()
+{
+	local file preinst_path old_files='' exec_files='' \
+		preinst_reg_file="${dist_dir}/preinst_reg.md5" \
+		prev_config_format='' upd_config_format='' config_format_changed='' \
+		dist_dir="${1}" version="${2}" upd_channel="${3}" new_file_list="${4}"
 
-install_abl_files "${DIST_DIR}" "${UPD_CHANNEL}_${REF}" || { inst_failed; exit 1; }
+	[ -n "${1}" ] && [ -n "${2}" ] && [ -n "${3}" ] || inst_failed "Missing arguments."
+	log_msg "" "Installing new files..."
 
-IS_UPDATE=
-[ -f "${DIST_DIR}/is_update" ] && IS_UPDATE=1
+	# normalize path
+	try_mkdir -p "${dist_dir}${ABL_SERVICE_PATH%/*}"
+	mv "${dist_dir}/adblock-lean" "${dist_dir}${ABL_SERVICE_PATH}" || inst_failed
 
-rm -rf "${ABL_DIR}" "${ABL_PID_DIR}" "${UCL_ERR_FILE}"
-
-log_msg "" "adblock-lean ${REF} has been installed."
-
-if [ -n "${DO_DIALOGS}" ]
-then
-	if [ -n "${IS_UPDATE}" ] && [ -s "${ABL_CONFIG_FILE}" ]
+	# get new file list
+	if [ -z "${new_file_list}" ]
 	then
-		print_msg "" "Start adblock-lean now? (y|n)"
-		pick_opt "y|n"
-		if [ "$REPLY" = y ]
+		new_file_list="$(get_file_list "${dist_dir}${ABL_SERVICE_PATH}" ALL)" &&
+		[ -n "${new_file_list}" ] ||
+			inst_failed "Failed to get the file list from fetched adblock-lean version."
+	fi
+
+	printf '%s\n' "${new_file_list}" > "${dist_dir}/new_file_list"
+
+	# check new files
+	for file in ${new_file_list}
+	do
+		[ -z "${file}" ] || [ -f "${dist_dir}${file}" ] && continue
+		inst_failed "Missing file: '${dist_dir}${file}'."
+	done
+
+	# get new exec file list
+	exec_files="$(get_file_list "${dist_dir}${ABL_SERVICE_PATH}" EXEC)"
+
+	# handle update
+	if [ -n "${IS_UPDATE}" ]
+	then
+		# get currently installed file list
+		old_files="$(get_file_list "${ABL_SERVICE_PATH}" ALL)"
+		prev_config_format="$(get_config_format < "${ABL_SERVICE_PATH}")"
+		upd_config_format="$(get_config_format < "${dist_dir}${ABL_SERVICE_PATH}")"
+		[ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && \
+			[ "${upd_config_format}" != "${prev_config_format}" ] &&
+			config_format_changed=1
+
+		local IFS="${_NL_}"
+
+		# delete obsolete files
+		for file in ${old_files}
+		do
+			case "${file}" in /*) ;; *) continue; esac # only accept absolute paths
+			if [ -f "${file}" ] && ! is_included "${file}" "${new_file_list}" "${_NL_}"
+			then
+				log_msg "Deleting obsolete file ${file}."
+				rm -f "${file}"
+			fi
+		done
+		IFS="${DEFAULT_IFS}"
+
+		(
+			clean_abl_env
+			# shellcheck source=/dev/null
+			if . "${dist_dir}${ABL_SERVICE_PATH}" && check_func abl_post_update_1
+			then
+				abl_post_update_1
+			fi
+		)
+	fi
+
+	# version and update channel string replacement
+	busybox sed -i "
+		/^\s*ABL_VERSION\s*=/{s/.*/ABL_VERSION=\"${version}\"/;}
+		/^\s*ABL_UPD_CHANNEL\s*=/{s/.*/ABL_UPD_CHANNEL=\"${upd_channel}\"/;}" \
+			"${dist_dir}${ABL_SERVICE_PATH}"
+	
+	# Check for changed files
+	local changed_files='' unchanged_files='' man_changed_files=''
+
+	if [ -s "${ABL_FILES_REG_PATH}" ]
+	then
+		# prefix file paths in the reg file for md5sum comparison
+		${SED_CMD} -E "/^$/d;s~([^ 	]+$)~${dist_dir}\\1~" "${ABL_FILES_REG_PATH}" > "${preinst_reg_file}"
+
+		# Detect unchanged files
+		md5sum -c "${preinst_reg_file}" 2>/dev/null |
+			${SED_CMD} -n "/:\s*OK\s*$/{s/\s*:\s*OK\s*$//;s~^\s*${dist_dir}~~;p;}" > "${dist_dir}/unchanged"
+		rm -f "${preinst_reg_file}"
+
+		# Detect manually modified files
+		man_changed_files="$(md5sum -c "${ABL_FILES_REG_PATH}" 2>/dev/null |
+			${SED_CMD} -n "/:\s*FAILED\s*$/{s/\s*:\s*FAILED\s*$//;p;}")"
+
+		# Remove manually modified files from unchanged files
+		if [ -n "${man_changed_files}" ]
 		then
-			${ABL_SERVICE_PATH} start
+			unchanged_files="$(
+				printf '%s\n' "${man_changed_files}" | busybox awk '
+					NR==FNR {man_ch[$0];next}
+					{
+						if ($0=="" || $0 in man_ch) {next}
+						print $0
+					}
+				' - "${dist_dir}/unchanged"
+			)"
+		else
+			unchanged_files="$(cat "${dist_dir}/unchanged")"
 		fi
+		rm -f "${dist_dir}/unchanged"
+
+		# remove unchanged files from ${new_file_list} to reliably get a list of files to copy
+		changed_files="$(
+			printf '%s\n' "${unchanged_files}" | busybox awk '
+				NR==FNR {unch[$0];next}
+				{
+					if ($0=="" || $0 in unch) {next}
+					print $0
+				}
+			' - "${dist_dir}/new_file_list"
+		)"
 	else
-		print_msg "" "Set up adblock-lean now? (y|n)"
-		pick_opt "y|n"
-		if [ "$REPLY" = y ]
+		changed_files="${new_file_list}"
+	fi
+
+	local IFS="${_NL_}"
+	for file in ${unchanged_files}
+	do
+		[ -n "${file}" ] || continue
+		log_msg "File '${file}' did not change - not updating."
+	done
+
+	local mod_files_bk_dir="/tmp/abl_old_modified_files"
+	for file in ${man_changed_files}
+	do
+		[ -n "${file}" ] && [ -f "${file}" ] || continue
+		log_msg "Warning: File '${file}' was manually modified - overwriting."
+		if try_mkdir -p "${mod_files_bk_dir}" && cp "${file}" "${mod_files_bk_dir}/${file##*/}"
 		then
-			${ABL_SERVICE_PATH} setup
+			log_msg "Saved a backup copy of manually modified file to ${mod_files_bk_dir}/${file##*/}"
+		else
+			log_msg "Warning: Can not create a backup copy of manually modified file '${file}' - overwriting anyway."
+		fi
+	done
+
+	# Copy changed files
+	for file in ${changed_files}
+	do
+		preinst_path="${dist_dir}${file}"
+		log_msg "Copying file '${file}'."
+		try_mkdir -p "${file%/*}" && cp "${preinst_path}" "${file}" ||
+			inst_failed "Failed to copy file '${preinst_path}' to '${file}'."
+	done
+
+	# make files executable
+	[ -n "${exec_files}" ] && {
+		set -- ${exec_files} # relying on IFS=\n
+		for file in "${@}"
+		do
+			[ -n "${file}" ] || continue
+			chmod +x "${file}" || inst_failed "Failed to make file '$file' executable."
+		done
+	}
+
+	# save the md5sum registry file if needed
+	if [ -n "${changed_files}" ] || [ ! -s "${ABL_FILES_REG_PATH}" ]
+	then
+		# make md5sum registry of new files
+		# relying on IFS=\n
+		# shellcheck disable=SC2046
+		set -- $(
+			printf '%s\n' "${new_file_list}" |
+			busybox sed "/^$/d;s~^\s*~${dist_dir}~"
+		) &&
+		md5sums="$(md5sum "$@")" && [ -n "${md5sums}" ] &&
+		try_mkdir -p "${ABL_FILES_REG_PATH%/*}" &&
+		printf '%s\n' "${md5sums}" |
+			busybox sed "s~\s${dist_dir}~ ~" > "${ABL_FILES_REG_PATH}" ||
+				inst_failed "Failed to register new files."
+	fi
+	IFS="${DEFAULT_IFS}"
+
+	if [ -n "${IS_UPDATE}" ] && grep -m1 -q '[ 	]*abl_post_update_2()' "${dist_dir}${ABL_SERVICE_PATH}"
+	then
+		(
+			clean_abl_env
+			# shellcheck source=/dev/null
+			if . "${dist_dir}${ABL_SERVICE_PATH}" && check_func abl_post_update_2
+			then
+				abl_post_update_2
+			fi
+		)
+	fi
+
+	if [ -n "${config_format_changed}" ]
+	then
+		(
+			clean_abl_env
+			failsafe_log "NOTE: config format has changed from v${prev_config_format} to v${upd_config_format}."
+			# load config in new version
+			# shellcheck source=/dev/null
+			if  . "${ABL_SERVICE_PATH}" &&
+				{ ! check_func source_libs || source_libs; } &&
+				check_func load_config && load_config
+			then
+				:
+			else
+				failsafe_log "Please run 'service adblock-lean start' to initialize the new config."
+			fi
+		:
+		)
+	fi
+
+	:
+}
+
+fetch_and_install()
+{
+	trap 'cleanup_and_exit 1' INT TERM
+	trap 'cleanup_and_exit ${?}' EXIT
+
+	# unset vars and functions from current version to have a clean slate with the new version
+	fetch_failed()
+	{
+		local fail_msg="${1}"
+		[ -s "${UCL_ERR_FILE}" ] && fail_msg="${fail_msg} uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'"
+		[ -n "${fail_msg}" ] && reg_falure "${fail_msg}"
+		rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
+		inst_failed
+	}
+
+	unexp_arg()
+	{
+		fetch_failed "fetch_and_install: unexpected argument '${1}'."
+	}
+
+	local file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
+		upd_channel='' req_upd_channel='' force_upd_channel=''
+
+	IGNORE_CACHE=
+	while getopts ":s:v:U:W:i" opt
+	do
+		case ${opt} in
+			s) export sim_path="$OPTARG" ;;
+			v) ver_str_arg=$OPTARG ;;
+			U) force_upd_channel=$OPTARG ;;
+			W) req_ver=$OPTARG ;;
+			i) IGNORE_CACHE=1 ;; # global var
+			*) unexp_arg "$OPTARG"
+		esac
+	done
+	shift $((OPTIND-1))
+	[ -z "${*}" ] || unexp_arg "${*}"
+
+	# parse version string from arguments into $req_upd_channel, $req_ver
+	case "${ver_str_arg}" in
+		'') ;;
+		release|latest)
+			req_upd_channel=release req_ver='' ;;
+		snapshot)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		commit=*)
+			req_upd_channel="${ver_str_arg}" req_ver="${ver_str_arg#*=}" ;;
+		branch=*)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		[0-9]*|v[0-9]*)
+			req_upd_channel=release
+			req_ver="${ver_str_arg#*=}"
+			req_ver="${req_ver#v}"
+			;;
+		*) fetch_failed "Invalid version string '${ver_str_arg}'."
+	esac
+
+	if ${ABL_SERVICE_PATH} enabled
+	then
+		${ABL_SERVICE_PATH} stop
+	fi 2>/dev/null
+
+	rm -rf "${ABL_UPD_DIR:-???}"
+	try_mkdir -p "${ABL_UPD_DIR}" || fetch_failed
+
+	upd_channel="${req_upd_channel:-"${ABL_UPD_CHANNEL}"}"
+	upd_channel="${force_upd_channel:-"${upd_channel}"}"
+	upd_channel="${upd_channel:-"release"}"
+
+	dist_dir="${ABL_UPD_DIR}/dist"
+	try_mkdir -p "${dist_dir}" || fetch_failed
+
+	if [ -n "${sim_path}" ]
+	then
+		print_msg "Installing in simulation mode."
+		[ -d "${sim_path}" ] || fetch_failed "Update simulation directory '${sim_path}' does not exist."
+		[ -n "${ver_str_arg}" ] || fetch_failed "Specify new version string."
+		upd_ver="${ver_str_arg}"
+
+		[ -d "${sim_path}" ] || fetch_failed "Simulation source directory doesn't exist."
+		cp -rT "${sim_path}" "${dist_dir}"
+		log_msg "" "Installing adblock-lean version '${upd_ver}' (update channel: '${upd_channel}')."
+	else
+		get_gh_ref "${upd_channel}" "${req_ver}" upd_ver tarball_url ver_type || fetch_failed
+		case "${upd_channel}" in
+			commit=*)
+				# set update channel to 'commit=<full_commit_hash>'
+				upd_channel="${upd_channel%=*}=${upd_ver}"
+		esac
+		log_msg "" "Downloading adblock-lean, ${ver_type} '${upd_ver}' (update channel: '${upd_channel}')."
+		fetch_abl_dist "${tarball_url}" "${dist_dir}" || fetch_failed
+	fi
+
+	get_abl_version "${dist_dir}/adblock-lean"
+	(
+		case "${?}" in
+			2)
+				# no version found - call install_abl_files() from this installer
+				rm -f "${ABL_FILES_REG_PATH}"
+				export pid_file="/tmp/adblock-lean/adblock-lean.pid" # for compatibility with older versions
+				install_abl_files "${dist_dir}" "${upd_ver}" "${upd_channel}" "${ABL_SERVICE_PATH}" ;;
+			3)
+				# new version format - call install_abl_files() from fetched installer
+				clean_abl_env
+				# shellcheck source=/dev/null
+				INST_SOURCED=1 . "${dist_dir}/abl-install.sh" ||
+					{ reg_falure "Failed to source fetched install script."; exit 1; }
+				install_abl_files "${dist_dir}" "${upd_ver}" "${upd_channel}" ;;
+			4)
+				# old version format - call install_abl_files() from fetched service file
+				rm -f "${ABL_FILES_REG_PATH}"
+				clean_abl_env
+				# shellcheck source=/dev/null
+				. "${dist_dir}/adblock-lean" ||
+					{ reg_falure "Failed to source fetched script."; exit 1; }
+				printf '%s\n' "${ABL_SERVICE_PATH} ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}" > "${dist_dir}/inst_files"
+				install_abl_files "${dist_dir}" "${upd_channel}_v${upd_ver}" ;;
+			*) reg_falure "Failed to get version from fetched adblock-lean distribution."; exit 1 ;;
+		esac
+	) || exit 1
+
+	rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
+	log_msg "adblock-lean (version '${upd_ver}') has been installed."
+
+	if [ -n "${DO_DIALOGS}" ]
+	then
+		if [ -n "${IS_UPDATE}" ] && [ -s "${ABL_CONFIG_FILE}" ]
+		then
+			print_msg "" "Start adblock-lean now? (y|n)"
+			pick_opt "y|n"
+			if [ "$REPLY" = y ]
+			then
+				clean_abl_env
+				# shellcheck source=/dev/null
+				. "${ABL_SERVICE_PATH}" || exit 1
+				enable &&
+				start
+			else
+				exit 0
+			fi
+		else
+			print_msg "" "Set up adblock-lean now? (y|n)"
+			pick_opt "y|n"
+			if [ "$REPLY" = y ]
+			then
+				clean_abl_env
+				# shellcheck source=/dev/null
+				. "${ABL_SERVICE_PATH}" || exit 1
+				setup
+			else
+				exit 0
+			fi
 		fi
 	fi
-fi
+}
 
-:
+[ -s "${ABL_SERVICE_PATH}" ] && IS_UPDATE=1
+
+if [ -z "${INST_SOURCED}" ]
+then
+	fetch_and_install "${@}"
+else
+	:
+fi

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -11,7 +11,8 @@ ABL_SERVICE_PATH=/etc/init.d/adblock-lean
 ABL_DIR=/var/run/adblock-lean
 ABL_INST_DIR="${ABL_DIR}/remote_abl"
 UCL_ERR_FILE="${ABL_DIR}/uclient-fetch_err"
-ABL_GH_URL_API=https://api.github.com/repos/lynxthecat/adblock-lean
+: "${ABL_REPO_AUTHOR:=lynxthecat}"
+ABL_GH_URL_API=https://api.github.com/repos/${ABL_REPO_AUTHOR}/adblock-lean
 
 LC_ALL=C
 DEFAULT_IFS='	 
@@ -245,11 +246,11 @@ fetch_abl_dist()
 	local fetch_tarball_url="${2}" fetch_ref="${3}"
 	local fetch_dir fetch_rv tarball="${ABL_INST_DIR}/remote_abl.tar.gz"
 	log_msg "Downloading adblock-lean, version '${fetch_ref}'."
-	rm -rf "${UCL_ERR_FILE}" "${ABL_INST_DIR}/lynxthecat-adblock-lean-"*
+	rm -rf "${UCL_ERR_FILE}" "${ABL_INST_DIR}/${ABL_REPO_AUTHOR}-adblock-lean-"*
 	uclient-fetch "${fetch_tarball_url}" -O "${tarball}" 2> "${UCL_ERR_FILE}" &&
 	grep -q "Download completed" "${UCL_ERR_FILE}" &&
 	tar -C "${ABL_INST_DIR}" -xzf "${tarball}" &&
-	fetch_dir="$(find "${ABL_INST_DIR}/" -type d -name "lynxthecat-adblock-lean-*")"
+	fetch_dir="$(find "${ABL_INST_DIR}/" -type d -name "${ABL_REPO_AUTHOR}-adblock-lean-*")"
 	fetch_rv=${?}
 
 	[ "${fetch_rv}" != 0 ] && [ -s "${UCL_ERR_FILE}" ] && ! grep -q "Download completed" "${UCL_ERR_FILE}" &&

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -43,7 +43,7 @@ fi
 [ -n "${luci_skip_dialogs}" ] && export ABL_LUCI_SOURCED=1
 
 DO_DIALOGS=
-[ -z "${ABL_LUCI_SOURCED}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
+[ -z "${ABL_LUCI_SOURCED}" ] && [ -z "${APPROVE_UPD_CHANGES}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
 
 if sed --version 2>/dev/null | grep -qe '(GNU sed)'
 then

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -861,7 +861,7 @@ fetch_and_install()
 	) || exit 1
 
 	rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
-	log_msg "adblock-lean (version '${upd_ver}') has been installed."
+	log_msg "" "adblock-lean (version '${upd_ver}') has been installed."
 
 	if [ -n "${DO_DIALOGS}" ]
 	then

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -502,11 +502,12 @@ clean_abl_env()
 get_file_list()
 {
 	clean_abl_env
+	local _file_types="${2}"
 	# shellcheck source=/dev/null
 	[ -f "${1}" ] && . "${1}" || return 1
 	if check_func print_file_list # v0.7.2 and later
 	then
-		print_file_list "${2}"
+		print_file_list "${_file_types}"
 	elif check_func install_abl_files # v0.6.0-v0.7.1
 	then
 		case "${2}" in

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -510,7 +510,7 @@ get_file_list()
 		print_file_list "${_file_types}"
 	elif check_func install_abl_files # v0.6.0-v0.7.1
 	then
-		case "${2}" in
+		case "${_file_types}" in
 			EXEC) printf '%s\n' "${ABL_SERVICE_PATH}" ;;
 			*)
 				printf '%s\n' "${ABL_SERVICE_PATH}${_NL_}${ABL_LIB_FILES}${_NL_}${ABL_EXTRA_FILES}" |

--- a/adblock-lean
+++ b/adblock-lean
@@ -60,7 +60,8 @@ UCL_ERR_FILE="${ABL_DIR}/uclient-fetch_err"
 
 ABL_CRON_CMD="/etc/init.d/adblock-lean start"
 
-ABL_GH_URL_API=https://api.github.com/repos/lynxthecat/adblock-lean
+: "${ABL_REPO_AUTHOR:=lynxthecat}"
+ABL_GH_URL_API=https://api.github.com/repos/${ABL_REPO_AUTHOR}/adblock-lean
 
 SCHEDULER_PID=
 
@@ -1012,11 +1013,11 @@ fetch_abl_dist()
 	local fetch_tarball_url="${2}"
 	local fetch_dir fetch_rv tarball="${ABL_UPD_DIR}/remote_abl.tar.gz"
 
-	rm -rf "${UCL_ERR_FILE}" "${ABL_UPD_DIR}/lynxthecat-adblock-lean-"*
+	rm -rf "${UCL_ERR_FILE}" "${ABL_UPD_DIR}/${ABL_REPO_AUTHOR}-adblock-lean-"*
 	uclient-fetch "${fetch_tarball_url}" -O "${tarball}" 2> "${UCL_ERR_FILE}" &&
 	grep -q "Download completed" "${UCL_ERR_FILE}" &&
 	tar -C "${ABL_UPD_DIR}" -xzf "${tarball}" &&
-	fetch_dir="$(find "${ABL_UPD_DIR}/" -type d -name "lynxthecat-adblock-lean-*")"
+	fetch_dir="$(find "${ABL_UPD_DIR}/" -type d -name "${ABL_REPO_AUTHOR}-adblock-lean-*")"
 	fetch_rv=${?}
 
 	[ "${fetch_rv}" != 0 ] && [ -s "${UCL_ERR_FILE}" ] && ! grep -q "Download completed" "${UCL_ERR_FILE}" &&

--- a/adblock-lean
+++ b/adblock-lean
@@ -114,7 +114,7 @@ are_var_names_safe() {
 	local var_name
 	for var_name in "${@}"
 	do
-		case "${var_name}" in *[!a-zA-Z_]*) reg_failure "Invalid var name '${var_name}'."; return 1; esac
+		case "${var_name}" in [!a-zA-Z_]*|*[!a-zA-Z0-9_]*) reg_failure "Invalid var name '${var_name}'."; return 1; esac
 	done
 	:
 }
@@ -369,8 +369,14 @@ detect_util()
 		/*) ;; # paths already known
 		*)
 			# get paths
-			if check_util "${res_cmd}" &&
-				{
+			if check_util "${res_cmd}" && _util_path="$(command -v "${res_cmd}")"
+			then
+				if [ -f "${_util_path}" ] && [ ! -h "${_util_path}" ] && [ ! -L "${_util_path}" ]
+				then
+					# path is not symlink
+					res_cmd="${_util_path}"
+				elif [ -h "${_util_path}" ] || [ -L "${_util_path}" ]
+				then
 					# resolve symlinks
 					_util_path="$(command -v "${res_cmd}")" &&
 					{ [ -h "${_util_path}" ] || [ -L "${_util_path}" ]; } &&
@@ -378,28 +384,28 @@ detect_util()
 					[ -n "${_util_path}" ] &&
 					_util_path="$(command -v "${_util_path}")" &&
 					case "${_util_path}" in
-						/bin/busybox*) _util="/bin/busybox ${gen_name}" ;;
-						*) _util="${_util_path}"
+						/bin/busybox*) res_cmd="/bin/busybox ${gen_name}" ;;
+						*) res_cmd="${_util_path}"
 					esac
-				} ||
-				[ -f "${_util}" ]
-			then
-				res_cmd="${_util}"
+				fi
+				[ -n "${res_cmd}" ] || return 1
 			else
 				return 1
 			fi
 	esac
-
 	export "${du_out_var}=${res_cmd}"
 }
 
 # sets $AWK_CMD, $SED_CMD, $SORT_CMD
 detect_utils() {
 	unset SED_CMD AWK_CMD SORT_CMD
+	local failed_utils=''
 
-	detect_util SED_CMD sed "" "/usr/libexec/sed-gnu" -b &&
-	detect_util AWK_CMD awk gawk "/usr/bin/gawk" -b &&
-	detect_util SORT_CMD sort "" "/usr/libexec/sort-coreutils" -b || return 1
+	detect_util SED_CMD sed "" "/usr/libexec/sed-gnu" -b || add2list failed_utils sed ', '
+	detect_util AWK_CMD awk gawk "/usr/bin/gawk" -b || add2list failed_utils awk ', '
+	detect_util SORT_CMD sort "" "/usr/libexec/sort-coreutils" -b || add2list failed_utils sort ', '
+
+	[ -z "${failed_utils}" ] || { reg_failure "Can not find essential utilities: ${failed_utils}.";  return 1; }
 
 	:
 }
@@ -1948,7 +1954,7 @@ then
 fi
 rm -f /tmp/abl-test
 
-detect_utils
+detect_utils || exit 1
 
 # register 1st arg as $ABL_CMD when called by 'sh /etc/init.d/adblock-lean'
 if [ "${0}" = "${ABL_SERVICE_PATH}" ]

--- a/adblock-lean
+++ b/adblock-lean
@@ -343,15 +343,23 @@ rc_enabled()
 detect_utils() {
 	detect_util()
 	{
-		local out_var="${1}" pkg_name="${2}" gen_name="${3}" specific_path="${4}" busybox_cmd="${5}" specific_name="${6}" \
-			res_cmd=''
+		local out_var="${1}" gen_name="${2}" pkg_name="${3}" specific_names="${4}" specific_paths="${5}" busybox_cmd="${6}" \
+			res_cmd='' util_path='' util_name=''
 		are_var_names_safe "${out_var}" || return 1
-		if [ -f "${specific_path}" ]
+		if [ -n "${specific_paths}" ] &&
+			for util_path in ${specific_paths}
+			do
+				[ -f "${util_path}" ] && break
+			done
 		then
-			res_cmd="${specific_path}"
-		elif [ -n "${specific_name}" ] && check_util "${specific_name}"
+			res_cmd="${util_path}"
+		elif [ -n "${specific_names}" ] &&
+			for util_name in ${specific_names}
+			do
+				check_util "${util_name}" && break
+			done
 		then
-			res_cmd="${specific_name}"
+			res_cmd="${util_name}"
 		elif check_util "${gen_name}"
 		then
 			res_cmd="${gen_name}"
@@ -371,9 +379,9 @@ detect_utils() {
 
 	printf '%s\n' "." > "${test_path}" || { reg_failure "Failed to detect utils."; return 1; }
 
-	detect_util SED_CMD sed sed "/usr/libexec/sed-gnu" "-n '/./q'" &&
-	detect_util AWK_CMD gawk awk "/usr/bin/gawk" "'BEGIN{exit}'" gawk &&
-	detect_util SORT_CMD coreutils-sort sort "/usr/libexec/sort-coreutils" || return 1
+	detect_util SED_CMD sed sed sed "/usr/libexec/sed-gnu" "-n '/./q'" &&
+	detect_util AWK_CMD awk gawk gawk "/usr/bin/gawk" "'BEGIN{exit}'" gawk &&
+	detect_util SORT_CMD sort coreutils-sort sort "/usr/libexec/sort-coreutils" || return 1
 
 	rm -f /tmp/utils-test
 	:
@@ -1442,6 +1450,8 @@ start()
 {
 	reg_action -purple "Starting adblock-lean, version ${ABL_VERSION}."
 	init_command start || exit 1
+
+	detect_util COMPR_CMD gzip gzip "pigz zstd gzip" "/usr/bin/pigz /usr/bin/zstd /bin/gzip" "-c" || return 1
 
 	if [ "${RANDOM_DELAY}" = "1" ]
 	then

--- a/adblock-lean
+++ b/adblock-lean
@@ -369,9 +369,10 @@ detect_util()
 		/*) ;; # paths already known
 		*)
 			# get paths
-			if _util_path="$(command -v "${res_cmd}")" &&
+			if check_util "${res_cmd}" &&
 				{
 					# resolve symlinks
+					_util_path="$(command -v "${res_cmd}")" &&
 					{ [ -h "${_util_path}" ] || [ -L "${_util_path}" ]; } &&
 					_util_path="$(readlink "${_util_path}")" &&
 					[ -n "${_util_path}" ] &&

--- a/adblock-lean
+++ b/adblock-lean
@@ -339,51 +339,67 @@ rc_enabled()
 	[ -L "/etc/rc.d/K${STOP}adblock-lean" ]
 }
 
+detect_util()
+{
+	local du_out_var="${1}" gen_name="${2}" specific_name="${3}" specific_path="${4}" \
+		res_cmd='' _util _util_path='' busybox_variant_avail=''
+
+	are_var_names_safe "${du_out_var}" || return 1
+
+	[ "${5}" = '-b' ] && busybox_variant_avail=1
+
+	if [ -n "${specific_path}" ] && [ -f "${specific_path}" ]
+	then
+		res_cmd="${specific_path}"
+	elif [ -n "${specific_name}" ] && check_util "${specific_name}"
+	then
+		res_cmd="${specific_name}"
+	elif [ -n "${gen_name}" ] && check_util "${gen_name}"
+	then
+		res_cmd="${gen_name}"
+	elif [ -n "${busybox_variant_avail}" ]
+	then
+		res_cmd="/bin/busybox ${gen_name}"
+	else
+		reg_failure "${gen_name} not found."
+		return 1
+	fi
+
+	case "${res_cmd}" in
+		/*) ;; # paths already known
+		*)
+			# get paths
+			if _util_path="$(command -v "${res_cmd}")" &&
+				{
+					# resolve symlinks
+					{ [ -h "${_util_path}" ] || [ -L "${_util_path}" ]; } &&
+					_util_path="$(readlink "${_util_path}")" &&
+					[ -n "${_util_path}" ] &&
+					_util_path="$(command -v "${_util_path}")" &&
+					case "${_util_path}" in
+						/bin/busybox*) _util="/bin/busybox ${gen_name}" ;;
+						*) _util="${_util_path}"
+					esac
+				} ||
+				[ -f "${_util}" ]
+			then
+				res_cmd="${_util}"
+			else
+				return 1
+			fi
+	esac
+
+	export "${du_out_var}=${res_cmd}"
+}
+
 # sets $AWK_CMD, $SED_CMD, $SORT_CMD
 detect_utils() {
-	detect_util()
-	{
-		local out_var="${1}" gen_name="${2}" pkg_name="${3}" specific_names="${4}" specific_paths="${5}" busybox_cmd="${6}" \
-			res_cmd='' util_path='' util_name=''
-		are_var_names_safe "${out_var}" || return 1
-		if [ -n "${specific_paths}" ] &&
-			for util_path in ${specific_paths}
-			do
-				[ -f "${util_path}" ] && break
-			done
-		then
-			res_cmd="${util_path}"
-		elif [ -n "${specific_names}" ] &&
-			for util_name in ${specific_names}
-			do
-				check_util "${util_name}" && break
-			done
-		then
-			res_cmd="${util_name}"
-		elif check_util "${gen_name}"
-		then
-			res_cmd="${gen_name}"
-		elif eval "/bin/busybox ${gen_name} ${busybox_cmd} \"${test_path}\"" &>/dev/null
-		then
-			res_cmd="/bin/busybox ${gen_name}"
-		else
-			rm -f "${test_path}"
-			reg_failure "${gen_name} not found. Please install ${pkg_name}."
-			return 1
-		fi
-		: "${res_cmd}"
-		eval "${out_var}"='${res_cmd}'
-	}
+	unset SED_CMD AWK_CMD SORT_CMD
 
-	local test_path=/tmp/utils-test
+	detect_util SED_CMD sed "" "/usr/libexec/sed-gnu" -b &&
+	detect_util AWK_CMD awk gawk "/usr/bin/gawk" -b &&
+	detect_util SORT_CMD sort "" "/usr/libexec/sort-coreutils" -b || return 1
 
-	printf '%s\n' "." > "${test_path}" || { reg_failure "Failed to detect utils."; return 1; }
-
-	detect_util SED_CMD sed sed sed "/usr/libexec/sed-gnu" "-n '/./q'" &&
-	detect_util AWK_CMD awk gawk gawk "/usr/bin/gawk" "'BEGIN{exit}'" gawk &&
-	detect_util SORT_CMD sort coreutils-sort sort "/usr/libexec/sort-coreutils" || return 1
-
-	rm -f /tmp/utils-test
 	:
 }
 
@@ -762,12 +778,12 @@ get_abl_run_state()
 {
 	[ -n "${DNSMASQ_CONF_D}" ] || { reg_failure "\$DNSMASQ_CONF_D is not set"; return 1; }
 	local f
-	for f in "${DNSMASQ_CONF_D}/.abl-blocklist.gz" "${DNSMASQ_CONF_D}/abl-blocklist"
+	for f in "${DNSMASQ_CONF_D}/.abl-blocklist${COMPR_EXT}" "${DNSMASQ_CONF_D}/abl-blocklist"
 	do
 		[ -f "${f}" ] && return 0
 	done
 
-	[ -f "${ABL_DIR}/prev_blocklist.gz" ] && return 3
+	[ -f "${ABL_DIR}/prev_blocklist${COMPR_EXT}" ] && return 3
 	return 4
 }
 
@@ -939,12 +955,47 @@ rm_cron_job()
 	:
 }
 
+# Delete adblock-lean addnmount entries for dnsmasq instance
+# NOTE: need to run 'uci commit dhcp' after calling this function
+# 1 - dnsmasq instance index
+# return codes:
+# 0 - OK
+# 1 - Error deleting all found entries
+# 2 - Some entries deleted
+# 3 - No entries found for instance
+del_addnmount()
+{
+	local rv path paths entry_deleted=0 entry_failed=0
+	paths="$(uci -q get "dhcp.@dnsmasq[${1}].addnmount" 2>/dev/null)"
+	for path in ${paths}
+	do
+		case "${path}" in */bin/busybox*|*gzip*|*pigz*|*zstd*) ;; *) continue; esac
+		log_msg -purple "" "Deleting addnmount entry for '${path}' for dnsmasq instance ${1} from /etc/config/dhcp."
+		if uci -q del_list "dhcp.@dnsmasq[${1}].addnmount=${path}"
+		then
+			entry_deleted=1
+		else
+			entry_failed=1
+			reg_failure "Failed to delete addnmount entry for '${path}' from /etc/config/dhcp."
+		fi
+	done
+
+	case "${entry_deleted}${entry_failed}" in
+		00) rv=3 ;;
+		01) rv=1 ;;
+		10) rv=0 ;;
+		11) rv=2 ;;
+	esac
+
+	return ${rv}
+}
+
 
 ### Commands init
 init_command()
 {
 	ABL_CMD="${1}"
-	local config_req='' work_dir_req='' init_action_msg=''
+	local config_req='' work_dir_req='' init_action_msg='' process_vars_req=''
 
 	DO_DIALOGS=
 	[ -z "${ABL_LUCI_SOURCED}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
@@ -964,12 +1015,12 @@ init_command()
 	case ${ABL_CMD} in
 		help|enabled|enable|disable|print_log|'') ;;
 		gen_stats) ;;
-		status) libs_req=1 work_dir_req=1 config_req=1 ;;
+		status) libs_req=1 work_dir_req=1 config_req=1 process_vars_req=1 ;;
 		upd_cron_job) libs_req=1 config_req=1 ;;
 		setup|gen_config) libs_req=1 LOCK_REQ=1 ;;
 		boot) libs_req=1 config_req=1 LOCK_REQ=1 ;;
-		pause) libs_req=1 work_dir_req=1 config_req=1 LOCK_REQ=1 ;;
-		start|resume) libs_req=1 work_dir_req=1 config_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
+		pause) libs_req=1 work_dir_req=1 config_req=1 process_vars_req=1 LOCK_REQ=1 ;;
+		start|resume) libs_req=1 work_dir_req=1 config_req=1 process_vars_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		stop)
 			init_action_msg="Stopping adblock-lean."
 			reg_action -purple "${init_action_msg}" || exit 1
@@ -981,6 +1032,7 @@ init_command()
 				1) exit 1 ;;
 				2) reg_failure "Failed to kill running adblock-lean processes."; exit 1
 			esac
+			load_config
 			CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		select_dnsmasq_instance)
 			libs_req=1 LOCK_REQ=1
@@ -990,6 +1042,8 @@ init_command()
 		update) work_dir_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
 		*) reg_failure "Invalid action '${ABL_CMD}'."; exit 1
 	esac
+
+	[ -n "${process_vars_req}" ] && libs_req=1 # ensure that libs are loaded
 
 	# source library scripts
 	if [ -n "${libs_req}" ]
@@ -1036,6 +1090,9 @@ init_command()
 		load_config ${force_config_fix} || { reg_failure "Failed to load config."; exit 1; }
 		CONFIG_LOADED=1
 	fi
+
+	# detect compression/extraction utils
+	[ -n "${process_vars_req}" ] && { set_processing_vars || exit 1; }
 
 	# check dnsmasq, source custom script
 	case ${ABL_CMD} in
@@ -1451,8 +1508,6 @@ start()
 	reg_action -purple "Starting adblock-lean, version ${ABL_VERSION}."
 	init_command start || exit 1
 
-	detect_util COMPR_CMD gzip gzip "pigz zstd gzip" "/usr/bin/pigz /usr/bin/zstd /bin/gzip" "-c" || return 1
-
 	if [ "${RANDOM_DELAY}" = "1" ]
 	then
 		random_delay_mins=$(($(hexdump -n 1 -e '"%u"' </dev/urandom)%60))
@@ -1809,25 +1864,33 @@ uninstall()
 		rm -rf "${ABL_CONFIG_DIR:-???}"
 	fi
 
-	local i="-1" addnmount_deleted=1
+	local i="-1" addnm_deleted='' addnm_del_fail=''
 	while [ ${i} -lt 128 ]
 	do
 		i=$((i+1))
 		uci -q get dhcp.@dnsmasq[${i}] >/dev/null || break
-		case "$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" in */bin/busybox*) ;; *) continue; esac
-		addnmount_deleted=
-		log_msg -purple "" "Deleting the custom addnmount entry from /etc/config/dhcp."
-		if uci -q del_list dhcp.@dnsmasq[${i}].addnmount='/bin/busybox' && uci commit
+		del_addnmount "${i}"
+		case ${?} in
+			0) addnm_deleted=1 ;;
+			3) ;;
+			1) addnm_del_fail=1 ;;
+			2) addnm_deleted=1 addnm_del_fail=1
+		esac
+	done
+
+	if [ -n "${addnm_deleted}" ]
+	then
+		if uci commit dhcp
 		then
-			case "$(uci -q get dhcp.@dnsmasq[${i}].addnmount)" in */bin/busybox*) continue; esac
-			addnmount_deleted=1
 			log_msg "Note: the adblock-lean developers are not aware of any other software that requires the specific addnmount entry created by adblock-lean." \
 				"Should the addnmount entry be required for any reason then you will need to manually re-add it."
+		else
+			uci revert dhcp
+			addnm_del_fail=1
 		fi
-		break
-	done
-	[ -z "${addnmount_deleted}" ] &&
-		reg_failure "Failed to delete the custom addnmount entry from /etc/config/dhcp. Please delete manually."
+	fi
+
+	[ -n "${addnm_del_fail}" ] && log_msg "Some addnmount entries were not deleted. Please delete manually."
 
 	log_msg -purple "" "Deleting the scripts."
 	rm -f "${ABL_SERVICE_PATH}"

--- a/adblock-lean
+++ b/adblock-lean
@@ -998,7 +998,7 @@ init_command()
 	local config_req='' work_dir_req='' init_action_msg='' process_vars_req=''
 
 	DO_DIALOGS=
-	[ -z "${ABL_LUCI_SOURCED}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
+	[ -z "${ABL_LUCI_SOURCED}" ] && [ -z "${APPROVE_UPD_CHANGES}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
 
 	if [ -z "${ABL_NOTRAPS}" ]
 	then
@@ -1708,7 +1708,7 @@ update()
 		upd_channel='' req_upd_channel='' force_upd_channel='' force_update=''
 
 	IGNORE_CACHE=
-	while getopts ":s:v:U:W:fi" opt
+	while getopts ":s:v:U:W:yfi" opt
 	do
 		case ${opt} in
 			s) export sim_path="$OPTARG" ;;
@@ -1716,6 +1716,7 @@ update()
 			U) force_upd_channel=$OPTARG force_update=1 ;;
 			W) req_ver=$OPTARG force_update=1 ;;
 			f) force_update=1 libs_req='' ;;
+			y) export APPROVE_UPD_CHANGES=1 DO_DIALOGS='' ;;
 			i) IGNORE_CACHE=1 ;; # global var
 			*) unexp_arg "$OPTARG"; return 1
 		esac

--- a/adblock-lean
+++ b/adblock-lean
@@ -1,9 +1,10 @@
 #!/bin/sh /etc/rc.common
-# shellcheck disable=SC3043,SC2018,SC3020,SC1090,SC3045,SC2155,SC2015,SC3057,SC3044,SC2016,SC3003
+# shellcheck disable=SC3043,SC2018,SC3020,SC1090,SC3045,SC2155,SC2015,SC3057,SC3044,SC2016,SC3003,SC3060
 
 # adblock-lean - powerful and ultra efficient adblocking with dnsmasq on OpenWrt
 # Project homepage: https://github.com/lynxthecat/adblock-lean
-# ABL_VERSION=dev
+ABL_VERSION=dev
+ABL_UPD_CHANNEL=release
 
 START=99
 STOP=04
@@ -30,11 +31,16 @@ _NL_='
 '
 IFS="${DEFAULT_IFS}"
 
-if [ -t 0 ]
+CONFIG_FORMAT=v8
+
+if [ -z "${MSGS_DEST}" ]
 then
-	MSGS_DEST=/dev/tty
-else
-	MSGS_DEST=/dev/null
+	if [ -t 0 ]
+	then
+		export MSGS_DEST=/dev/tty
+	else
+		export MSGS_DEST=/dev/null
+	fi
 fi
 
 ABL_DIR=/var/run/adblock-lean
@@ -45,11 +51,18 @@ ABL_UPD_DIR="/var/run/adblock-lean-update"
 ABL_CONF_STAGING_DIR="/tmp/abl-conf-staging"
 
 ABL_SERVICE_PATH=/etc/init.d/adblock-lean
-ABL_LIB_FILES="${ABL_LIB_DIR}/abl-lib.sh ${ABL_LIB_DIR}/abl-process.sh"
+
+ABL_FILE_TYPES="GEN LIB EXTRA"
+
+ABL_GEN_FILES="${ABL_SERVICE_PATH}"
+ABL_LIB_FILES="${ABL_LIB_DIR}/abl-lib.sh
+	${ABL_LIB_DIR}/abl-process.sh"
 ABL_EXTRA_FILES="" # may be useful in the future
+ABL_EXEC_FILES="${ABL_SERVICE_PATH}"
+
+ABL_FILES_REG_PATH=/etc/adblock-lean/abl-reg.md5
 
 ABL_CONFIG_FILE=${ABL_CONFIG_DIR}/config
-CONFIG_FORMAT=v7
 
 PID_FILE="${ABL_PID_DIR}/adblock-lean.pid"
 ACTION_FILE="${ABL_PID_DIR}/adblock-lean.action"
@@ -61,7 +74,8 @@ UCL_ERR_FILE="${ABL_DIR}/uclient-fetch_err"
 ABL_CRON_CMD="/etc/init.d/adblock-lean start"
 
 : "${ABL_REPO_AUTHOR:=lynxthecat}"
-ABL_GH_URL_API=https://api.github.com/repos/${ABL_REPO_AUTHOR}/adblock-lean
+ABL_GH_URL_API="https://api.github.com/repos/${ABL_REPO_AUTHOR}/adblock-lean"
+ABL_MAIN_BRANCH=master
 
 SCHEDULER_PID=
 
@@ -88,11 +102,22 @@ adblock-lean custom commands:
 : "${action:=}" "${action_rv}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}"
 : "${purple}" "${green}" "${TAB}" "${CR}" "${CR_LF}"
 : "${AWK_CMD}" "${SORT_CMD}"
+: "${ABL_GEN_FILES}" "${ABL_LIB_FILES}" "${ABL_EXTRA_FILES}" "${ABL_EXEC_FILES}" "${CONFIG_FORMAT}"
 : "${luci_log}" "${luci_pid_action}" "${luci_errors}" "${luci_dnsmasq_status}"
 : "${luci_good_line_count}" "${luci_update_status}" "${luci_pkgs_install_failed}" "${luci_cron_job_creation_failed}"
 
 
 ### UTILITY FUNCTIONS
+
+# check if var names are safe to use with eval
+are_var_names_safe() {
+	local var_name
+	for var_name in "${@}"
+	do
+		case "${var_name}" in *[!a-zA-Z_]*) reg_failure "Invalid var name '${var_name}'."; return 1; esac
+	done
+	:
+}
 
 check_func()
 {
@@ -210,11 +235,6 @@ read_str_from_file()
 	return 1
 }
 
-get_md5()
-{
-	md5sum "${1}" | cut -d' ' -f1
-}
-
 # 0 - (optional) '-p'
 # 1 - path
 try_mkdir()
@@ -247,6 +267,59 @@ pick_opt()
 
 ### HELPER FUNCTIONS
 
+# Get version and update channel of adblock-lean file
+# Assigns vars $2 = version, $3 = update channel
+# 1 - path to adblock-lean service file
+# Return codes:
+# 1 - error
+# 2 - no version found
+# 3 - new version format
+# 4 - old version format
+get_abl_version()
+{
+	get_ver_str()
+	{
+		local key_ptrn='' migr_ptrn=''
+		case "${1}" in
+			version)
+				key_ptrn="\\s*ABL_VERSION"
+				[ "${3}" = '-o' ] && migr_ptrn='s/^[^_]*_//;' ;;
+			upd_channel)
+				key_ptrn="\\s*ABL_UPD_CHANNEL"
+				[ "${3}" = '-o' ] && { key_ptrn="\\s*ABL_VERSION" migr_ptrn='s/_.*//;'; }
+		esac
+		[ "${3}" = '-o' ] && key_ptrn="\\s*#${key_ptrn}"
+
+		${SED_CMD} -n "/^${key_ptrn}=/{s/^${key_ptrn}=//;s/#.*$//;s/\"//g;${migr_ptrn}p;:1 n;b1;}" "${2}"
+	}
+
+	local gv_ver='' gv_upd_ch='' gv_rv=''
+	if [ -n "${2}${3}" ]
+	then
+		are_var_names_safe "${2}" "${3}" || return 1
+		eval "${2}"='' "${3}"=''
+	fi
+	# version format in v0.7.2 and later
+	if grep -q '^\s*ABL_UPD_CHANNEL=' "${1}" &&
+		gv_upd_ch="$(get_ver_str upd_channel "${1}")" &&
+		gv_ver="$(get_ver_str version "${1}")" &&
+		[ -n "${gv_upd_ch}" ] && [ -n "${gv_ver}" ]
+	then
+		gv_rv=3
+	# version format in v0.6.0 - v0.7.1
+	elif grep -q '^\s*#\s*ABL_VERSION=' "${1}" &&	
+		gv_upd_ch="$(get_ver_str upd_channel "${1}" -o)" &&
+		gv_ver="$(get_ver_str version "${1}" -o)" &&
+		[ -n "${gv_upd_ch}" ] && [ -n "${gv_ver}" ]
+	then
+		gv_rv=4
+	else
+		gv_rv=2
+	fi
+	[ -n "${2}${3}" ] && eval "${2}"='${gv_ver}' "${3}"='${gv_upd_ch}'
+	return ${gv_rv}
+}
+
 rc_disable()
 {
 	rm -f /etc/rc.d/S${START}adblock-lean /etc/rc.d/K${STOP}adblock-lean
@@ -268,26 +341,41 @@ rc_enabled()
 
 # sets $AWK_CMD, $SED_CMD, $SORT_CMD
 detect_utils() {
-	if type gawk &> /dev/null
-	then
-		AWK_CMD="gawk"
-	else
-		AWK_CMD="busybox awk"
-	fi
+	detect_util()
+	{
+		local out_var="${1}" pkg_name="${2}" gen_name="${3}" specific_path="${4}" busybox_cmd="${5}" specific_name="${6}" \
+			res_cmd=''
+		are_var_names_safe "${out_var}" || return 1
+		if [ -f "${specific_path}" ]
+		then
+			res_cmd="${specific_path}"
+		elif [ -n "${specific_name}" ] && check_util "${specific_name}"
+		then
+			res_cmd="${specific_name}"
+		elif check_util "${gen_name}"
+		then
+			res_cmd="${gen_name}"
+		elif eval "/bin/busybox ${gen_name} ${busybox_cmd} \"${test_path}\"" &>/dev/null
+		then
+			res_cmd="/bin/busybox ${gen_name}"
+		else
+			rm -f "${test_path}"
+			reg_failure "${gen_name} not found. Please install ${pkg_name}."
+			return 1
+		fi
+		: "${res_cmd}"
+		eval "${out_var}"='${res_cmd}'
+	}
 
-	if sed --version 2>/dev/null | grep -qe '(GNU sed)'
-	then
-		SED_CMD="sed"
-	else
-		SED_CMD="busybox sed"
-	fi
+	local test_path=/tmp/utils-test
 
-	if sort --version 2>/dev/null | grep -qe coreutils
-	then
-		SORT_CMD="sort"
-	else
-		SORT_CMD="busybox sort"
-	fi
+	printf '%s\n' "." > "${test_path}" || { reg_failure "Failed to detect utils."; return 1; }
+
+	detect_util SED_CMD sed sed "/usr/libexec/sed-gnu" "-n '/./q'" &&
+	detect_util AWK_CMD gawk awk "/usr/bin/gawk" "'BEGIN{exit}'" gawk &&
+	detect_util SORT_CMD coreutils-sort sort "/usr/libexec/sort-coreutils" || return 1
+
+	rm -f /tmp/utils-test
 	:
 }
 
@@ -371,7 +459,7 @@ cleanup_and_exit()
 	luci_log="${recent_log}"
 
 	# execute custom script actions
-	if [ -z "${luci_sourced}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_func report_failure
+	if [ -z "${ABL_LUCI_SOURCED}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_func report_failure
 	then
 		[ -n "${recent_log}" ] && failure_msg="${failure_msg}${_NL_}${_NL_}Session log:${_NL_}${recent_log}"
 		report_failure "${failure_msg}"
@@ -381,7 +469,7 @@ cleanup_and_exit()
 		report_update "${UPD_AVAIL_MSG}${_NL_}${UPD_DIRECTIONS}"
 	fi
 
-	[ -n "${luci_sourced}" ] && abl_luci_exit "${1}"
+	[ -n "${ABL_LUCI_SOURCED}" ] && abl_luci_exit "${1}"
 	exit "${1}"
 }
 
@@ -491,7 +579,7 @@ update_action_file()
 # 1 (optional): '-log' to log current action as well
 report_curr_action()
 {
-	[ "${MSGS_DEST}" = "/dev/null" ] && [ -z "${luci_sourced}" ] && [ "${1}" != "-log" ] && return 0
+	[ "${MSGS_DEST}" = "/dev/null" ] && [ -z "${ABL_LUCI_SOURCED}" ] && [ "${1}" != "-log" ] && return 0
 	local reported_pid report_cmd=print_msg
 	[ -n "${ACTION_FILE}" ] || { reg_failure "\$ACTION_FILE var is unset."; return 1; }
 	[ -f "${ACTION_FILE}" ] || return 0
@@ -675,53 +763,126 @@ get_abl_run_state()
 	return 4
 }
 
-# 1 (optional) - libs directory
-# 2 (optional) - service directory
-check_libs()
+# 1 - types: 'ALL' (doesn't print executable files) or any combination (space-separated) of 'GEN', 'LIB', 'EXTRA', 'EXEC'
+print_file_list()
 {
-	local lib_file service_file service_version lib_version
-	local libs_dir="${1:-"${ABL_LIB_DIR}"}" service_dir="${2:-"${ABL_SERVICE_PATH%/*}"}"
-	service_file="${service_dir}/adblock-lean"
-	get_abl_version "${service_file}" service_version
-	for lib_file in ${ABL_LIB_FILES}
+	local me=print_file_list file_type files='' IFS="${DEFAULT_IFS}" \
+		file_types="${1}"
+
+	[ -n "$1" ] || { reg_failure "${me}: missing args."; return 1; }
+
+	if [ "${file_types}" = ALL ]
+	then
+		file_types="${ABL_FILE_TYPES}"
+	fi
+
+	for file_type in ${file_types}
 	do
-		lib_file="${libs_dir}/${lib_file##*/}"
-		if [ -s "${lib_file}" ]
-		then
-			get_abl_version "${lib_file}" lib_version
-			if [ "${lib_version}" = "${service_version}" ]
-			then
-				continue
-			else
-				log_msg -warn "Version mismatch between ${service_file} ('${service_version}') and ${lib_file} ('${lib_version}')."
-			fi
-		else
-			log_msg -warn "adblock-lean library files are missing."
-		fi
-		return 1
+		case "${file_type}" in
+			GEN|LIB|EXTRA|EXEC)
+				eval "files=\"${files}\${ABL_${file_type}_FILES}${_NL_}\"" ;;
+			*) reg_failure "${me}: invalid type '${file_type}'"; return 1
+		esac
 	done
+
+	# remove extra newlines, leading and trailing whitespaces and tabs
+	printf '%s\n' "${files}" | ${SED_CMD} "s/^\s*//;s/\s*$//;/^$/d"
 	:
 }
 
-# 1 (optional) - libs directory
-# 2 (optional) - service directory
+ver_upd_fixup()
+{
+	local me=ver_upd_fixup fix_ver='' fix_upd_channel='' md5sums='' \
+		curr_ver="${1}" curr_upd_ch="${2}"
+
+	[ -n "${1}" ] && [ -n "${2}" ] || { reg_failure "${me}: missing args."; return 1; }
+
+	log_msg -purple "Completing adblock-lean version upgrade..."
+
+	# fix version and upd channel strings in installed files, then make md5sum registry
+	case "${curr_upd_ch}" in
+		''|release|latest) fix_upd_channel=release ;;
+		*) fix_upd_channel="${curr_upd_ch}"
+	esac
+
+	fix_ver="${curr_ver#v}"
+	: "${fix_ver:=dev}"
+
+	# shellcheck disable=SC2046
+	busybox sed -i "
+		s/^\s*ABL_VERSION=.*/ABL_VERSION=\"${fix_ver}\"/
+		s/^\s*ABL_UPD_CHANNEL=.*/ABL_UPD_CHANNEL=\"${fix_upd_channel}\"/" \
+			"${ABL_SERVICE_PATH}" &&
+	mkdir -p "${ABL_FILES_REG_PATH%/*}" &&
+	local IFS="${_NL_}" &&
+	set -- $(print_file_list ALL) &&
+	IFS="${DEFAULT_IFS}" &&
+	md5sums="$(md5sum "$@")" && [ -n "${md5sums}" ] &&
+	printf '%s\n' "${md5sums}" > "${ABL_FILES_REG_PATH}" ||
+		reg_failure "${me}: Failed to register new files. Please re-install adblock-lean."
+	:
+}
+
+# return codes:
+# 0 - OK
+# 1 - general error
+# 2 - missing files
+# 3 - non-matching md5sums
+check_libs()
+{
+	local file files='' reg_file="${ABL_FILES_REG_PATH}"
+
+	files="$(print_file_list ALL)" && [ -n "${files}" ] ||
+		{ reg_failure "check_libs: failed to get file list."; return 1; }
+	
+	local IFS="${_NL_}"
+	for file in ${reg_file}${_NL_}${files}
+	do
+		[ -n "$file" ] || continue
+		[ -f "$file" ] || { reg_failure "Missing file: '$file'."; return 2; }
+	done
+
+	IFS="${DEFAULT_IFS}"
+
+	md5sum -c "${reg_file}" &>/dev/null || return 3
+	:
+}
+
 source_libs()
 {
 	[ -n "${LIBS_SOURCED}" ] && return 0
 
-	local file libs_dir="${1:-"${ABL_LIB_DIR}"}" service_dir="${2:-"${ABL_SERVICE_PATH%/*}"}" libs_missing='' libs_source_failed=''
-	if ! check_libs "${libs_dir}" "${service_dir}"
+	# fixup for upgrading from earlier versions
+	if [ ! -f "${ABL_REG_FILE}" ] && [ -f "${ABL_CONFIG_DIR}/ver_migration" ]
 	then
-		log_msg "Please run 'sh /etc/init.d/adblock-lean update -f' to fetch required files."
-		return 1
+		local curr_ver='' curr_upd_ch=''
+		read_str_from_file -f "${ABL_CONFIG_DIR}/ver_migration" -d -v "curr_upd_ch curr_ver" &&
+		[ -n "${curr_upd_ch}" ] && [ -n "${curr_ver}" ] &&
+		ver_upd_fixup "${curr_ver}" "${curr_upd_ch}" &&
+		. "${ABL_SERVICE_PATH}" || return 1
 	fi
+
+	local file libs_missing='' libs_source_failed=''
+	if [ -z "${UPD_SOURCED}" ]
+	then
+		check_libs
+	else
+		:
+	fi
+	case ${?} in
+		0|3) ;;
+		*)
+			log_msg "Please run 'sh /etc/init.d/adblock-lean update -f' to fetch required files."
+			return 1
+	esac
 
 	# source libs
 	for file in ${ABL_LIB_FILES}
 	do
 		file="${file##*/}"
-		[ -f "${libs_dir}/${file}" ] || { libs_source_failed=1 libs_missing=1; break; }
-		. "${libs_dir}/${file}" || { libs_source_failed=1; break; }
+		[ -f "${ABL_LIB_DIR}/${file}" ] || { libs_source_failed=1 libs_missing=1; break; }
+		# shellcheck source=/dev/null
+		. "${ABL_LIB_DIR}/${file}" || { libs_source_failed=1; break; }
 	done
 
 	[ -n "${libs_source_failed}" ] &&
@@ -777,12 +938,8 @@ init_command()
 	ABL_CMD="${1}"
 	local config_req='' work_dir_req='' init_action_msg=''
 
-	# detect if sourced from external RPC script for luci, depends on abl_luci_exit() being defined
-	luci_sourced=
-	check_func "abl_luci_exit" && luci_sourced=1
-
 	DO_DIALOGS=
-	[ -z "${luci_skip_dialogs}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
+	[ -z "${ABL_LUCI_SOURCED}" ] && [ "${MSGS_DEST}" = "/dev/tty" ] && DO_DIALOGS=1
 
 	if [ -z "${ABL_NOTRAPS}" ]
 	then
@@ -866,7 +1023,9 @@ init_command()
 
 	if [ -n "${config_req}" ] && [ -z "${CONFIG_LOADED}" ]
 	then
-		load_config || { reg_failure "Failed to load config."; exit 1; }
+		local force_config_fix=
+		[ -n "${ABL_LUCI_SOURCED}" ] && force_config_fix='-f'
+		load_config ${force_config_fix} || { reg_failure "Failed to load config."; exit 1; }
 		CONFIG_LOADED=1
 	fi
 
@@ -877,6 +1036,7 @@ init_command()
 			if [ -n "${custom_script}" ]
 			then
 				custom_scr_sourced=
+				# shellcheck source=/dev/null
 				[ -f "${custom_script}" ] && . "${custom_script}" && custom_scr_sourced=1 ||
 					reg_failure "Custom script '${custom_script}' doesn't exist or it returned an error."
 			fi
@@ -885,98 +1045,215 @@ init_command()
 	:
 }
 
-# get version of adblock-lean file $1
-# assign version to var $2, update channel to var $3
-get_abl_version()
-{
-	unset "${2}" "${3:-dummy}"
-	local gv_ver_string gv_version gv_upd_channel
-	gv_ver_string="$(${SED_CMD} -n '/^\s*#\s*ABL_VERSION=/{s/^\s*#\s*ABL_VERSION=//;s/\s*$//;p;q;}' "${1}")"
-	gv_version="${gv_ver_string##*_}"
-	gv_upd_channel="${gv_ver_string%"_${gv_version}"}"
-	: "${gv_upd_channel}" # silence shellcheck warning
-	eval "${2}"='${gv_version}'
-	[ -n "${3}" ] && eval "${3}"='${gv_upd_channel}'
-}
-
-# Get GitHub ref and tarball url for specified version
-# 1 - [latest|snapshot|v<version>|tag=<github_tag>|commit=<commit_hash>]
+# Get GitHub ref and tarball url for specified component, update channel, branch and version
+# 1 - update channel: release|snapshot|branch=<github_branch>|commit=<commit_hash>
+# 2 - version (optional): [version|commit_hash]
 # Output via variables:
-#   $2 - github ref, $3 - tarball url, $4 - update channel
-get_gh_ref_data()
+#   $3 - github ref (version/commit hash), $4 - tarball url, $5 - version type ('version' or 'commit')
+get_gh_ref()
 {
-	local me=get_gh_ref_data ref_fetch_url jsonfilter_ptrn commit version="${1}"
-	local gh_ref=''  gh_channel=''
-	unset "${2}" "${3}" "${4}"
+	set_res_vars()
+	{
+		# validate resulting ref
+		case "${gr_ref}" in
+			*[^"${_NL_}"]*"${_NL_}"*[^"${_NL_}"]*)
+				reg_failure "Got multiple download URLs for version '${gr_version}'." \
+					"If using commit hash, please specify the complete commit hash string."
+				return 1 ;;
+			''|*[!a-zA-Z0-9._-]*)
+				reg_failure "Failed to get GitHub download URL for ${gr_ver_type} '${gr_version}' (update channel: '${gr_channel}')."
+				return 1
+		esac
 
-	case "${version}" in
-		snapshot)
-			ref_fetch_url="${ABL_GH_URL_API}/commits/master"
-			jsonfilter_ptrn='@.sha' # latest commit is first on the list
-			gh_channel=snapshot ;;
-		latest)
-			ref_fetch_url="${ABL_GH_URL_API}/releases"
-			jsonfilter_ptrn='@[@.prerelease=false]' # ignore pre-releases
-			gh_channel=release ;;
-		v[0-9]*)
-			gh_ref="${version}"
-			gh_channel=release ;;
-		tag=*)
-			gh_ref="${version#tag=}"
-			gh_channel=tag ;;
-		commit=*)
-			commit="${version#commit=}"
-			gh_ref="${commit%"${commit#???????}"}" # trim commit hash to 7 characters
-			gh_channel=commit ;;
-		*) reg_failure "${me}: invalid version '${version}'."; return 1
+		case "${gr_channel}" in
+			release|latest) gr_channel=release gr_version="${gr_ref#v}" ;;
+			*) gr_version="${gr_ref}"
+		esac
+
+		eval "${3}"='${gr_version}' "${4}"='${ABL_GH_URL_API}/tarball/${gr_ref}' "${5}"='${gr_ver_type}' \
+			"prev_ref"='${gr_ref}' "prev_ver_type"='${gr_ver_type}' \
+			"prev_upd_channel"='${gr_channel}' "prev_version"='${gr_version}'
+	}
+
+	local gr_branch gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
+		gr_fetch_tmp_dir="${ABL_UPD_DIR}/ref_fetch" \
+		prev_ref prev_ver_type prev_upd_channel prev_version \
+		gr_channel="${1}" gr_version="${2}"
+
+	[ "$gr_channel" = release ] && gr_version="${gr_version#v}"
+
+	local gr_ucl_err_file="${gr_fetch_tmp_dir}/ucl_err"
+
+	are_var_names_safe "${3}" "${4}" "${5}" || return 1
+	eval "${3}='' ${4}='' ${5}=''"
+
+	eval "prev_ref=\"\${prev_ref}\"
+		prev_ver_type=\"\${prev_ver_type}\"
+		prev_upd_channel=\"\${prev_upd_channel}\"
+		prev_version=\"\${prev_version}\""
+
+	# if commit hash is specified and it's 40-char long, use it directly without API query or cache check
+	case "${gr_channel}" in
+		snapshot|branch=*|commit=*) [ "${#gr_version}" = 40 ] && gr_ref="${gr_version}"
 	esac
 
-	if [ -n "${ref_fetch_url}" ]
+	# if previously stored data exists, use it without API query or cache check
+	if [ -z "${gr_ref}" ] && [ -n "${prev_ref}" ] && [ -n "${prev_ver_type}" ] && \
+		[ "${prev_upd_channel}" = "${gr_channel}" ] && [ "${gr_version}" = "${prev_version}" ]
 	then
-		# Get ref for latest/snapshot
-		log_msg -blue "Getting GitHub ref for ${version} version of adblock-lean."
-		gh_ref="$(
-			uclient-fetch -q "${ref_fetch_url}" -O - 2> "${UCL_ERR_FILE}" |
-			jsonfilter -e "${jsonfilter_ptrn}" |
-			{
-				case "${version}" in
-					snapshot) head -c7 ;;
-					latest)
-						jsonfilter -a -e '@[@.target_commitish="master"].tag_name' | # get latest tag for master
-						head -n1
-				esac
-				cat 1>/dev/null
-			}
-		)"
+			gr_ref="${prev_ref}" gr_ver_type="${prev_ver_type}"
+	elif [ -z "${gr_ref}" ]
+	then
+		# ref cache
+		local cache_ttl cache_file cache_filename="${gr_version}_${gr_channel}" gr_cache_dir="/tmp/abl_cache"
+		case "${gr_channel}" in
+			commit=*) cache_ttl=2880 ;; # 48 hours
+			*) cache_ttl=10 # 10 minutes
+		esac
+
+		# clean up old cache
+		find "${gr_cache_dir:-?}" -maxdepth 1 -type f -mmin +"${cache_ttl}" -exec rm -f {} \; 2>/dev/null
+
+		# check if the query is cached
+		cache_file="$(find "${gr_cache_dir:-?}" -maxdepth 1 -type f -name "${cache_filename}" -print 2>/dev/null)"
+		case "${cache_file}" in
+			'') ;; # found nothing
+			*[^"${_NL_}"]*"${_NL_}"*[^"${_NL_}"]*)
+				# found multiple files - delete them
+				local file IFS="${_NL_}"
+				for file in ${cache_file}
+				do
+					[ -n "${file}" ] || continue
+					rm -f "${file}"
+				done
+				IFS="${DEFAULT_IFS}" ;;
+			*)
+				# found cached query
+				if [ -z "${IGNORE_CACHE}" ] && [ -f "${cache_file}" ] &&
+					read -r prev_ref prev_ver_type < "${cache_file}" &&
+					[ -n "${prev_ref}" ] && [ -n "${prev_ver_type}" ]
+				then
+					gr_ref="${prev_ref}" gr_ver_type="${prev_ver_type}"
+				else
+					rm -f "${cache_file:-???}"
+				fi
+		esac
 	fi
 
-	# validate resulting ref
-	case "${gh_ref}" in
-		''|*[!a-zA-Z0-9._-]*) reg_failure "${me}: failed to get GitHub ref for version '${version}'."; return 1
+	if [ -n "${gr_ref}" ]
+	then
+		set_res_vars "${@}" || return 1
+		return 0
+	fi
+
+	try_mkdir -p "${gr_fetch_tmp_dir}" || return 1
+	rm -f "${gr_ucl_err_file}"
+
+	case "${gr_channel}" in
+		release)
+			gr_ver_type=version
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^v${gr_version#v}$" ;;
+		snapshot)
+			gr_ver_type=commit
+			gr_branches="${ABL_MAIN_BRANCH}"
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^${gr_version}$" ;;
+		branch=*)
+			gr_ver_type=commit
+			gr_branches="${gr_channel#*=}"
+			[ -n "${gr_version}" ] && gr_grep_ptrn="^${gr_version}$" ;;
+		commit=*)
+			gr_ver_type=commit
+			local gr_hash="${gr_channel#*=}"
+
+			if [ "${#gr_hash}" = 40 ]
+			then
+				# if upd. ch. is 'commit', the upd. ch. string includes commit hash -
+				#    if it's 40-char long, use it directly without API query
+				gr_ref="${gr_hash}"
+			else
+				gr_branches="$(
+					uclient-fetch "${ABL_GH_URL_API}/branches" -O-  2> "${gr_ucl_err_file}" |
+						{ jsonfilter -e '@[@]["name"]'; cat 1>/dev/null; }
+				)"
+				[ -n "${gr_branches}" ] || {
+					reg_failure "Failed to get adblock-lean branches via GH API (url: '${ABL_GH_URL_API}/branches')."
+					[ -f "${gr_ucl_err_file}" ] &&
+						log_msg "uclient-fetch log:${_NL_}$(cat "${gr_ucl_err_file}")"
+						rm -f "${gr_ucl_err_file}"
+					return 1
+				}
+				rm -f "${gr_ucl_err_file}"
+				gr_grep_ptrn="^${gr_hash}"
+			fi ;;
+		*)
+			reg_failure "Invalid update channel '${gr_channel}'."
+			return 1
 	esac
 
-	eval "${2}"='${gh_ref}' "${3}"='${ABL_GH_URL_API}/tarball/${gh_ref}' "${4}"='${gh_channel}'
-	: "${gh_channel}" # silence shellcheck warning
+	# Get GH ref
+	[ -z "${gr_ref}" ] && gr_ref="$(
+		case "${gr_channel}" in
+			release)
+				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${gr_ucl_err_file}" | {
+					jsonfilter -e '@[@.prerelease=false]' |
+					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
+					cat 1>/dev/null
+				} ;;
+			snapshot|branch=*|commit=*)
+				for gr_branch in ${gr_branches}
+				do
+					ref_fetch_url="${ABL_GH_URL_API}/commits?sha=${gr_branch}"
+					uclient-fetch "${ref_fetch_url}" -O- 2> "${gr_ucl_err_file}" | {
+						jsonfilter -e '@[@.commit]["url"]' |
+						${SED_CMD} 's/.*\///' # only leave the commit hash
+						cat 1>/dev/null
+					}
+				done
+		esac |
+		{
+			if [ -n "${gr_grep_ptrn}" ]
+			then
+				grep "${gr_grep_ptrn}"
+			else
+				head -n1 # get latest version or commit
+			fi
+			cat 1>/dev/null
+		}
+	)"
 
+	if [ -z "${gr_ref}" ]
+	then
+		gr_fetch_rv=1
+		reg_failure "Failed to get GitHub download URL for ${gr_ver_type} '${gr_version}' (update channel: '${gr_channel}')."
+		[ -f "${gr_ucl_err_file}" ] && log_msg "uclient-fetch output:${_NL_}$(cat "${gr_ucl_err_file}")"
+	fi
+	rm -rf "${gr_fetch_tmp_dir:-?}"
+	[ "$gr_fetch_rv" = 0 ] || return 1
+
+	# write query result to cache
+	try_mkdir -p "${gr_cache_dir}" &&
+	printf '%s\n' "${gr_ref} ${gr_ver_type}" > "${gr_cache_dir}/${cache_filename}"
+
+	set_res_vars "${@}" || return 1
 	:
-}
-
-# 1 - new version
-# 2 - path to file
-update_version()
-{
-	${SED_CMD} -i "/^\s*#\s*ABL_VERSION=/{s/.*/# ABL_VERSION=${1}/;:1 n;b1;}" "${2}"
 }
 
 # will be executed upon update from the old version of the script, before new version is installed
 abl_post_update_1()
 {
+	[ -n "${POST_UPDATE_1_DONE}" ] && return 0
+	POST_UPDATE_1_DONE=1
+
 	# fix incorrect rc.d symlink from older versions
-	[ -f /etc/rc.d/K4adblock-lean ] || [ -f /etc/rc.d/k99adblock-lean ] && mv /etc/rc.d/K*adblock-lean /etc/rc.d/K${STOP}adblock-lean
+	local file
+	for file in /etc/rc.d/K4adblock-lean /etc/rc.d/k99adblock-lean
+	do
+		[ -f "${file}" ] && mv "${file}" /etc/rc.d/K${STOP}adblock-lean
+	done
 
 	# @temp_workaround - remove a few months from now
 	# when upgrading from older versions, fetch and install latest release
-	if [ -z "${POST_UPDATE_1_DONE}" ] && [ -f "${ABL_DIR}/adblock-lean.latest" ]
+	if [ -f "${ABL_DIR}/adblock-lean.latest" ]
 	then
 		if rc_enabled
 		then
@@ -984,102 +1261,76 @@ abl_post_update_1()
 			(
 				unset -f clean_dnsmasq_dir restart_dnsmasq
 				unset action ABL_CMD
+				# shellcheck source=/dev/null
 				. "${ABL_SERVICE_PATH}"
 				check_func clean_dnsmasq_dir && clean_dnsmasq_dir &&
 				check_func restart_dnsmasq && restart_dnsmasq
 			)
 		fi
-		POST_UPDATE_1_DONE=1
-		update -f -v latest || exit 1
+		update -f -v release || exit 1
 		cp "${ABL_SERVICE_PATH}" "${ABL_DIR}/adblock-lean.latest"
 	fi
+
 	:
 }
 
-# assigns path to extracted distribution directory to $1
-# (optional) 1 - '-n' to quiet
-# 1 - var name for output
-# 2 - tarball url
-# 3 - github ref
+abl_post_update_2()
+{
+	# fixups for upgrading from earlier versions
+	get_abl_version "${ABL_SERVICE_PATH}"
+	case "${?}" in
+		1) exit 1 ;;
+		2)
+			# no version string found
+			update -f -v release || exit 1 ;;
+		3) ;; # new version format
+		4)
+			# old version format
+			[ -n "${dist_dir}" ] && [ -n "${upd_channel}" ] && [ -n "${ref}" ] &&
+			mkdir -p "${ABL_CONFIG_DIR}" &&
+			printf '%s\n' " $(print_file_list ALL | tr '\n' ' ' | busybox sed 's/\s\s*/ /g') " > "${dist_dir}/inst_files" &&
+			printf '%s\n' "${upd_channel} ${ref}" > "${ABL_CONFIG_DIR}/ver_migration"
+	esac
+
+	:
+}
+
+# Fetches and unpacks adblock-lean distribution
+# 1 - tarball url
+# 2 - distribution directory
 fetch_abl_dist()
 {
-	if [ "${1}" = '-n' ]
-	then
-		shift
-	else
-		reg_action -blue "Downloading adblock-lean, version '${3}'." || return 1
-	fi
+	[ -n "${1}" ] && [ -n "${2}" ] || { reg_failure "fetch_abl_dist: missing arguments."; return 1; }
 
-	local fetch_tarball_url="${2}"
-	local fetch_dir fetch_rv tarball="${ABL_UPD_DIR}/remote_abl.tar.gz"
+	local tarball_url_fetch="${1}" dist_dir_fetch="${2}"
 
-	rm -rf "${UCL_ERR_FILE}" "${ABL_UPD_DIR}/${ABL_REPO_AUTHOR}-adblock-lean-"*
-	uclient-fetch "${fetch_tarball_url}" -O "${tarball}" 2> "${UCL_ERR_FILE}" &&
-	grep -q "Download completed" "${UCL_ERR_FILE}" &&
-	tar -C "${ABL_UPD_DIR}" -xzf "${tarball}" &&
-	fetch_dir="$(find "${ABL_UPD_DIR}/" -type d -name "${ABL_REPO_AUTHOR}-adblock-lean-*")"
+	local fetch_rv extract_dir fetch_dir="${dist_dir_fetch}/fetch"
+	local  tarball="${fetch_dir}/remote_abl.tar.gz" ucl_err_file="${fetch_dir}/ucl_err" \
+
+
+	rm -f "${ucl_err_file}" "${tarball}"
+	rm -rf "${fetch_dir}/${ABL_REPO_AUTHOR}-adblock-lean-"*
+	try_mkdir -p "${fetch_dir}" || return 1
+
+	uclient-fetch "${tarball_url_fetch}" -O "${tarball}" 2> "${ucl_err_file}" &&
+	grep -q "Download completed" "${ucl_err_file}" &&
+	tar -C "${fetch_dir}" -xzf "${tarball}" &&
+	extract_dir="$(find "${fetch_dir}/" -type d -name "${ABL_REPO_AUTHOR}-adblock-lean-*")" &&
+		[ -n "${extract_dir}" ] && [ "${extract_dir}" != "/" ]
 	fetch_rv=${?}
+	rm -f "${tarball}"
 
-	[ "${fetch_rv}" != 0 ] && [ -s "${UCL_ERR_FILE}" ] && ! grep -q "Download completed" "${UCL_ERR_FILE}" &&
-		reg_failure "uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'."
-	rm -f "${UCL_ERR_FILE}"
-	eval "${1}"='${fetch_dir}'
-	: "${fetch_dir}" # silence shellcheck warning
+	[ "${fetch_rv}" != 0 ] && [ -s "${ucl_err_file}" ] &&
+		log_msg "uclient-fetch output: ${_NL_}$(cat "${ucl_err_file}")."
+	rm -f "${ucl_err_file}"
+
+	[ "${fetch_rv}" = 0 ] && {
+		mv "${extract_dir:-?}"/* "${dist_dir_fetch:-?}/" ||
+			{ rm -rf "${extract_dir:-?}"; reg_failure "Failed to move files to dist dir."; return 1; }
+	}
+	rm -rf "${extract_dir:-?}" "${fetch_dir:-?}"
+
 	return ${fetch_rv}
-}
-
-# 1 - path to distribution dir
-# 2 - version string to write to files
-install_abl_files()
-{
-	local file preinst_path new_files curr_files
-	local dist_dir="${1}" version="${2}"
-
-	# read new files list
-	read_str_from_file -d -v new_files -f "${dist_dir}/inst_files" -a 2 || return 1
-
-	# compile current files list
-	curr_files="${ABL_SERVICE_PATH}"
-	for file in ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}
-	do
-		add2list curr_files "${file}" " "
-	done
-
-	# delete obsolete files
-	for file in ${curr_files}
-	do
-		if [ -f "${file}" ] && ! is_included "${file}" "${new_files}" " "
-		then
-			log_msg "Deleting obsolete file ${file}."
-			rm -f "${file}"
-		fi
-	done
-
-	for file in ${new_files}
-	do
-		case "${file##*/}" in
-			adblock-lean) preinst_path="${dist_dir}/adblock-lean" ;;
-			*) preinst_path="${dist_dir}/${file}"
-		esac
-
-		# set new ABL_VERSION
-		update_version "${version}" "${preinst_path}"
-
-		if [ -f "${file}" ] && check_util md5sum && [ "$(get_md5 "${preinst_path}")" = "$(get_md5 "${file}")" ]
-		then
-			log_msg "File '${file}' did not change - not updating."
-		else
-			log_msg "Copying file '${file##*/}'."
-			try_mkdir -p "${file%/*}" && cp "${preinst_path}" "${file}" ||
-			{
-				reg_failure "Failed to copy file '${file##*/}'."
-				return 1
-			}
-		fi
-	done
-
-	chmod +x "${ABL_SERVICE_PATH}"
-	:
 }
 
 # shellcheck disable=SC2120
@@ -1101,9 +1352,7 @@ get_config_format()
 
 version()
 {
-	local version='' upd_channel=''
-	get_abl_version "${ABL_SERVICE_PATH}" version upd_channel
-	print_msg "adblock-lean version: '${version}', update channel: '${upd_channel}'."
+	print_msg "adblock-lean version: '${ABL_VERSION}', update channel: '${ABL_UPD_CHANNEL}'."
 }
 
 gen_config()
@@ -1191,9 +1440,7 @@ boot()
 
 start()
 {
-	local version
-	get_abl_version "${ABL_SERVICE_PATH}" version
-	reg_action -purple "Starting adblock-lean, version ${version}."
+	reg_action -purple "Starting adblock-lean, version ${ABL_VERSION}."
 	init_command start || exit 1
 
 	if [ "${RANDOM_DELAY}" = "1" ]
@@ -1277,7 +1524,7 @@ reload()
 # 4 - adblock-lean is stopped
 status()
 {
-	local run_state version active_entries_cnt=0 active_entries_cnt_human dnsmasq_status=''
+	local run_state active_entries_cnt=0 active_entries_cnt_human dnsmasq_status=''
 	init_command status || exit 1
 	check_lock
 	case ${?} in
@@ -1288,8 +1535,7 @@ status()
 	esac
 	get_abl_run_state
 	run_state=${?}
-	get_abl_version "${ABL_SERVICE_PATH}" version
-	log_msg -purple "" "adblock-lean (${version}) status:"
+	log_msg -purple "" "adblock-lean (${ABL_VERSION}) status:"
 	case ${run_state} in
 		0) ;;
 		1) reg_failure "Failed to check adblock-lean run state." ;;
@@ -1368,15 +1614,15 @@ resume()
 }
 
 # optional: '-s <path>' to simulate update (intended for testing: service adblock-lean update -s <path_to_new_ver> -v <version>)
-# optional: -v [latest|snapshot|v<version>|tag=<github_tag>|commit=<commit_hash>]
+# optional: -v [release|snapshot|<version>|branch=<github_branch>|commit=<commit_hash>]
 # optional: '-f' to skip calling stop()
 update()
 {
 	# unset vars and functions from current version to have a clean slate with the new version
 	clean_abl_env()
 	{
-		unset ABL_LIB_FILES ABL_EXTRA_FILES LIBS_SOURCED CONFIG_FORMAT libs_missing
-		unset -f abl_post_update_1 abl_post_update_2 load_config update source_libs
+		unset action ABL_CMD ABL_LIB_FILES ABL_EXTRA_FILES ABL_EXEC_FILES LIBS_SOURCED CONFIG_FORMAT
+		unset -f abl_post_update_1 abl_post_update_2 load_config update source_libs check_libs install_abl_files cleanup_and_exit
 	}
 
 	upd_failed()
@@ -1388,119 +1634,142 @@ update()
 		rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
 	}
 
-	failsafe_log()
-	{
-		printf '%s\n' "${1}" > "${MSGS_DEST:-/dev/tty}"
-		logger -t adblock-lean "${1}"
-	}
-
 	unexp_arg()
 	{
 		upd_failed "update: unexpected argument '${1}'."
 	}
 
-	init_command update || { upd_failed; return 1; }
+	local file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
+		upd_channel='' req_upd_channel='' force_upd_channel='' force_update=''
 
-	local file version='' force_update='' dist_dir='' ref='' tarball_url='' upd_channel='' prev_config_format upd_config_format
-
-	while getopts ":s:v:f" opt; do
+	IGNORE_CACHE=
+	while getopts ":s:v:U:W:fi" opt
+	do
 		case ${opt} in
-			s) SIM_PATH=${OPTARG} ;;
-			v) version=${OPTARG} ;;
-			f) force_update=1 ;;
-			*) unexp_arg "-${OPTARG}"; return 1
+			s) export sim_path="$OPTARG" ;;
+			v) ver_str_arg=$OPTARG force_update=1 ;;
+			U) force_upd_channel=$OPTARG force_update=1 ;;
+			W) req_ver=$OPTARG force_update=1 ;;
+			f) force_update=1 libs_req='' ;;
+			i) IGNORE_CACHE=1 ;; # global var
+			*) unexp_arg "$OPTARG"; return 1
 		esac
 	done
 	shift $((OPTIND-1))
 	[ -z "${*}" ] || { unexp_arg "${*}"; return 1; }
 
+	init_command update || { upd_failed; return 1; }
+
 	[ -z "${force_update}" ] && stop -noexit
+
+	# parse version string from arguments into $req_upd_channel, $req_ver
+	case "${ver_str_arg}" in
+		'') ;;
+		release|latest)
+			req_upd_channel=release req_ver='' ;;
+		snapshot)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		commit=*)
+			req_upd_channel="${ver_str_arg}" req_ver="${ver_str_arg#*=}" ;;
+		branch=*)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		[0-9]*|v[0-9]*)
+			req_upd_channel=release
+			req_ver="${ver_str_arg#*=}"
+			req_ver="${req_ver#v}"
+			;;
+		*)
+			upd_failed "Invalid version string '${ver_str_arg}'."
+			return 1
+	esac
 
 	rm -rf "${ABL_UPD_DIR:-???}"
 	try_mkdir -p "${ABL_UPD_DIR}" || { upd_failed; return 1; }
 
-	if [ -n "${SIM_PATH}" ]
+	upd_channel="${req_upd_channel:-"${ABL_UPD_CHANNEL}"}"
+	upd_channel="${force_upd_channel:-"${upd_channel}"}"
+	upd_channel="${upd_channel:-"release"}"
+
+	dist_dir="${ABL_UPD_DIR}/dist"
+	try_mkdir -p "${dist_dir}" || { upd_failed; return 1; }
+
+	if [ -n "${sim_path}" ]
 	then
-		print_msg -yellow "Running in simulation mode."
-		[ -d "${SIM_PATH}" ] || { upd_failed "Directory '${SIM_PATH}' does not exist."; return 1; }
-		[ -n "${version}" ] || { upd_failed "Specify new version."; return 1; }
-		upd_channel=release ref="${version}"
-		dist_dir="${ABL_UPD_DIR}/simulation"
-		try_mkdir -p "${dist_dir}" || { upd_failed; return 1; }
-		cp -rT "${SIM_PATH}" "${dist_dir}"
+		print_msg -yellow "Updating in simulation mode."
+		[ -d "${sim_path}" ] || { upd_failed "Update simulation directory '${sim_path}' does not exist."; return 1; }
+		[ -n "${ver_str_arg}" ] || { upd_failed "Specify new version string."; return 1; }
+		upd_ver="${ver_str_arg}"
+
+		[ -d "${sim_path}" ] || { upd_failed "Simulation source directory doesn't exist."; return 1; }
+		cp -rT "${sim_path}" "${dist_dir}"
+		log_msg "" "Updating adblock-lean to version '${upd_ver}' (update channel: '${upd_channel}')."
 	else
-		get_abl_version "${ABL_SERVICE_PATH}" _ upd_channel
-		local def_version
+		get_gh_ref "${upd_channel}" "${req_ver}" upd_ver tarball_url ver_type || { upd_failed; return 1; }
 		case "${upd_channel}" in
-			release) def_version=latest ;;
-			snapshot) def_version=snapshot ;;
-			*) def_version=latest
+			commit=*)
+				# set update channel to 'commit=<full_commit_hash>'
+				upd_channel="${upd_channel%=*}=${upd_ver}"
 		esac
-		: "${version:="${def_version}"}"
-		get_gh_ref_data "${version}" ref tarball_url upd_channel &&
-		fetch_abl_dist dist_dir "${tarball_url}" "${ref}" || { upd_failed; return 1; }
+		log_msg "" "Downloading adblock-lean, ${ver_type} '${upd_ver}' (update channel: '${upd_channel}')."
+		fetch_abl_dist "${tarball_url}" "${dist_dir}" || { upd_failed; return 1; }
 	fi
 
-	prev_config_format="${CONFIG_FORMAT#v}"
-	upd_config_format="$(get_config_format < "${dist_dir}/adblock-lean")"
-
-	unset action ABL_CMD # prevents infinite loop
-
+	get_abl_version "${dist_dir}/adblock-lean"
 	(
-		# shellcheck disable=SC2030
-		UPD_SOURCED=1
+		case "${?}" in
+			2)
+				# no version string found - fetch latest installer script and call install_abl_files() from it
+				unset tarball_url
+				get_gh_ref "release" "" _ tarball_url _ &&
+					fetch_abl_dist "${tarball_url}" "${dist_dir}/fixup" &&
+					[ -f "${dist_dir}/fixup/abl-install.sh" ] ||
+						{ reg_failure "Failed to fetch install script."; exit 1; }
 
-		clean_abl_env
-		export pid_file="${PID_FILE}" # for compatibility with older versions
+				rm -f "${ABL_FILES_REG_PATH}"
+				export pid_file="/tmp/adblock-lean/adblock-lean.pid" # for compatibility with older versions
+				# shellcheck source=/dev/null
+				INST_SOURCED=1 . "${dist_dir}/fixup/abl-install.sh" ||
+					{ reg_failure "Failed to source fetched install script."; exit 1; }
+				install_abl_files "${dist_dir}" "${upd_ver}" "${upd_channel}" "${ABL_SERVICE_PATH}" ;;
+			3)
+				# new version format - call install_abl_files() from fetched installer
+				clean_abl_env
+				# shellcheck source=/dev/null
+				INST_SOURCED=1 . "${dist_dir}/abl-install.sh" ||
+					{ reg_failure "Failed to source fetched install script."; exit 1; }
+				install_abl_files "${dist_dir}" "${upd_ver}" "${upd_channel}" ;;
+			4)
+				# old version format - call install_abl_files() from fetched service file
+				rm -f "${ABL_FILES_REG_PATH}"
+				clean_abl_env
+				# shellcheck source=/dev/null
+				. "${dist_dir}/adblock-lean" ||
+					{ reg_failure "Failed to source fetched script."; exit 1; }
+				printf '%s\n' "${ABL_SERVICE_PATH} ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}" > "${dist_dir}/inst_files"
+				install_abl_files "${dist_dir}" "${upd_channel}_v${upd_ver}" ;;
+			*) reg_failure "Failed to get version from fetched adblock-lean distribution."; exit 1 ;;
+		esac
+	) || exit 1
 
-		curr_dist_dir="${dist_dir}"
-
-		# shellcheck source=/dev/null
-		. "${dist_dir}/adblock-lean" || { failsafe_log "Error: Failed to source the downloaded script."; exit 1; }
-
-		# call abl_post_update_1() in new version
-		check_func abl_post_update_1 && abl_post_update_1
-
-		printf '%s\n' "${ABL_SERVICE_PATH} ${ABL_LIB_FILES} ${ABL_EXTRA_FILES}" > "${curr_dist_dir}/inst_files"
-
-		if [ -n "${upd_config_format}" ] && [ -n "${prev_config_format}" ] && [ "${upd_config_format}" != "${prev_config_format}" ]
-		then
-			failsafe_log "NOTE: config format has changed from v${prev_config_format} to v${upd_config_format}."
-			# load config and call abl_post_update_2() in new version
-			if { ! check_func source_libs || source_libs "${curr_dist_dir}${ABL_LIB_DIR}" "${curr_dist_dir}"; } &&
-					check_func load_config
-			then
-				load_config
-				check_func abl_post_update_2 && abl_post_update_2
-			else
-				failsafe_log "Please run 'service adblock-lean start' to initialize the new config."
-			fi
-		fi
-		:
-	) 1>/dev/null || { upd_failed "Failed to source the new version of adblock-lean. Update is cancelled."; return 1; }
-
-	install_abl_files "${dist_dir}" "${upd_channel}_${ref}" || { upd_failed; return 1; }
-	rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
-
-	# shellcheck disable=SC2031
-	[ -n "${UPD_SOURCED}" ] && return 0
-
-	enable || return 1
-	log_msg -green "adblock-lean has been updated to version '${version}'."
+	log_msg -green "adblock-lean has been updated to version '${upd_ver}'."
 
 	if [ -n "${DO_DIALOGS}" ]
 	then
 		print_msg "" "Start adblock-lean now? (y|n)"
 		pick_opt "y|n"
-		if [ "$REPLY" = y ]
-		then
-			clean_abl_env
-			# shellcheck source=/dev/null
-			. "${ABL_SERVICE_PATH}" || return 1
-			start
-		fi
+	else
+		REPLY=y
 	fi
-	:
+
+	if [ "${REPLY}" = y ]
+	then
+		clean_abl_env
+		# shellcheck source=/dev/null
+		. "${ABL_SERVICE_PATH}" || return 1
+		start
+	else
+		exit 0
+	fi
 }
 
 uninstall()
@@ -1591,6 +1860,9 @@ disable()
 
 set_ansi
 
+# $luci_skip_dialogs is set if sourced from external RPC script for luci
+[ -n "${luci_skip_dialogs}" ] && export ABL_LUCI_SOURCED=1
+
 # test process substitution support
 printf '%s\n%s\n' "#!/bin/sh" "printf %s >(:)" > /tmp/abl-test
 if ! /bin/sh /tmp/abl-test 1>/dev/null 2>/dev/null
@@ -1610,12 +1882,10 @@ then
 	shift
 fi
 
-# shellcheck source=/dev/null
-# this is needed when running via 'sh /etc/init.d/adblock-lean'
-check_func config_load 1>/dev/null || . /lib/functions.sh || { reg_failure "Failed to source /lib/functions.sh"; exit 1; }
-
 # detect when sourced from update() in older versions
 check_func failsafe_log 1>/dev/null && UPD_SOURCED=1
+
+LIBS_SOURCED=
 
 case "${ABL_CMD}" in
 	enable|disable|uninstall|update|setup) ${ABL_CMD} "${@}"; exit ${?} ;;

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -38,7 +38,7 @@ try_extract()
 			esac ;;
 		*) reg_failure "try_extract: file '${1}' has unexpected extension."; false
 	esac &&
-	${EXTR_CMD} "${1}" || { rm -f "${1%"${COMPR_EXT}"}"; reg_failure "Failed to extract '${1}'."; return 1; }
+	${EXTR_CMD} "${1}" || { rm -f "${1%.*}"; reg_failure "Failed to extract '${1}'."; return 1; }
 }
 
 # subtract list $1 from list $2, with optional field separator $4 (otherwise uses newline)
@@ -1091,8 +1091,9 @@ import_blocklist_file()
 
 	if [ -n "${src_compressed}" ] && [ -z "${final_compress}" ]
 	then
-		try_extract "${src_file}" || return 1
-		src_file="${src_file%"${COMPR_EXT}"}"
+		try_extract "${src_file}" &&
+		src_file="${src_file%.*}" &&
+		[ -n "${src_file}" ] || return 1
 	elif [ -z "${src_compressed}" ] && [ -n "${final_compress}" ]
 	then
 		try_compress "${src_file}" "${FINAL_COMPR_OPTS}" || return 1

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-# shellcheck disable=SC3043,SC3001,SC2016,SC2015,SC3020,SC2181,SC2019,SC2018,SC3045,SC3003
+# shellcheck disable=SC3043,SC3001,SC2016,SC2015,SC3020,SC2181,SC2019,SC2018,SC3045,SC3003,SC3060
 # ABL_VERSION=dev
 
 # silence shellcheck warnings
-: "${use_compression:=}" "${max_file_part_size_KB:=}" "${whitelist_mode:=}" "${list_part_failed_action:=}" "${test_domains:=}"
-: "${max_download_retries:=}" "${deduplication:=}" "${max_blocklist_file_size_KB:=}" "${min_good_line_count:=}" "${local_allowlist_path:=}"
-: "${blue:=}" "${green:=}" "${n_c:=}"
+: "${max_file_part_size_KB:=}" "${whitelist_mode:=}" "${list_part_failed_action:=}" "${test_domains:=}" \
+	"${max_download_retries:=}" "${deduplication:=}" "${max_blocklist_file_size_KB:=}" "${min_good_line_count:=}" "${local_allowlist_path:=}" \
+	"${intermediate_compression_options:=}" "${final_compression_options:=}" \
+	"${blue:=}" "${green:=}" "${n_c:=}"
 
 PROCESSED_PARTS_DIR="${ABL_DIR}/list_parts"
 
@@ -19,14 +20,25 @@ ABL_TEST_DOMAIN="adblocklean-test123.info"
 
 # UTILITY FUNCTIONS
 
-try_gzip()
+try_compress()
 {
-	busybox gzip -f "${1}" || { rm -f "${1}.gz"; reg_failure "Failed to compress '${1}'."; return 1; }
+	${COMPR_CMD} ${2} "${1}" || { rm -f "${1}${COMPR_EXT}"; reg_failure "Failed to compress '${1}'."; return 1; }
 }
 
-try_gunzip()
+try_extract()
 {
-	busybox gunzip -f "${1}" || { rm -f "${1%.gz}"; reg_failure "Failed to extract '${1}'."; return 1; }
+	case "${1}" in
+		*.gz)
+			case "${EXTR_CMD}" in *gzip*|*pigz*) ;; *)
+				local EXTR_CMD="gzip -fd"
+			esac ;;
+		*.zst)
+			case "${EXTR_CMD}" in *zstd*) ;; *)
+				local EXTR_CMD="zstd -fd --rm -q --no-progress"
+			esac ;;
+		*) reg_failure "try_extract: file '${1}' has unexpected extension."; false
+	esac &&
+	${EXTR_CMD} "${1}" || { rm -f "${1%"${COMPR_EXT}"}"; reg_failure "Failed to extract '${1}'."; return 1; }
 }
 
 # subtract list $1 from list $2, with optional field separator $4 (otherwise uses newline)
@@ -69,6 +81,81 @@ get_elapsed_time_s()
 	local ge_uptime_s
 	get_uptime_s ge_uptime_s || return 1
 	eval "${1}"=$(( ge_uptime_s-${2:-ge_uptime_s} ))
+}
+
+# 1 (optional): '-f' to force re-detection
+# exports $PARALLEL_JOBS, $COMPR_EXT, $COMPR_CMD, $COMPR_CMD_STDOUT, $EXTR_CMD, $EXTR_CMD_STDOUT, $INTERM_COMPR_OPTS, $FINAL_COMPR_OPTS
+set_processing_vars()
+{
+	[ -n "${PROCESS_VARS_SET}" ] && [ "${1}" != '-f' ] && return 0
+
+	case "${MAX_PARALLEL_JOBS}" in
+		auto)
+			local cpu_cnt
+			cpu_cnt="$(grep -c '^processor\s*:' /proc/cpuinfo)"
+			case "${cpu_cnt}" in
+				''|*[!0-9]*|0)
+					log_msg "Failed to detect CPU core count. Parallel processing will be disabled."
+					PARALLEL_JOBS=1 ;;
+				*)
+					# cap PARALLEL_JOBS to 4 in 'auto' mode
+					PARALLEL_JOBS=$(( (cpu_cnt>4)*4 + (cpu_cnt<=4)*cpu_cnt ))
+			esac ;;
+		*)
+			PARALLEL_JOBS="${MAX_PARALLEL_JOBS}"
+	esac
+	export PARALLEL_JOBS
+
+	local compr_util_known='' compr_util_path='' compr_cmd_opts='' extr_cmd_opts=''
+	[ -n "${compression_util}" ] && compr_util_known=1
+
+	local compression_util="${compression_util:-gzip}"
+	unset PROCESS_VARS_SET USE_COMPRESSION COMPR_EXT COMPR_CMD COMPR_CMD_STDOUT EXTR_CMD EXTR_CMD_STDOUT INTERM_COMPR_OPTS FINAL_COMPR_OPTS
+
+	case "${compression_util}" in
+		gzip)
+			detect_util compr_util_path gzip "" "/usr/libexec/gzip-gnu" -b &&
+			COMPR_EXT=.gz ;;
+		pigz)
+			detect_util compr_util_path "" pigz "/usr/bin/pigz" &&
+			COMPR_EXT=.gz ;;
+		zstd)
+			detect_util compr_util_path "" zstd "/usr/bin/zstd" &&
+			COMPR_EXT=.zst &&
+			compr_cmd_opts="--rm -q --no-progress" &&
+			extr_cmd_opts="--rm -q --no-progress" ;;
+		none) : ;;
+		*) reg_failure "Unexpected compression utility '${compression_util}'."; false
+	esac || return 1
+
+	case "${compression_util}" in none) ;; *)
+		USE_COMPRESSION=1
+		COMPR_CMD="${compr_util_path} -f ${compr_cmd_opts}"
+		COMPR_CMD_STDOUT="${compr_util_path} -c"
+		EXTR_CMD="${compr_util_path} -fd ${extr_cmd_opts}"
+		EXTR_CMD_STDOUT="${compr_util_path} -cd"
+
+		# set compression parallelization, unless specified by the user
+		local par_opt=''
+		case "${COMPR_CMD}" in *zstd*|*pigz*)
+			case "${COMPR_CMD}" in
+				*zstd*) par_opt=T ;;
+				*pigz*) par_opt=p
+			esac
+			case "${intermediate_compression_options}" in
+			*" -${par_opt}"*) INTERM_COMPR_OPTS="${intermediate_compression_options}" ;;
+			*) INTERM_COMPR_OPTS="${intermediate_compression_options} -${par_opt}$((PARALLEL_JOBS/2 + (PARALLEL_JOBS/2<1) ))" # not less than 1
+			esac
+			case "${final_compression_options}" in
+				*" -${par_opt}"*) FINAL_COMPR_OPTS="${final_compression_options}" ;;
+				*) FINAL_COMPR_OPTS="${final_compression_options} -${par_opt}${PARALLEL_JOBS}"
+			esac
+		esac
+	esac
+
+	[ -n "${compr_util_known}" ] && export PROCESS_VARS_SET=1
+	export COMPR_EXT COMPR_CMD COMPR_CMD_STDOUT EXTR_CMD EXTR_CMD_STDOUT USE_COMPRESSION
+	:
 }
 
 
@@ -236,7 +323,7 @@ schedule_jobs()
 				log_msg -warn "" "Following Hagezi URLs are in dnsmasq format and should be either changed to raw list URLs" \
 					"or moved to one of the 'dnsmasq_' config entries:" "${bad_hagezi_urls}"
 				case "${list_type}" in blocklist|allowlist)
-					bad_hagezi_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | $SED_CMD -n '/\/hagezi\//{/onlydomains\./d;/^$/d;p;}')"
+					bad_hagezi_urls="$(printf %s "${list_urls}" | tr ' ' '\n' | ${SED_CMD} -n '/\/hagezi\//{/onlydomains\./d;/^$/d;p;}')"
 					[ -n "${bad_hagezi_urls}" ] && log_msg -warn "" \
 						"Following Hagezi URLs are missing the '-onlydomains' suffix in the filename:" "${bad_hagezi_urls}"
 				esac
@@ -346,7 +433,7 @@ process_list_part()
 		part_size_B='' retry=1
 
 	case ${list_type} in
-		blocklist|blocklist_ipv4) [ "${use_compression}" = 1 ] && { dest_file="${dest_file}.gz"; compress_part=1; }
+		blocklist|blocklist_ipv4) [ -n "${USE_COMPRESSION}" ] && { dest_file="${dest_file}${COMPR_EXT}"; compress_part=1; }
 	esac
 	eval "min_line_count=\"\${min_${list_type}_part_line_count}\""
 
@@ -370,7 +457,7 @@ process_list_part()
 		{ head -c "${max_file_part_size_KB}k"; read -rn1 -d '' && { touch "${size_exceeded_file}"; cat 1>/dev/null; }; } |
 
 		# Remove comment lines and trailing comments, remove whitespaces
-		$SED_CMD 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d' |
+		${SED_CMD} 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d' |
 
 		# Convert dnsmasq format to raw format
 		if [ "${list_format}" = dnsmasq ]
@@ -381,7 +468,7 @@ process_list_part()
 				blocklist_ipv4) rm_prefix_expr="s~^[ \t]*bogus-nxdomain=~~" ;;
 				allowlist) rm_suffix_expr='s~/#$~~'
 			esac
-			$SED_CMD -E "${rm_prefix_expr};${rm_suffix_expr}" | tr '/' '\n'
+			${SED_CMD} -E "${rm_prefix_expr};${rm_suffix_expr}" | tr '/' '\n'
 		else
 			cat
 		fi |
@@ -410,12 +497,12 @@ process_list_part()
 		fi |
 
 		# check lists for rogue elements
-		tee >($SED_CMD -nE "/${val_entry_regex}/d;p;:1 n;b1" > "${rogue_el_file}") |
+		tee >(${SED_CMD} -nE "/${val_entry_regex}/d;p;:1 n;b1" > "${rogue_el_file}") |
 
 		# compress parts
 		if [ -n "${compress_part}" ]
 		then
-			busybox gzip
+			${COMPR_CMD_STDOUT} ${INTERM_COMPR_OPTS}
 		else
 			cat
 		fi > "${dest_file}"
@@ -505,27 +592,6 @@ gen_list_parts()
 		done
 		use_allowlist=1
 	fi
-
-	case "${MAX_PARALLEL_JOBS}" in
-		auto)
-			local cpu_cnt
-			cpu_cnt="$(grep -c '^processor\s*:' /proc/cpuinfo)"
-			case "${cpu_cnt}" in
-				''|*[!0-9]*|0)
-					log_msg "Failed to detect CPU core count. Parallel processing will be disabled."
-					PARALLEL_JOBS=1 ;;
-				*)
-					# cap PARALLEL_JOBS to 4 in 'auto' mode
-					if [ "${cpu_cnt}" -ge 4 ]
-					then
-						PARALLEL_JOBS=4
-					else
-						PARALLEL_JOBS=${cpu_cnt}
-					fi
-			esac ;;
-		*)
-			PARALLEL_JOBS="${MAX_PARALLEL_JOBS}"
-	esac
 
 	reg_action -blue "Downloading and processing blocklist parts (max parallel jobs: ${PARALLEL_JOBS})."
 	print_msg ""
@@ -626,10 +692,10 @@ gen_and_process_blocklist()
 		case "$1" in
 			blocklist)
 				# packs 4 domains in one 'local=/.../' line
-				$SED_CMD "/^$/d;s~^.*$~local=/&/~;\$!{n;a /${_NL_}};\$!{n;a /${_NL_}};\$!{n; a /${_NL_}};a @" ;;
+				${SED_CMD} "/^$/d;s~^.*$~local=/&/~;\$!{n;a /${_NL_}};\$!{n;a /${_NL_}};\$!{n; a /${_NL_}};a @" ;;
 			allowlist)
 				# packs 4 domains in one 'server=/.../#'' line
-				{ cat; printf '\n'; } | $SED_CMD '/^$/d;$!N;$!N;$!N;s~\n~/~g;s~^~server=/~;s~/*$~/#@~' ;;
+				{ cat; printf '\n'; } | ${SED_CMD} '/^$/d;$!N;$!N;$!N;s~\n~/~g;s~^~server=/~;s~/*$~/#@~' ;;
 			*) printf ''; return 1
 		esac | tr -d '\n' | tr "@" '\n'
 	}
@@ -647,7 +713,7 @@ gen_and_process_blocklist()
 
 		len_lim=$((len_lim-${#entry_type}-${#allow_char}-2))
 		# shellcheck disable=SC2016
-		$AWK_CMD -v ORS="" -v m=${len_lim} -v a="${allow_char}" -v t=${entry_type} '
+		${AWK_CMD} -v ORS="" -v m=${len_lim} -v a="${allow_char}" -v t=${entry_type} '
 			BEGIN {al=0; r=0; s=""}
 			NF {
 				r=r+1
@@ -661,12 +727,12 @@ gen_and_process_blocklist()
 	}
 
 	# 1 - list type (blocklist|blocklist_ipv4)
+	# 2 - <.gz|.zst|>
+	# 3 - decompression command or 'cat'
 	print_list_parts()
 	{
-		local find_name="${1}-*" find_cmd="cat"
-		[ "${use_compression}" = 1 ] && { find_name="${1}-*.gz" find_cmd="busybox zcat"; }
-		find "${ABL_DIR}" -name "${find_name}" -exec ${find_cmd} {} \; -exec rm -f {} \;
-		printf ''
+		local find_name="${1}-*${2}" find_cmd="${3}"
+		find "${ABL_DIR}/list_parts/" -type f -name "${find_name}" -exec ${find_cmd} {} \; -exec rm -f {} \;
 	}
 
 	# 1 - var name for output
@@ -681,7 +747,7 @@ gen_and_process_blocklist()
 	{
 		if [ "${deduplication}" = 1 ]
 		then
-			$SORT_CMD -u -
+			${SORT_CMD} -u -
 		else
 			cat
 		fi
@@ -690,9 +756,11 @@ gen_and_process_blocklist()
 	local elapsed_time_s list_type out_f="${ABL_DIR}/abl-blocklist"
 	local dnsmasq_err max_blocklist_file_size_B=$((max_blocklist_file_size_KB*1024))
 
-	local final_compress=
-	if [ "${use_compression}" = 1 ]
+	local find_ext='' find_cmd="cat" final_compress=
+	if [ -n "${USE_COMPRESSION}" ]
 	then
+		find_ext="${COMPR_EXT}" find_cmd="${EXTR_CMD_STDOUT}"
+
 		check_blocklist_compression_support
 		case ${?} in
 			0) final_compress=1 ;;
@@ -744,16 +812,15 @@ gen_and_process_blocklist()
 
 	reg_action -blue "Sorting and merging the blocklist parts into a single blocklist file." || return 1
 
-	[ -n "${final_compress}" ] && out_f="${out_f}.gz"
+	[ -n "${final_compress}" ] && out_f="${out_f}${COMPR_EXT}"
 
 	rm -f "${ABL_DIR}/dnsmasq_err"
 
 	{
 		# print blocklist parts
-		print_list_parts blocklist |
+		print_list_parts blocklist "${find_ext}" "${find_cmd}" |
 		# optional deduplication
 		dedup |
-
 		# count entries
 		tee >(wc -w > "${ABL_DIR}/blocklist_entries") |
 		# pack entries in 1024 characters long lines
@@ -762,12 +829,12 @@ gen_and_process_blocklist()
 		# print ipv4 blocklist parts
 		if [ -n "${use_blocklist_ipv4}" ]
 		then
-			print_list_parts blocklist_ipv4 |
+			print_list_parts blocklist_ipv4 "${find_ext}" "${find_cmd}" |
 			# optional deduplication
 			dedup |
 			tee >(wc -w > "${ABL_DIR}/blocklist_ipv4_entries") |
 			# add prefix
-			$SED_CMD 's/^/bogus-nxdomain=/'
+			${SED_CMD} 's/^/bogus-nxdomain=/'
 		fi
 
 		# print allowlist parts
@@ -801,7 +868,7 @@ gen_and_process_blocklist()
 	{ head -c "${max_blocklist_file_size_B}"; read -rn1 -d '' && { touch "${ABL_DIR}/abl-too-big.tmp"; cat 1>/dev/null; }; } |
 	if  [ -n "${final_compress}" ]
 	then
-		busybox gzip
+		${COMPR_CMD_STDOUT} ${FINAL_COMPR_OPTS}
 	else
 		cat
 	fi > "${out_f}" || { reg_failure "Failed to write to output file '${out_f}'."; rm -f "${out_f}"; return 1; }
@@ -820,14 +887,14 @@ gen_and_process_blocklist()
 	reg_action -blue "Checking the resulting blocklist with 'dnsmasq --test'." || return 1
 	if  [ -n "${final_compress}" ]
 	then
-		busybox zcat -f "${out_f}"
+		${EXTR_CMD_STDOUT} "${out_f}"
 	else
 		cat "${out_f}"
 	fi |
 	dnsmasq --test -C - 2> "${ABL_DIR}/dnsmasq_err"
 	if [ ${?} != 0 ] || ! grep -q "syntax check OK" "${ABL_DIR}/dnsmasq_err"
 	then
-		dnsmasq_err="$(head -n10 "${ABL_DIR}/dnsmasq_err" | $SED_CMD '/^$/d')"
+		dnsmasq_err="$(head -n10 "${ABL_DIR}/dnsmasq_err" | ${SED_CMD} '/^$/d')"
 		rm -f "${out_f}" "${ABL_DIR}/dnsmasq_err"
 		reg_failure "The dnsmasq test on the final blocklist failed."
 		log_msg "dnsmasq --test errors:" "${dnsmasq_err:-"No specifics: probably killed because of OOM."}"
@@ -903,40 +970,55 @@ try_export_existing_blocklist()
 # 2 - blocklist file not found (nothing to export)
 export_existing_blocklist()
 {
-	reg_export()
-	{
-		reg_action -blue "Creating ${1} backup of existing blocklist." || return 1
-	}
+	export_failed() { rm -f "${src_d}/abl-blocklist" "${src_d}/.abl-blocklist"* "${bk_path:-?}"*; }
 
-	local src src_d="${DNSMASQ_CONF_D}" dest="${ABL_DIR}/prev_blocklist"
-	if [ -f "${src_d}/.abl-blocklist.gz" ]
-	then
-		case ${use_compression} in
-			1)
-				src="${src_d}/.abl-blocklist.gz" dest="${dest}.gz"
-				reg_export compressed || return 1 ;;
-			*)
-				reg_export uncompressed || return 1
-				try_gunzip "${src_d}/.abl-blocklist.gz" || { rm -f "${src_d}/.abl-blocklist.gz"; return 1; }
-				src="${src_d}/.abl-blocklist"
-		esac
-	elif [ -f "${src_d}/abl-blocklist" ]
-	then
-		if [ "${use_compression}" = 1 ]
+	reg_export() { reg_action -blue "Creating ${1} backup of existing blocklist." || return 1; }
+
+	local src_d="${DNSMASQ_CONF_D}" bk_path="${ABL_DIR}/prev_blocklist" file prev_file='' prev_file_compat='' prev_file_compressed=''
+
+	for file in "${src_d}/abl-blocklist" "${src_d}/.abl-blocklist."*
+	do
+		[ -n "${file}" ] && [ -f "${file}" ] || continue
+		prev_file="${file}"
+		case "${prev_file}" in *"/.abl-blocklist"*) prev_file_compressed=1; esac
+		if
+			{ [ -n "${USE_COMPRESSION}" ] && case "${prev_file}" in *"/.abl-blocklist${COMPR_EXT}") : ;; *) false; esac; } ||
+			{ [ -z "${USE_COMPRESSION}" ] && [ -z "${prev_file_compressed}" ]; }
 		then
-			reg_export compressed || return 1
-			try_mv "${src_d}/abl-blocklist" "${src_d}/.abl-blocklist" || return 1
-			try_gzip "${src_d}/.abl-blocklist" || return 1
-			src="${src_d}/.abl-blocklist.gz" dest="${dest}.gz"
-		else
-			reg_export uncompressed || return 1
-			src="${src_d}/abl-blocklist"
+			prev_file_compat=1
 		fi
+		break
+	done
+
+	[ -n "${prev_file}" ] || { log_msg "" "No existing compressed or uncompressed blocklist identified."; return 2; }
+
+	if [ -n "${USE_COMPRESSION}" ]
+	then
+		bk_path="${bk_path}${COMPR_EXT}"
+		reg_export compressed
 	else
-		log_msg "" "No existing compressed or uncompressed blocklist identified."
-		return 2
+		reg_export uncompressed
+	fi || return 1
+
+	if [ -z "${prev_file_compat}" ] && [ -n "${prev_file_compressed}" ]
+	then
+		try_extract "${prev_file}" || { export_failed; return 1; }
+		prev_file="${src_d}/.abl-blocklist"
+		prev_file_compressed=
 	fi
-	try_mv "${src}" "${dest}" || return 1
+
+	if [ -z "${USE_COMPRESSION}" ] && [ -n "${prev_file_compressed}" ]
+	then
+		try_extract "${prev_file}" || { export_failed; return 1; }
+		prev_file="${src_d}/.abl-blocklist"
+	elif [ -n "${USE_COMPRESSION}" ] && [ -z "${prev_file_compressed}" ]
+	then
+		{ [ "${prev_file}" = "${src_d}/.abl-blocklist" ] || try_mv "${prev_file}" "${src_d}/.abl-blocklist"; } &&
+		try_compress "${src_d}/.abl-blocklist" "${FINAL_COMPR_OPTS}" || { export_failed; return 1; }
+		prev_file="${src_d}/.abl-blocklist${COMPR_EXT}"
+	fi
+
+	try_mv "${prev_file}" "${bk_path}" || { export_failed; return 1; }
 	:
 }
 
@@ -944,14 +1026,14 @@ restore_saved_blocklist()
 {
 	restore_failed()
 	{
+		rm -f "${mv_src:-?}"* "${mv_dest:-?}"*
 		reg_failure "Failed to restore saved blocklist."
 	}
 
-	local mv_src="${ABL_DIR}/prev_blocklist" mv_dest="${ABL_DIR}/abl-blocklist"
+	local mv_src="${ABL_DIR}/prev_blocklist" mv_dest="${ABL_DIR}/abl-blocklist" final_compress=
 	reg_action -blue "Restoring saved blocklist file." || { restore_failed; return 1; }
 
-	local final_compress=
-	if [ "${use_compression}" = 1 ]
+	if [ "${USE_COMPRESSION}" = 1 ]
 	then
 		check_blocklist_compression_support
 		case ${?} in
@@ -960,19 +1042,19 @@ restore_saved_blocklist()
 		esac
 	fi
 
-	if [ -f "${mv_src}.gz" ]
+	if [ -f "${mv_src}${COMPR_EXT}" ]
 	then
-		try_mv "${mv_src}.gz" "${mv_dest}.gz" || { restore_failed; return 1; }
+		try_mv "${mv_src}${COMPR_EXT}" "${mv_dest}${COMPR_EXT}" || { restore_failed; return 1; }
 		if [ -z "${final_compress}" ]
 		then
-			try_gunzip "${mv_dest}.gz" || { restore_failed; return 1; }
+			try_extract "${mv_dest}${COMPR_EXT}" || { restore_failed; return 1; }
 		fi
 	elif [ -f "${mv_src}" ]
 	then
 		try_mv "${mv_src}" "${mv_dest}" || { restore_failed; return 1; }
 		if [ -n "${final_compress}" ]
 		then
-			try_gzip -f "${mv_dest}" || { restore_failed; return 1; }
+			try_compress "${mv_dest}" "${FINAL_COMPR_OPTS}" || { restore_failed; return 1; }
 		fi
 	else
 		reg_failure "No previous blocklist file found."
@@ -991,34 +1073,42 @@ import_blocklist_file()
 {
 	local src src_compressed='' src_file="${ABL_DIR}/abl-blocklist" dest_file="${DNSMASQ_CONF_D}/abl-blocklist"
 	local final_compress="${1}"
-	[ -n "${final_compress}" ] && dest_file="${DNSMASQ_CONF_D}/.abl-blocklist.gz"
-	for src in "${src_file}" "${src_file}.gz"
+
+	log_msg -blue "" "Importing the blocklist file."
+
+	[ -n "${final_compress}" ] && dest_file="${DNSMASQ_CONF_D}/.abl-blocklist${COMPR_EXT}"
+	for src in "${src_file}" "${src_file}${COMPR_EXT}"
 	do
-		case "${src}" in *.gz) src_compressed=1; esac
-		[ -f "${src}" ] && { src_file="${src}"; break; }
+		if [ -f "${src}" ]
+		then
+			[ -n "${COMPR_EXT}" ] && case "${src}" in *"${COMPR_EXT}") src_compressed=1; esac
+			src_file="${src}"
+			break
+		fi
 	done || { reg_failure "Failed to find file to import."; return 1; }
 
 	clean_dnsmasq_dir
 
 	if [ -n "${src_compressed}" ] && [ -z "${final_compress}" ]
 	then
-		try_gunzip "${src_file}" || return 1
-		src_file="${src_file%.gz}"
+		try_extract "${src_file}" || return 1
+		src_file="${src_file%"${COMPR_EXT}"}"
 	elif [ -z "${src_compressed}" ] && [ -n "${final_compress}" ]
 	then
-		try_gzip "${src_file}" || return 1
-		src_file="${src_file}.gz"
+		try_compress "${src_file}" "${FINAL_COMPR_OPTS}" || return 1
+		src_file="${src_file}${COMPR_EXT}"
 	fi
 
 	try_mv "${src_file}" "${dest_file}" || return 1
 	imported_final_list_size_human=$(get_file_size_human "${dest_file}")
 
-	compressed=
+	local compressed=
 	if [ -n "${final_compress}" ]
 	then
 		printf '%s\n' "conf-script=\"busybox sh ${DNSMASQ_CONF_D}/.abl-extract_blocklist\"" > "${DNSMASQ_CONF_D}"/abl-conf-script &&
-		printf '%s\n%s\n' "busybox zcat ${DNSMASQ_CONF_D}/.abl-blocklist.gz" "exit 0" > "${DNSMASQ_CONF_D}"/.abl-extract_blocklist ||
-			{ reg_failure "Failed to create conf-script for dnsmasq."; return 1; }
+		printf '%s\n%s\n' "${EXTR_CMD_STDOUT} ${DNSMASQ_CONF_D}/.abl-blocklist${COMPR_EXT}" "exit 0" > \
+			"${DNSMASQ_CONF_D}"/.abl-extract_blocklist ||
+				{ reg_failure "Failed to create conf-script for dnsmasq."; return 1; }
 		compressed=" compressed"
 	fi
 
@@ -1083,12 +1173,12 @@ test_url_domains()
 			[ "${list_format}" = dnsmasq ] && d="dnsmasq_"
 			eval "urls=\"\${${d}${list_type}_urls}\""
 			[ -z "${urls}" ] && continue
-			domains="${domains}$(printf %s "${urls}" | tr ' \t' '\n' | $SED_CMD -n '/http/{s~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;p;}')${_NL_}"
+			domains="${domains}$(printf %s "${urls}" | tr ' \t' '\n' | ${SED_CMD} -n '/http/{s~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;p;}')${_NL_}"
 		done
 	done
 	[ -z "${domains}" ] && return 0
 
-	for dom in $(printf %s "${domains}" | $SORT_CMD -u)
+	for dom in $(printf %s "${domains}" | ${SORT_CMD} -u)
 	do
 		try_lookup_domain "${dom}" "127.0.0.1" 2 || { reg_failure "Lookup of '${dom}' failed."; return 1; }
 	done
@@ -1139,22 +1229,26 @@ get_active_entries_cnt()
 	done
 	[ "${whitelist_mode}" = 1 ] && [ -n "${test_domains}" ] && add2list list_prefixes "server" "|"
 
-	if [ -f "${DNSMASQ_CONF_D}"/.abl-blocklist.gz ]
-	then
-		busybox zcat "${DNSMASQ_CONF_D}"/.abl-blocklist.gz
-	elif [ -f "${DNSMASQ_CONF_D}"/abl-blocklist ]
-	then
-		cat "${DNSMASQ_CONF_D}/abl-blocklist"
-	else
-		printf ''
-	fi |
-	$SED_CMD -E "s~^(${list_prefixes})=/~~;/${ABL_TEST_DOMAIN}/d;s~/#{0,1}$~~" | tr '/' '\n' | wc -w > "/tmp/abl_entries_cnt"
+	cnt="$(
+		if [ -f "${DNSMASQ_CONF_D}/.abl-blocklist${COMPR_EXT}" ]
+		then
+			${EXTR_CMD_STDOUT} "${DNSMASQ_CONF_D}/.abl-blocklist${COMPR_EXT}"
+		elif [ -f "${DNSMASQ_CONF_D}"/abl-blocklist ]
+		then
+			cat "${DNSMASQ_CONF_D}/abl-blocklist"
+		else
+			rm -f "${DNSMASQ_CONF_D}"/.abl-blocklist*
+			printf ''
+		fi |
+		${SED_CMD} -E "s~^(${list_prefixes})=/~~;/${ABL_TEST_DOMAIN}/d;s~/#{0,1}$~~" | tr '/' '\n' | wc -w
+	)"
 
-	read_str_from_file -d -v cnt -f "/tmp/abl_entries_cnt" -a 2 -D "entries count"
-
+	: "${cnt:=0}"
 	[ "${whitelist_mode}" = 1 ] && cnt=$((cnt-26)) # ignore alphabet entries
 
 	case "${cnt}" in *[!0-9]*|'') printf 0; return 1; esac
 	printf %s "${cnt}"
 	:
 }
+
+:


### PR DESCRIPTION
- Rather than writing the version string into each of the installed files, only write it into the main file
- Rather than checking libraries by comparing version strings, create a file with md5sums of all installed files and check against that. Together with the above bullet point, this is both more robust and allows to minimize the number of flash writes when updating adblock-lean scripts. Currently all scripts are re-written upon update because the version string changes every time in all of them. This way only the main script will be re-written unconditionally and all others will be only re-written when they actually change.
- Because we discovered that GitHub limits the number of API requests, implement local API query caching which works around that
- Support a new update channel: `branch=<gh_branch>`
- Rather than registering the version string like so:
   ```
   # ABL_VERSION=<upd_channel>_<version>
   ```
   use 2 variables:
   ```
   ABL_VERSION="<version>"
   ABL_UPD_CHANNEL="<upd_channel>"
   ```
- Remove some unused functions

This also makes it possible to override the GH repo author by setting the variable `ABL_REPO_AUTHOR`. I added this in order to be able to test upgrading more easily.

This PR solves some bugs present in #164. Unfortunately, at some point I had to reset the commit history in my branch, so I can not easily add the extra bugfixes to #164. Hence this separate PR.

Extra changes:

- Implement support for additional compression utils: GNU gzip, pigz, zstd
- Support the `-y` option to auto-approve all suggested changes during adblock-lean version updates