### PR TITLE
Implement calculate limits and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Main features of adblock-lean:
 - during blocklist update, a **compressed backup copy** of the previous blocklist file is kept until the new blocklist passes all checks. If checks fail, adblock-lean restores the previous blocklist
 - supports **concurrent download and processing** of blocklist/allowlist parts for faster blocklist updates
 - supports **pause and resume** of adblocking without re-downloading blocklist/allowlist parts
+- supports adblocking on **multiple dnsmasq instances**
 - supports optional calls to **user-configurable script** on success or failure (for example to send an email report)
 - automatic check for application updates and **self update** functionality (initiated by the user)
 - **config validation** and optional **automatic config repair** when problems are detected
@@ -121,6 +122,7 @@ Additional available commands (use with `service adblock-lean <command>`):
                   if config option set to 'disable', removes existing cron job if any
 - `select_dnsmasq_instances`: analyzes dnsmasq instances and sets required options in the adblock-lean config.
             If multiple dnsmasq instances are found, allows the user to pick which instances to adblock on.
+- `calculate_values`: calculates and prints recommended values for config options `min_good_line_count`, `max_file_part_size_KB`, `max_blocklist_file_size_KB`, based on target entries count (specified by the user).
 
 ## Basic configuration
 Generally, if you ran the automated setup then you don't have to make any additional configuration changes. If you want to further customize adblocking, this can be achieved by modifying the config file located at `/etc/adblock-lean/config`.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Additional available commands (use with `service adblock-lean <command>`):
                   if config option set to 'disable', removes existing cron job if any
 - `select_dnsmasq_instances`: analyzes dnsmasq instances and sets required options in the adblock-lean config.
             If multiple dnsmasq instances are found, allows the user to pick which instances to adblock on.
-- `calculate_values`: calculates and prints recommended values for config options `min_good_line_count`, `max_file_part_size_KB`, `max_blocklist_file_size_KB`, based on target entries count (specified by the user).
+- `calculate_limits`: calculates and prints recommended values for config options `min_good_line_count`, `max_file_part_size_KB`, `max_blocklist_file_size_KB`, based on target entries count (specified by the user).
 
 ## Basic configuration
 Generally, if you ran the automated setup then you don't have to make any additional configuration changes. If you want to further customize adblocking, this can be achieved by modifying the config file located at `/etc/adblock-lean/config`.

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -307,7 +307,38 @@ get_gh_ref()
 			"prev_upd_channel"='${gr_channel}' "prev_version"='${gr_version}'
 	}
 
-	local gr_branch gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
+	get_and_process_ref()
+	{
+		local branch url \
+			channel="${1}" ptrn="${2}" branches="${3}" err_file="${4}"
+		case "${channel}" in
+			release)
+				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${err_file}" | {
+					jsonfilter -e '@[@.prerelease=false]' |
+					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
+					cat 1>/dev/null
+				} ;;
+			snapshot|branch=*|commit=*)
+				for branch in ${branches}
+				do
+					url="${ABL_GH_URL_API}/commits?sha=${branch}"
+					uclient-fetch "${url}" -O- 2> "${err_file}" | {
+						jsonfilter -e '@[@.commit]["url"]' |
+						${SED_CMD} 's/.*\///' # only leave the commit hash
+						cat 1>/dev/null
+					}
+				done
+		esac |
+		if [ -n "${ptrn}" ]
+		then
+			grep "${ptrn}"
+		else
+			head -n1 # get latest version or commit
+			cat 1>/dev/null
+		fi
+	}
+
+	local gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
 		gr_fetch_tmp_dir="${ABL_UPD_DIR}/ref_fetch" \
 		prev_ref prev_ver_type prev_upd_channel prev_version \
 		gr_channel="${1}" gr_version="${2}"
@@ -423,35 +454,8 @@ get_gh_ref()
 	esac
 
 	# Get GH ref
-	[ -z "${gr_ref}" ] && gr_ref="$(
-		case "${gr_channel}" in
-			release)
-				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${gr_ucl_err_file}" | {
-					jsonfilter -e '@[@.prerelease=false]' |
-					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
-					cat 1>/dev/null
-				} ;;
-			snapshot|branch=*|commit=*)
-				for gr_branch in ${gr_branches}
-				do
-					ref_fetch_url="${ABL_GH_URL_API}/commits?sha=${gr_branch}"
-					uclient-fetch "${ref_fetch_url}" -O- 2> "${gr_ucl_err_file}" | {
-						jsonfilter -e '@[@.commit]["url"]' |
-						${SED_CMD} 's/.*\///' # only leave the commit hash
-						cat 1>/dev/null
-					}
-				done
-		esac |
-		{
-			if [ -n "${gr_grep_ptrn}" ]
-			then
-				grep "${gr_grep_ptrn}"
-			else
-				head -n1 # get latest version or commit
-			fi
-			cat 1>/dev/null
-		}
-	)"
+	[ -z "${gr_ref}" ] &&
+		gr_ref="$(get_and_process_ref "${gr_channel}" "${gr_grep_ptrn}" "${gr_branches}" "${gr_ucl_err_file}")"
 
 	if [ -z "${gr_ref}" ]
 	then

--- a/adblock-lean
+++ b/adblock-lean
@@ -81,7 +81,7 @@ SCHEDULER_PID=
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
-EXTRA_COMMANDS="setup version status pause resume gen_stats select_dnsmasq_instances gen_config upd_cron_job print_log update uninstall calculate_values"
+EXTRA_COMMANDS="setup version status pause resume gen_stats select_dnsmasq_instances gen_config upd_cron_job print_log update uninstall calculate_limits"
 EXTRA_HELP="
 adblock-lean custom commands:
 	version                   print adblock-lean version
@@ -97,7 +97,7 @@ adblock-lean custom commands:
 	print_log                 print most recent session log
 	update                    update adblock-lean to the latest version
 	uninstall                 uninstall adblock-lean, remove all adblock-lean-related files and settings
-	calculate_values          calculate values for configuration options based on target entries count"
+	calculate_limits          calculate recommended values for max_ and min_ config options based on target entries count"
 
 # silence shellcheck warnings
 : "${action:=}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}"
@@ -1991,10 +1991,10 @@ disable()
 	return "$rv"
 }
 
-calculate_values()
+calculate_limits()
 {
 	source_libs || exit 1
-	do_calculate_values "${@}"
+	do_calculate_limits "${@}"
 	exit ${?}
 }
 

--- a/adblock-lean
+++ b/adblock-lean
@@ -1212,7 +1212,38 @@ get_gh_ref()
 			"prev_upd_channel"='${gr_channel}' "prev_version"='${gr_version}'
 	}
 
-	local gr_branch gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
+	get_and_process_ref()
+	{
+		local branch url \
+			channel="${1}" ptrn="${2}" branches="${3}" err_file="${4}"
+		case "${channel}" in
+			release)
+				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${err_file}" | {
+					jsonfilter -e '@[@.prerelease=false]' |
+					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
+					cat 1>/dev/null
+				} ;;
+			snapshot|branch=*|commit=*)
+				for branch in ${branches}
+				do
+					url="${ABL_GH_URL_API}/commits?sha=${branch}"
+					uclient-fetch "${url}" -O- 2> "${err_file}" | {
+						jsonfilter -e '@[@.commit]["url"]' |
+						${SED_CMD} 's/.*\///' # only leave the commit hash
+						cat 1>/dev/null
+					}
+				done
+		esac |
+		if [ -n "${ptrn}" ]
+		then
+			grep "${ptrn}"
+		else
+			head -n1 # get latest version or commit
+			cat 1>/dev/null
+		fi
+	}
+
+	local gr_branches='' gr_grep_ptrn='' gr_ref='' gr_ver_type='' gr_fetch_rv=0 \
 		gr_fetch_tmp_dir="${ABL_UPD_DIR}/ref_fetch" \
 		prev_ref prev_ver_type prev_upd_channel prev_version \
 		gr_channel="${1}" gr_version="${2}"
@@ -1328,35 +1359,8 @@ get_gh_ref()
 	esac
 
 	# Get GH ref
-	[ -z "${gr_ref}" ] && gr_ref="$(
-		case "${gr_channel}" in
-			release)
-				uclient-fetch "${ABL_GH_URL_API}/releases" -O- 2> "${gr_ucl_err_file}" | {
-					jsonfilter -e '@[@.prerelease=false]' |
-					jsonfilter -a -e "@[@.target_commitish=\"${ABL_MAIN_BRANCH}\"].tag_name"
-					cat 1>/dev/null
-				} ;;
-			snapshot|branch=*|commit=*)
-				for gr_branch in ${gr_branches}
-				do
-					ref_fetch_url="${ABL_GH_URL_API}/commits?sha=${gr_branch}"
-					uclient-fetch "${ref_fetch_url}" -O- 2> "${gr_ucl_err_file}" | {
-						jsonfilter -e '@[@.commit]["url"]' |
-						${SED_CMD} 's/.*\///' # only leave the commit hash
-						cat 1>/dev/null
-					}
-				done
-		esac |
-		{
-			if [ -n "${gr_grep_ptrn}" ]
-			then
-				grep "${gr_grep_ptrn}"
-			else
-				head -n1 # get latest version or commit
-			fi
-			cat 1>/dev/null
-		}
-	)"
+	[ -z "${gr_ref}" ] &&
+		gr_ref="$(get_and_process_ref "${gr_channel}" "${gr_grep_ptrn}" "${gr_branches}" "${gr_ucl_err_file}")"
 
 	if [ -z "${gr_ref}" ]
 	then

--- a/adblock-lean
+++ b/adblock-lean
@@ -81,7 +81,7 @@ SCHEDULER_PID=
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
-EXTRA_COMMANDS="setup version status pause resume gen_stats select_dnsmasq_instances gen_config upd_cron_job print_log update uninstall"
+EXTRA_COMMANDS="setup version status pause resume gen_stats select_dnsmasq_instances gen_config upd_cron_job print_log update uninstall calculate_values"
 EXTRA_HELP="
 adblock-lean custom commands:
 	version                   print adblock-lean version
@@ -96,7 +96,8 @@ adblock-lean custom commands:
 	                          if config option set to 'disable', remove existing cron job if any
 	print_log                 print most recent session log
 	update                    update adblock-lean to the latest version
-	uninstall                 uninstall adblock-lean, remove all adblock-lean-related files and settings"
+	uninstall                 uninstall adblock-lean, remove all adblock-lean-related files and settings
+	calculate_values          calculate values for configuration options based on target entries count"
 
 # silence shellcheck warnings
 : "${action:=}" "${EXTRA_COMMANDS}" "${EXTRA_HELP}" "${boot_start_delay_s:=}"
@@ -1988,6 +1989,13 @@ disable()
 		log_msg "The adblock-lean service is already disabled."
 	fi
 	return "$rv"
+}
+
+calculate_values()
+{
+	source_libs || exit 1
+	do_calculate_values "${@}"
+	exit ${?}
 }
 
 set_ansi

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -410,7 +410,7 @@ set_preset_vars()
 		blocklist_urls=\"\${${1}_urls}\""
 	: "${lim_coeff:=1}" "${mem:=???}"
 
-	do_calculate_values -n "${tgt_entries_cnt}" "${urls_cnt}" "${lim_coeff}" || return 1
+	do_calculate_limits -n "${tgt_entries_cnt}" "${urls_cnt}" "${lim_coeff}" || return 1
 
 	[ "${2}" = '-d' ] && print_msg "" "${purple}${1}${n_c}: recommended for devices with ${mem} MB of memory."
 
@@ -427,7 +427,7 @@ set_preset_vars()
 	:
 }
 
-do_calculate_values()
+do_calculate_limits()
 {
 	# keeps first two digits, replaces others with 0's
 	# 1 - var for I/O
@@ -484,16 +484,16 @@ do_calculate_values()
 		done
 	else
 		case "${tgt_entries_cnt}" in ''|*[!0-9]*)
-			reg_failure "calculate_values: invalid entries count '${tgt_entries_cnt}'."; return 1 ;;
+			reg_failure "calculate_limits: invalid entries count '${tgt_entries_cnt}'."; return 1 ;;
 		esac
 
 		case "${urls_cnt}" in ''|*[!0-9]*)
-			reg_failure "calculate_values: Invalid URLs count '${urls_cnt}'."
+			reg_failure "calculate_limits: Invalid URLs count '${urls_cnt}'."
 			return 1
 		esac
 	fi
 
-	[ "${urls_cnt}" -eq 0 ] && { reg_failure "calculate_values: Invalid URLs count '${urls_cnt}'."; return 1; }
+	[ "${urls_cnt}" -eq 0 ] && { reg_failure "calculate_limits: Invalid URLs count '${urls_cnt}'."; return 1; }
 
 
 	# Default values calculation:

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -484,7 +484,7 @@ do_calculate_limits()
 		done
 	else
 		case "${tgt_entries_cnt}" in ''|*[!0-9]*)
-			reg_failure "calculate_limits: invalid entries count '${tgt_entries_cnt}'."; return 1 ;;
+			reg_failure "calculate_limits: Invalid entries count '${tgt_entries_cnt}'."; return 1 ;;
 		esac
 
 		case "${urls_cnt}" in ''|*[!0-9]*)

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -756,7 +756,7 @@ gen_list_parts()
 			# consolidate allowlist parts into one file
 			for file in "${PROCESSED_PARTS_DIR}/allowlist-"*
 			do
-				[ -e "${file}" ] || break
+				case "${file}" in ''|*"*") continue; esac
 				cat "${file}" >> "${PROCESSED_PARTS_DIR}/allowlist" || { reg_failure "Failed to merge allowlist part."; return 1; }
 				rm -f "${file}"
 			done
@@ -768,7 +768,7 @@ gen_list_parts()
 			local file part_line_count=0 list_line_count=0
 			for file in "${ABL_TMP_DIR}/stats_${list_type}-"*
 			do
-				[ -e "${file}" ] || break
+				case "${file}" in ''|*"*") continue; esac
 				read_str_from_file -v "part_line_count _" -f "${file}" -a 1 -V 0 || return 1
 				list_line_count=$((list_line_count+part_line_count))
 			done

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -633,14 +633,6 @@ process_list_part()
 		# compress or cat
 		${part_compr_or_cat} > "${dest_file}"
 
-		read_str_from_file -v "part_line_count part_size_B _" -f "${list_stats_file}" -a 2 -D "list stats" || finalize_job 1
-		if [ -f "${size_exceeded_file}" ]
-		then
-			reg_failure "Size of ${list_type} part from '${list_path}' reached the maximum value set in config (${max_file_part_size_KB} KB)."
-			log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config."
-			finalize_job 2
-		fi
-
 		local lines_cnt_low='' dl_completed=''
 
 		[ -f "${ucl_err_file}" ] && grep -q "Download completed" "${ucl_err_file}" && dl_completed=1
@@ -663,6 +655,14 @@ process_list_part()
 				*) log_msg -warn "${rogue_el_print} identified in ${list_type} file from: ${list_path}."
 			esac
 			finalize_job 3
+		fi
+
+		read_str_from_file -v "part_line_count part_size_B _" -f "${list_stats_file}" -a 2 -D "list stats" || finalize_job 1
+		if [ -f "${size_exceeded_file}" ]
+		then
+			reg_failure "Size of ${list_type} part from '${list_path}' reached the maximum value set in config (${max_file_part_size_KB} KB)."
+			log_msg "Consider either increasing this value in the config or removing the corresponding ${list_type} part path or URL from config."
+			finalize_job 2
 		fi
 
 		int2human line_count_human "${part_line_count}"

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -803,12 +803,10 @@ gen_and_process_blocklist()
 {
 	convert_entries()
 	{
-		if [ "${AWK_CMD}" = gawk ]
-		then
-			pack_entries_awk "$@"
-		else
-			pack_entries_sed "$@"
-		fi
+		case "${AWK_CMD}" in
+			*gawk) pack_entries_awk "$@" ;;
+			*) pack_entries_sed "$@"
+		esac
 	}
 
 	# convert to dnsmasq format and pack 4 input lines into 1 output line


### PR DESCRIPTION
This PR implements support for command `calculate_values`, as discussed in the forum.

Edit: command name changed to `calculate_limits`.

Edit 2:

added a few more commits:
- Fix converting short ID to URL for dnsmasq format
- Fix packing entries with awk (turns out we had a regression which caused only sed to be used for packing)
- process_list_part(): refactor for better readability and to avoid unnecessary logic inside the processing pipeline
- process_list_part(): delay reading processed list stats to when they are actually needed (may avoid the need to `sleep 1` when the filesystem did not have time to prepare the file yet)
- get_gh_ref(): minor refactor to work around GH syntax highlighting bug
- gen_list_parts(): avoid unnecessary I/O
- parse_config(): handle duplicate keys