### PR TITLE
Various improvements

### DIFF
--- a/abl-install.sh
+++ b/abl-install.sh
@@ -1229,7 +1229,7 @@ fetch_and_install()
 
 	set -o pipefail
 
-	local file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
+	local OPTIND file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
 		upd_channel='' req_upd_channel='' force_upd_channel=''
 
 	IGNORE_CACHE=

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -53,7 +53,7 @@ fi
 AWK_CMD="/bin/busybox awk"
 
 
-check_util_install() { command -v "${1:?}" 1>/dev/null; }
+is_cmd_install() { command -v "${1:?}" 1>/dev/null; }
 
 had_f_install()
 {
@@ -190,7 +190,7 @@ find_files_install()
 
 	unset_vars_install "${ff_path_out_var}" || return 1
 
-	[ -n "${FF_EXEC}" ] && { check_util_install "${FF_EXEC%% *}" || { reg_failure_install "${me}: invalid exec cmd '${FF_EXEC}'"; return 1; }; }
+	[ -n "${FF_EXEC}" ] && { is_cmd_install "${FF_EXEC%% *}" || { reg_failure_install "${me}: invalid exec cmd '${FF_EXEC}'"; return 1; }; }
 
 	local had_f
 	had_f_install && had_f=1
@@ -1034,7 +1034,7 @@ install_abl_files()
 				blocklist_ipv4_urls=raw_ipv4_block_lists
 				min_good_line_count=min_blockset_entries
 				min_good_entries=min_blockset_entries
-				max_blocklist_file_size_KB=max_blockset_file_size_KB
+				max_blocklist_file_size_KB=max_blockset_size_KB
 			'
 
 			# convert into _DELIM_ separated lists
@@ -1207,7 +1207,7 @@ fetch_and_install()
 	local util
 	for util in tar find uclient-fetch jsonfilter dnsmasq
 	do
-		check_util_install "${util}" || inst_failed "Utility '${util}' not found."
+		is_cmd_install "${util}" || inst_failed "Utility '${util}' not found."
 	done
 
 	# Check dnsmasq
@@ -1372,6 +1372,9 @@ fetch_and_install()
 		[ "${DO_DIALOGS}" = 1 ] && [ "${REPLY}" = y ] || exit 0
 
 		clean_env_install
+		# for compatibility with older versions
+		set +o pipefail
+		set +f
 		. "${ABL_SERVICE_PATH}" || return 1
 		start
 		exit ${?}

--- a/abl-install.sh
+++ b/abl-install.sh
@@ -55,6 +55,14 @@ AWK_CMD="/bin/busybox awk"
 
 check_util_install() { command -v "${1:?}" 1>/dev/null; }
 
+had_f_install()
+{
+	case "${-}" in
+		*f*) return 0 ;;
+		*) return 1
+	esac
+}
+
 is_uint_install()
 {
 	local _v
@@ -151,7 +159,7 @@ check_func_install()
 }
 
 # asks the user to pick an option
-# 1 - input in the format 'a|b|c'
+# 1 - input in format 'a|b|c'
 # output via $REPLY
 pick_opt_install()
 {
@@ -177,16 +185,21 @@ pick_opt_install()
 #   5: filename suffix
 find_files_install()
 {
-	local me=find_files_install exec='' ff_file ff_found='' \
+	local me=find_files_install exec ff_file ff_found ff_fail \
 		ff_path_out_var="${1}" ff_dir="${2}" ff_prefix="${3}" ff_mid="${4}" ff_suffix="${5}"
 
 	unset_vars_install "${ff_path_out_var}" || return 1
 
 	[ -n "${FF_EXEC}" ] && { check_util_install "${FF_EXEC%% *}" || { reg_failure_install "${me}: invalid exec cmd '${FF_EXEC}'"; return 1; }; }
 
+	local had_f
+	had_f_install && had_f=1
+	set +f
+
 	# shellcheck disable=SC2027
 	for ff_file in "${ff_dir}/${ff_prefix}"${ff_mid}"${ff_suffix}"
 	do
+		set -f
 		case "${ff_file}" in
 			''|*"*"*) continue ;;
 			[\$\(\)\{\}\"\`\'] ) reg_msg_install -warn "${me}: path '${ff_file}' contains unsupported characters. Ignoring the file."; continue
@@ -196,11 +209,15 @@ find_files_install()
 		[ -n "${FF_EXEC}" ] &&
 		{
 			exec="${FF_EXEC//"{}"/"\"${ff_file}\""}"
-			eval "${exec}" || { reg_failure_install "${me}: '${exec}' returned code ${?}"; return 1; }
+			eval "${exec}" || { reg_failure_install "${me}: '${exec}' returned code ${?}"; ff_fail=1; break; }
 		}
 
 		ff_found="${ff_found}${ff_found:+"${_NL_}"}${ff_file}"
 	done
+
+	[ -n "${had_f}" ] || set +f
+
+	[ -n "${ff_fail}" ] && return 1
 
 	[ -n "${ff_found}" ] || return 2
 
@@ -211,7 +228,7 @@ find_files_install()
 # Splits path to file into dir, filename, ext
 split_path_install()
 {
-	local sp_file='' sp_fname='' sp_ext='' sp_dir='' \
+	local sp_file sp_fname sp_ext sp_dir \
 		sp_dir_out_var="${1}" sp_fname_out_var="${2}" sp_ext_out_var="${3}" sp_path="${4}"
 
 	unset_vars_install "${sp_dir_out_var}" "${sp_fname_out_var}" "${sp_ext_out_var}" || return 1
@@ -308,7 +325,6 @@ reg_msg_install()
 
 	[ "${log_level}" = 5 ] && msgs_dest="/dev/stderr" # Debug
 
-	set -f
 	IFS="${_DELIM_}"
 	for m in ${msgs}
 	do
@@ -327,7 +343,6 @@ reg_msg_install()
 		esac
 	done
 	IFS="${DEFAULT_IFS}"
-	set +f
 }
 
 # 1 - msg
@@ -598,9 +613,14 @@ fetch_abl_dist_install()
 	local fetch_rv extract_dir fetch_dir="${dist_dir_fetch}/fetch"
 	local tarball="${fetch_dir}/remote_abl.tar.gz" ucl_err_file="${fetch_dir}/ucl_err"
 
+	local had_f
+	had_f_install && had_f=1
+
 	rm -f "${ucl_err_file}" "${tarball}"
+	set +f
 	rm -rf "${fetch_dir}/${ABL_REPO_AUTHOR}-adblock-lean-"*
-	try_mkdir_install -p "${fetch_dir}" || return 1
+	set -f
+	try_mkdir_install -p "${fetch_dir}" || { [ -n "${had_f}" ] || set +f; return 1; }
 
 	uclient-fetch "${tarball_url_fetch}" -O "${tarball}" 2> "${ucl_err_file}" &&
 	grep -q "Download completed" "${ucl_err_file}" &&
@@ -615,10 +635,14 @@ fetch_abl_dist_install()
 	rm -f "${ucl_err_file}"
 
 	[ "${fetch_rv}" = 0 ] && {
+		set +f
 		mv "${extract_dir:-?}"/* "${dist_dir_fetch:-?}/" ||
-			{ rm -rf "${extract_dir:-?}"; reg_failure_install "Failed to move files to dist dir."; return 1; }
+			{ reg_failure_install "Failed to move files to dist dir."; fetch_rv=1; }
+		set -f
 	}
 	rm -rf "${extract_dir:-?}" "${fetch_dir:-?}"
+
+	[ -n "${had_f}" ] || set +f
 
 	return ${fetch_rv}
 }
@@ -760,7 +784,6 @@ install_abl_files()
 	[ -f "${dist_dir}/adblock-lean" ] || inst_failed "Can not find ${dist_dir}/adblock-lean"
 
 	log_msg_install "" "Installing new files..."
-
 
 	upd_cfg_format="$(get_cfg_format_install "${dist_dir}/adblock-lean")" || inst_failed
 	get_cur_main_cfg_path cur_main_cfg_path
@@ -998,6 +1021,7 @@ install_abl_files()
 				min_ipv4_blocklist_part_line_count=min_ipv4_block_part_entries
 				min_allowlist_part_line_count=min_allow_part_entries
 				max_file_part_size_KB=max_part_size_KB
+				max_download_retries=max_download_attempts
 			'
 
 			migrate_opts_blockset='
@@ -1008,10 +1032,8 @@ install_abl_files()
 				blocklist_urls=raw_block_lists
 				allowlist_urls=raw_allow_lists
 				blocklist_ipv4_urls=raw_ipv4_block_lists
-				dnsmasq_blocklist_urls=dnsmasq_block_lists
-				dnsmasq_blocklist_ipv4_urls=dnsmasq_ipv4_block_lists
-				dnsmasq_allowlist_urls=dnsmasq_allow_lists
-				min_good_line_count=min_good_entries
+				min_good_line_count=min_blockset_entries
+				min_good_entries=min_blockset_entries
 				max_blocklist_file_size_KB=max_blockset_file_size_KB
 			'
 
@@ -1181,17 +1203,31 @@ fetch_and_install()
 	unexp_arg() { fetch_failed "fetch_and_install: unexpected argument '${1}'."; }
 
 
+	# Check dependencies
+	local util
+	for util in tar find uclient-fetch jsonfilter dnsmasq
+	do
+		check_util_install "${util}" || inst_failed "Utility '${util}' not found."
+	done
+
+	# Check dnsmasq
+	dnsmasq --help | grep -qe "--conf-script" ||
+		inst_failed "The version of dnsmasq installed on this system is too old. To use adblock-lean, upgrade this system to OpenWrt 23.05 or later."
+
+	# Test process substitution support
+	printf '%s\n%s\n' "#!/bin/sh" "printf %s >(:)" > /tmp/abl-test
+	/bin/sh /tmp/abl-test 1>/dev/null 2>/dev/null ||
+	{
+		rm -f /tmp/abl-test
+		inst_failed "/bin/sh does not support process substitution. To use adblock-lean, please update OpenWrt to 23.05 or later version."
+	}
+	rm -f /tmp/abl-test
+
+
 	trap 'cleanup_and_exit_install 1' INT TERM
 	trap 'cleanup_and_exit_install ${?}' EXIT
 
 	set -o pipefail
-
-	local util
-
-	for util in tar find uclient-fetch jsonfilter
-	do
-		check_util_install "${util}" || inst_failed "Utility '${util}' not found."
-	done
 
 	local file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
 		upd_channel='' req_upd_channel='' force_upd_channel=''
@@ -1346,7 +1382,9 @@ fetch_and_install()
 		[ "$REPLY" = y ]
 	then
 		clean_env_install
-		set +o pipefail # for compatibility with older versions
+		# for compatibility with older versions
+		set +o pipefail
+		set +f
 		# shellcheck source=/dev/null
 		. "${ABL_SERVICE_PATH}"
 		setup
@@ -1360,25 +1398,14 @@ fetch_and_install()
 
 set_ansi_install
 
-# Test process substitution support
-printf '%s\n%s\n' "#!/bin/sh" "printf %s >(:)" > /tmp/abl-test
-/bin/sh /tmp/abl-test 1>/dev/null 2>/dev/null ||
-{
-	rm -f /tmp/abl-test
-	inst_failed "/bin/sh does not support process substitution. To use adblock-lean, please update OpenWrt to 23.05 or later version."
-}
-rm -f /tmp/abl-test
-
-dnsmasq --help | grep -qe "--conf-script" ||
-	inst_failed "The version of dnsmasq installed on this system is too old. To use adblock-lean, upgrade this system to OpenWrt 23.05 or later."
-
-
 export ABL_IN_INSTALL=1
 [ -s "${ABL_SERVICE_PATH}" ] && export ABL_IS_UPDATE=1
 
 if [ -z "${INST_SOURCED}" ]
 then
+	set -f
 	fetch_and_install "${@}"
 else
 	:
 fi
+

--- a/adblock-lean
+++ b/adblock-lean
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 # shellcheck source=/dev/null
-# shellcheck disable=SC3043,SC2018,SC3020,SC1090,SC3045,SC2155,SC2015,SC3057,SC3044,SC2016,SC3003,SC3060,SC3040
+# shellcheck disable=SC3043,SC2018,SC3020,SC1090,SC3045,SC2155,SC2015,SC3057,SC3044,SC2016,SC3003,SC3060,SC3040,SC3028
 
 ABL_VERSION=dev
 ABL_UPD_CHANNEL=release
@@ -122,14 +122,17 @@ export -n ABL_HOTPLUG_PATH_SRC="${ABL_CFG_DIR}/${HOTPLUG_SCRIPT_FNAME}" \
 
 export -n LEGACY_CFG_FILE=/etc/adblock-lean/config # unified config was used in adblock-lean v0.8.1 and earlier
 
+# !! Files lists must be newline-separated (spaces/tabs are ignored)
 export ABL_GEN_FILES="${ABL_SERVICE_PATH}
 		${ABL_HOTPLUG_PATH_SRC}" \
 	ABL_LIB_FILES="${ABL_LIB_DIR}/abl-lib.sh
 		${ABL_LIB_DIR}/abl-process.sh
-		${ABL_LIB_DIR}/abl-manage.sh" \
+		${ABL_LIB_DIR}/abl-manage.sh
+		${ABL_LIB_DIR}/abl-scheduler.sh" \
 	ABL_EXTRA_FILES="" \
 	ABL_EXEC_FILES="${ABL_SERVICE_PATH}" \
-	\
+
+export \
 	ABL_FILES_REG_PATH="/etc/adblock-lean/abl-reg.md5" \
 	\
 	GLOBAL_CFG_FILE="${ABL_CFG_DIR}/global.conf" \
@@ -164,23 +167,51 @@ DEBUG_THRESH=5 # DEBUG_THRESH must be > PRINT_THRESH
 # silence shellcheck warnings
 : "${action:=}" "${boot_start_delay_s:=}" "${CONFIG_FORMAT}" "${SBE_STATUS:=}" "${compression_util:=}"
 
-export -n luci_log luci_pid_action luci_errors luci_dnsmasq_status luci_good_entries luci_update_status luci_pkgs_install_failed luci_cron_job_creation_failed
+export -n luci_log luci_pid_action luci_errors luci_dmsq_status luci_good_entries luci_update_status luci_pkgs_install_failed luci_cron_job_creation_failed
 
 
 ### UTILITY FUNCTIONS
+
+test_exp() { [ "$(( ${1} ))" = 1 ];  }
+
+set_int() { : "$(( ${1} ))"; }
+
+trim_spaces()
+{
+	local tr_in tr_out
+	eval "tr_in=\"\${$1}\""
+	tr_out="${tr_in%"${tr_in##*[! 	]}"}"
+	tr_out="${tr_out#"${tr_out%%[! 	]*}"}"
+	export -n "${1}=${tr_out}"
+}
+
+tr_leading() { export -n "${1:?}=${2#"${2%%[!"${3}"]*}"}"; }
+
+tr_trailing() { export -n "${1:?}=${2%"${2##*[!"${3}"]}"}"; }
 
 is_hex_lc() { case "${1}" in ''|*[!0-9a-f]*) false ;; *) :; esac; }
 
 is_uint()
 {
 	local _v
-	for _v in "${@}"
+	for _v
 	do
 		case "${_v}" in
 			''|*[!0-9]*) return 1
 		esac
 	done
 	:
+}
+
+is_gr_eq()
+{
+	local _v _in="${1:?}"
+	shift
+	is_uint "${@}" || return 1
+	for _v
+	do
+		[ "${_v}" -ge "${_in}" ] || return 1
+	done
 }
 
 is_alphanum()
@@ -193,6 +224,14 @@ is_alphanum()
 		esac
 	done
 	:
+}
+
+has_f()
+{
+	case "${-}" in
+		*f*) return 0 ;;
+		*) return 1
+	esac
 }
 
 # Env vars:
@@ -209,12 +248,12 @@ assert_set()
 		[ -n "${ASSERT_NOEXIT}" ] || exit 1
 	}
 
-	local me=assert_set func _val_ne _var_ne _checked IFS="${DEFAULT_IFS}"
+	local me=assert_set _func _val_ne _var_ne _checked IFS="${DEFAULT_IFS}"
 
 	case "${1}" in
 		F_*)
-			func="${1#"F_"}"
-			case "${func}" in
+			_func="${1#"F_"}"
+			case "${_func}" in
 				'') false ;;
 			esac ;;
 		*) false
@@ -227,12 +266,12 @@ assert_set()
 		[ -n "${_var_ne}" ] || { assert_fail "${me}: func '${1}()': var name can not be empty string."; return 1; }
 		eval "_val_ne=\"\${${_var_ne}}\""
 		case "${_val_ne}" in
-			'') assert_fail "Assertion failed: ${func}(): variable '${_var_ne}' must have a value."; return 1 ;;
+			'') assert_fail "Assertion failed: ${_func}(): variable '${_var_ne}' must have a value."; return 1 ;;
 			*) _checked=1; continue
 		esac
 	done
 
-	case "${_checked}" in '') assert_fail "${me}: no vars specified by ${func}()"; return 1; esac
+	case "${_checked}" in '') assert_fail "${me}: no vars specified by ${_func}()"; return 1; esac
 
 	:
 }
@@ -243,7 +282,7 @@ bad_args()
 	shift
 	for arg in "${@}"
 	do
-		args="${args}${args:+", "}'${arg}'"
+		abl_append args "'${arg}'" ", "
 	done
 	reg_failure "${func}: bad args: ${args}"
 	exit 1
@@ -288,11 +327,13 @@ find_files()
 
 	unset_vars "${ff_path_out_var}"
 
-	[ -n "${FF_EXEC}" ] && { check_util "${FF_EXEC%% *}" || { reg_failure "${me}: invalid exec cmd '${FF_EXEC}'"; return 1; }; }
+	[ -n "${FF_EXEC}" ] && { is_cmd "${FF_EXEC%% *}" || { reg_failure "${me}: invalid exec cmd '${FF_EXEC}'"; return 1; }; }
 
+	set +f
 	# shellcheck disable=SC2027
 	for ff_file in "${ff_dir}/${ff_prefix}"${ff_mid}"${ff_suffix}"
 	do
+		set -f
 		case "${ff_file}" in
 			''|*"*"*) continue ;;
 			[\$\(\)\{\}\"\`\'] ) reg_msg -warn "${me}: path '${ff_file}' contains unsupported characters. Ignoring the file."; continue
@@ -307,10 +348,11 @@ find_files()
 			eval "${exec}" || { reg_failure "${me}: '${exec}' returned code ${?}"; return 1; }
 		}
 
-		ff_found="${ff_found}${ff_found:+"${_NL_}"}${ff_file}"
+		abl_append ff_found "${ff_file}" "${_NL_}"
 
 		[ -n "${FF_FIRST}" ] && [ -z "${FF_RM_EXTRA}" ] && break
 	done
+	set -f
 
 	[ -n "${ff_found}" ] || return 2
 
@@ -320,10 +362,10 @@ find_files()
 
 check_func()
 {
-	check_util "${1}" && [ "$(type "${1}" 2>/dev/null | head -n1)" = "${1} is a function" ]
+	is_cmd "${1}" && [ "$(type "${1}" 2>/dev/null | head -n1)" = "${1} is a function" ]
 }
 
-check_util()
+is_cmd()
 {
 	command -v "${1}" 1>/dev/null
 }
@@ -335,6 +377,15 @@ set_ansi()
 	# shellcheck disable=SC2046
 	set -- $(printf '\033[0;31m \033[0;32m \033[0;34m \033[1;34m \033[1;33m \033[0;35m \033[38;5;214m \033[0m \35 \t \r')
 	export red="${1}" green="${2}" blue="${3}" lblue="${4}" yellow="${5}" purple="${6}" orange="${7}" n_c="${8}" _DELIM_="${9}" TAB="${10}" CR="${11}" CR_LF="${11}${_NL_}"
+}
+
+# 1: var name
+# 2: val
+# 3: delim
+abl_append()
+{
+	check_var_names "${1}" || exit 1
+	eval "${1}=\"\${${1}}\${${1}:+\"\${3:-" "}\"}${2}\""
 }
 
 # checks if string $1 is included in space-separated list $2
@@ -350,6 +401,7 @@ is_included() {
 	esac
 }
 
+
 # adds a string to a space-separated list if it's not included yet
 # 1 - name of var which contains the list
 # 2 - new value(s)
@@ -361,17 +413,17 @@ add2list() {
 	esac
 
 	dbg_off
-	local a2l_val curr_list delim="${3:-" "}"
+	local a2l_val cur_list delim="${3:-" "}"
 
-	eval "curr_list=\"\${${1}}\""
+	eval "cur_list=\"\${${1}}\""
 	local IFS="${delim}"
 	for a2l_val in ${2}
 	do
 		case "${a2l_val}" in '') continue; esac
-		is_included "${a2l_val}" "${curr_list}" "${delim}" && continue
-		curr_list="${curr_list}${curr_list:+"${delim}"}${a2l_val}"
+		is_included "${a2l_val}" "${cur_list}" "${delim}" && continue
+		abl_append cur_list "${a2l_val}" "${delim}"
 	done
-	export -n "${1}=${curr_list}"
+	export -n "${1}=${cur_list}"
 	dbg_on
 	:
 }
@@ -394,37 +446,40 @@ subtract_a_from_b() {
 	return ${rv_su}
 }
 
-# reads first line from file into variables
+# reads file and extracts first line into variables
 # Args:
 # -v <out_var_name>
 # -f <file_path>
 # Optional args:
 # '-a <attempts_num>'
-# '-d' to delete the file after reading
-# '-q' to quiet error message
+# '-d' : delete the file
+# '-q' : quiet error message
 # '-n X' to limit number of bytes read
 # '-D <"[file_desc]">'
 # '-V <"[default_val]">'
 # '-F <"[fs_char]">'
-# '-E <"[eof_char]">'
+#
+# error codes:
+# 1=general error
+# 2=can't populate all vars
+# 3=file too big
 read_str_from_file()
 {
-	local me=read_str_from_file rs_del_file rs_quiet rs_num_bytes rs_outvars rs_file \
-		rs_file_desc rs_def_val rs_read_failed rs_attempts=1 rs_attempt rs_var rs_fs="${DEFAULT_IFS}" rs_eof="${_NL_}" \
-		IFS="${DEFAULT_IFS}"
-	while getopts ":dqn:v:f:a:D:V:F:E:" opt
+	local me=read_str_from_file rs_rv rs_del_file rs_quiet rs_num_bytes rs_limit rs_outvars rs_file rs_too_big rs_probe rs_fs=" "$'\t' \
+		rs_file_desc rs_def_val rs_read_failed rs_attempts=1 rs_attempt rs_var rs_val \
+		OPTIND IFS="${DEFAULT_IFS}"
+	while getopts ":dqn:v:f:a:D:V:F:" opt
 	do
 		case "${opt}" in
 			d) rs_del_file=1 ;;
 			q) rs_quiet=1 ;;
-			n) rs_num_bytes=-n${OPTARG} ;;
+			n) rs_num_bytes=${OPTARG} rs_limit=$((OPTARG+1)) ;;
 			v) rs_outvars=${OPTARG} ;;
 			f) rs_file=${OPTARG} ;;
 			a) rs_attempts=${OPTARG} ;;
 			D) rs_file_desc=${OPTARG} ;;
 			V) rs_def_val=${OPTARG} ;;
-			F) rs_fs="${OPTARG}" ;;
-			E) rs_eof="${OPTARG}" ;;
+			F) rs_fs=${OPTARG} ;;
 			*) reg_failure "${me}: unexpected option '${opt}'."; return 1;
 		esac
 	done
@@ -434,30 +489,61 @@ read_str_from_file()
 	rs_attempt=0
 	while :
 	do
+		rs_probe='' rs_too_big='' rs_read_failed=''
 		rs_attempt=$((rs_attempt+1))
 		[ "${rs_attempt}" -le "${rs_attempts}" ] || { rs_read_failed=1; break; }
 		[ "${rs_attempt}" = 1 ] || sleep 1
 
-		IFS="${rs_fs}" read -r -d "${rs_eof}" ${rs_num_bytes} ${rs_outvars:?} 2>/dev/null < "${rs_file:?}"
+		# NUL never matches in a text file, so read only succeeds when it consumed rs_limit bytes
+		IFS= read -r -d '' ${rs_limit:+"-n${rs_limit}"} rs_probe 2>/dev/null < "${rs_file:?}" &&
+		[ -n "${rs_limit}" ] &&
+		{
+			reg_failure "${rs_file_desc}${rs_file_desc:+ }file is larger than ${rs_num_bytes} bytes"
+			rs_too_big=1
+			rs_read_failed=1
+		}
+
+		rs_probe="${rs_probe%%"${_NL_}"*}"
+		[ -n "${rs_probe}" ] ||
+			{
+				[ -n "${rs_too_big}" ] && break
+				continue
+			}
+
+		IFS="${rs_fs}"
+		set -- ${rs_probe}
+		IFS="${DEFAULT_IFS}"
+
 		for rs_var in ${rs_outvars}
 		do
+			rs_val="${1}"
+			shift
 			case "${rs_var}" in _) continue; esac
-			eval "[ -n \"\${${rs_var}}\" ]" || continue 2
+			[ -n "${rs_val}" ] ||
+				{
+					[ -n "${rs_too_big}" ] && break 2
+					continue 2
+				}
+			export -n "${rs_var}=${rs_val}"
 		done
 		break
 	done
 
 	[ -n "${rs_del_file}" ] && rm -f "${rs_file}"
-	[ -z "${rs_read_failed}" ] && return 0
 
+	[ -z "${rs_read_failed}" ] || [ -n "${rs_quiet}" ] ||
+		reg_failure "Failed to read${rs_file_desc:+ }${rs_file_desc} file '${rs_file}'."
+
+	[ -z "${rs_read_failed}" ] && return 0
+	[ -n "${rs_too_big}" ] && rs_rv=3
+
+	[ -n "${rs_def_val}" ] &&
 	for rs_var in ${rs_outvars}
 	do
 		export -n "${rs_var}=${rs_def_val}"
 	done
 
-	[ -n "${rs_quiet}" ] || reg_failure "Failed to read${rs_file_desc:+ }${rs_file_desc} file '${rs_file}'."
-
-	return 1
+	return ${rs_rv:-2}
 }
 
 # 0 - (optional) '-p'
@@ -472,7 +558,7 @@ try_mkdir()
 }
 
 # asks the user to pick an option
-# 1 - input in the format 'a|b|c'
+# 1 - input in format 'a|b|c'
 # output via $REPLY
 pick_opt()
 {
@@ -490,6 +576,36 @@ pick_opt()
 	done
 }
 
+# 1 - var name for centiseconds output
+get_uptime_cs() {
+	local __uptime i_cs gu_cs gu_s
+	unset_vars "${1}"
+
+	read -r __uptime _ < /proc/uptime &&
+	case "${__uptime}" in
+		''|*.*.*) false ;;
+		*.*) ;;
+		*) false ;;
+	esac &&
+	i_cs="${__uptime##*.}" &&
+	case "${i_cs}" in
+		'') gu_cs=00 ;;
+		?) gu_cs="${i_cs}0" ;;
+		??) gu_cs="${i_cs}" ;;
+		??*) gu_cs="${i_cs%"${i_cs#??}"}"
+	esac &&
+	gu_s="${__uptime%.*}" &&
+	is_uint "${gu_s}" "${gu_cs}" ||
+	{
+		reg_failure "Failed to get uptime from /proc/uptime."
+		export -n "${1}"=0
+		return 1
+	}
+	gu_cs="${gu_s:-0}${gu_cs:-00}"
+	gu_cs="${gu_cs#"${gu_cs%%[!0]*}"}"
+	export -n "${1}=${gu_cs:-0}"
+}
+
 dbg_start() { DBG_INITIALIZED=1; set -x; }
 dbg_end() { DBG_INITIALIZED=''; set +x; }
 dbg_on() { case "${DBG_INITIALIZED}" in '') ;; *) set -x; esac; }
@@ -497,6 +613,18 @@ dbg_off() { case "${DBG_INITIALIZED}" in '') ;; *) set +x; esac; }
 
 
 ### HELPER FUNCTIONS
+
+config_load_a()
+{
+	{
+		[ -n "${FUNCTIONS_SH_SOURCED}" ] ||
+		check_func config_load 1>/dev/null ||
+		{ [ -f /lib/functions.sh ] && . /lib/functions.sh; }
+	} &&
+	FUNCTIONS_SH_SOURCED=1 &&
+	config_load "${1:?}" ||
+		{ reg_failure "Failed to load '${1}' config."; return 1; }
+}
 
 # Looks for blockset-*.conf files and populates ${SET_IDS}
 # 1 (optional): var name to output found paths (newline-separated)
@@ -599,7 +727,9 @@ rm_if_writable()
 		[ -n "${dir}" ] && [ -n "${filename}" ] &&
 		is_dir_writable "${set_id}" "${dir}" || continue
 
+		set +f
 		rm -f "${dir}/${filename}" "${dir}/${filename}."*
+		set -f
 		removed=1
 	done
 	[ -n "${removed}" ]
@@ -621,30 +751,30 @@ rm_bk()
 # KEEP_PERSIST, KEEP_BK
 rm_blocksets()
 {
-	local set_id install_path curr_path curr_persist_path persist_mode rm_enum rm_path rm_pr \
+	local set_id install_path cur_path cur_persist_path persist_mode rm_enum rm_path rm_pr \
 		rm_rv=0 \
 		set_ids="${*:-"${SET_IDS}"}"
 
 	for set_id in ${set_ids}
 	do
-		get_params "${set_id}" install_path curr_path bk_file persist_mode curr_persist_path
+		get_params "${set_id}" install_path cur_path bk_file persist_mode cur_persist_path
 
 		[ "${KEEP_PERSIST}" = 1 ] &&
 		{
-			[ -n "${curr_persist_path}" ] || [ "${persist_mode}" != disable ] &&
+			[ -n "${cur_persist_path}" ] || [ "${persist_mode}" != disable ] &&
 				rm_pr=" on the ramdisk"
-			curr_persist_path=
+			cur_persist_path=
 		}
 
 		[ -n "${KEEP_BK}" ] &&
 		{
-			[ "${curr_path}" = "${bk_file}" ] && curr_path=
-			[ "${curr_persist_path}" = "${bk_file}" ] && curr_persist_path=
+			[ "${cur_path}" = "${bk_file}" ] && cur_path=
+			[ "${cur_persist_path}" = "${bk_file}" ] && cur_persist_path=
 		}
 
-		[ -n "${install_path}${curr_path}${curr_persist_path}" ] || continue
-		[ -n "${curr_path}${curr_persist_path}" ] && reg_msg -fb "${set_id}" "Removing any existing blockset files${rm_pr}{}."
-		for rm_enum in curr install curr_persist
+		[ -n "${install_path}${cur_path}${cur_persist_path}" ] || continue
+		[ -n "${cur_path}${cur_persist_path}" ] && reg_msg -fb "${set_id}" "Removing any existing blockset files${rm_pr}{}."
+		for rm_enum in cur install cur_persist
 		do
 			eval "rm_path=\"\${${rm_enum}_path}\""
 			[ -n "${rm_path}" ] || continue
@@ -697,8 +827,8 @@ rc_enabled()
 # Sets global vars: $PKG_MANAGER $PKG_INSTALL_CMD $PKG_FILES_LIST_CMD
 detect_pkg_manager() {
 	local apk_present opkg_present
-	check_util apk && apk_present=1
-	check_util opkg && opkg_present=1
+	is_cmd apk && apk_present=1
+	is_cmd opkg && opkg_present=1
 	if [ -n "$apk_present" ] && [ -n "$opkg_present" ]
 	then
 		reg_failure "Both apk and opkg package managers present in the system."
@@ -772,8 +902,8 @@ detect_util()
 
 		# try to resolve specific name, then gen game
 		{
-			{ [ -n "${specific_name}" ] && check_util "${specific_name}" && res_name="${specific_name}"; } ||
-			{ [ -n "${gen_name}" ] && check_util "${gen_name}" && res_name="${gen_name}"; }
+			{ [ -n "${specific_name}" ] && is_cmd "${specific_name}" && res_name="${specific_name}"; } ||
+			{ [ -n "${gen_name}" ] && is_cmd "${gen_name}" && res_name="${gen_name}"; }
 		} &&
 		_util_path="$(command -v "${res_name}")" &&
 		[ -n "${_util_path}" ] &&
@@ -818,11 +948,12 @@ detect_main_utils()
 	local IFS="${DEFAULT_IFS}" util_params failed_utils
 # Format:	VAR			gen_name	specific_name	specific_path
 	for util_params in \
-		"AWK_CMD		awk			gawk	/usr/bin/gawk				" \
+		"AWK_CMD		awk				gawk	/usr/bin/gawk				" \
 		"SED_CMD		sed				''		/usr/libexec/sed-gnu		" \
 		"SORT_CMD		sort			''		/usr/libexec/sort-coreutils	" \
 		"CAT_CMD		cat				''		/bin/cat					" \
 		"LOG_CMD		logger			''		/usr/bin/logger				" \
+		"DMSQ_CMD		dnsmasq			''		/usr/sbin/dnsmasq			" \
 		"DF_CMD			df				''		/bin/df						" \
 		"MD5_CMD		md5sum			''		/usr/bin/md5sum				" \
 		"NSLOOKUP_CMD	nslookup		''		/usr/bin/nslookup			" \
@@ -849,7 +980,7 @@ reg_failure()
 	local arg fail_msg
 	log_msg -err "${@}"
 	for arg in "${@}"; do
-		fail_msg="${fail_msg:+"${fail_msg}${_NL_}"}${arg}"
+		abl_append fail_msg "${arg}" "${_NL_}"
 	done
 	luci_errors="${fail_msg}"
 }
@@ -877,7 +1008,7 @@ debug_msg() { reg_msg -5 -d "${@}"; }
 # -[action|report|noprint|err|warn|[color]
 # -b: append 'blockset[s] <OPTARG>' to the message
 # -d: message is debug
-# -fb|-wb: same as above, plus [for ]|[with ] prefix
+# -ib|-ob|-fb|-wb: same as above, plus [in|of|for|with ] prefix
 reg_msg()
 {
 	append_msg()
@@ -921,7 +1052,9 @@ reg_msg()
 				fi ;;
 			-b) fetch_ids=1 ;;
 			-d ) [ -n "${ABL_DEBUG}" ] || return 0; debug_prefix="${orange}debug:${n_c} " ;;
+			-ib) ids_pr_prefix="in " fetch_ids=1 ;;
 			-fb) ids_pr_prefix="for " fetch_ids=1 ;;
+			-ob) ids_pr_prefix="of " fetch_ids=1 ;;
 			-wb) ids_pr_prefix="with " fetch_ids=1 ;;
 			-noprint) noprint=1 ;;
 			-report) report_req=1 ;;
@@ -956,8 +1089,6 @@ reg_msg()
 	[ -z "${noprint}" ] && [ "${msg_level}" -le "${PRINT_THRESH}" ] && [ "${msgs_dest}" != "/dev/null" ] && print_req=1
 	[ "${msg_level}" -le "${sys_log_thresh}" ] && sys_log_req=1
 	[ "${msg_level}" -le "${SESSION_LOG_THRESH}" ] && log_file_req=1
-
-	set -f
 
 	if [ -n "${print_req}" ]
 	then
@@ -1000,10 +1131,9 @@ reg_msg()
 		done
 		IFS="${DEFAULT_IFS}"
 		[ -n "${report_req}" ] && [ -n "${custom_scr_sourced}" ] && check_func report_success && report_success "${msgs_nc//"${_DELIM_}"/"${_NL_}"}"
-		[ -n "${action_req}" ] && { update_action_file "${msgs_nc//"${_DELIM_}"/" "}" || { set +f; return 1; }; }
+		[ -n "${action_req}" ] && { update_action_file "${msgs_nc//"${_DELIM_}"/" "}" || return 1; }
 	fi
 
-	set +f
 	dbg_on
 }
 
@@ -1027,21 +1157,18 @@ trap_and_catch() {
 cleanup_and_exit()
 {
 	trap - INT TERM EXIT
-	if [ -n "${CLEANUP_REQ}" ]
-	then
-		[ "${1}" != 0 ] && print_msg "" "Cleaning up..."
-		[ -n "${SCHEDULER_PID}" ] && {
-			kill -s USR1 "${SCHEDULER_PID}" 2>/dev/null
-			wait_on_pid "${SCHEDULER_PID}" 5
-			[ -d "/proc/${SCHEDULER_PID}" ] && kill_pids_recursive "${SCHEDULER_PID}"
-		}
-	fi
+
+	[ -n "${SCHEDULER_PID}" ] && [ -d "/proc/${SCHEDULER_PID}" ] &&
+	{
+		print_msg "Cleaning up..."
+		term_ppid -TERM "${SCHEDULER_PID}"
+	}
 
 	rm -rf "${ABL_TMP_DIR}" "${ABL_CFG_STAGING_DIR}"
 
 	if [ "${1}" != 0 ] && [ -n "${FAIL_STOP_REQ}" ]
 	then
-		do_stop
+		FORCE_STOP_ALL=1 do_stop
 		rm -rf "${ABL_RUN_DIR}"
 	fi
 
@@ -1067,12 +1194,12 @@ cleanup_and_exit()
 	exit "${1}"
 }
 
-dnsmasq_stop_restart_shared()
+dmsq_stop_restart_shared()
 {
-	local rv index d_indexes dnsmasq_indexes cmd_pr inst_pr inst_name cmd_fail d_fail_ids \
-		cmd="${1}" set_ids="${2}" d_ok_ids_out_var="${3:-_}" indexes_out_var="${4:-_}" inst_names_out_var="${5:-_}"
+	local rv instance d_instances dmsq_instances cmd_pr cmd_fail d_fail_ids \
+		cmd="${1}" set_ids="${2}" d_ok_ids_out_var="${3:-_}" instances_out_var="${4:-_}"
 
-	unset_vars "${indexes_out_var}" "${inst_names_out_var}" "${d_ok_ids_out_var}"
+	unset_vars "${instances_out_var}" "${d_ok_ids_out_var}"
 
 	case "${cmd}" in
 		stop) cmd_pr=Stopping ;;
@@ -1082,11 +1209,11 @@ dnsmasq_stop_restart_shared()
 	if [ -n "${set_ids}" ] &&
 		for set_id in ${set_ids}
 		do
-			ASSERT_NOEXIT=1 get_params -f "${cmd}" "${set_id}" dnsmasq_indexes || { cmd_fail=1; break; }
-			add2list d_indexes "${dnsmasq_indexes}"
+			ASSERT_NOEXIT=1 get_params -f "${cmd}" "${set_id}" dmsq_instances || { cmd_fail=1; break; }
+			add2list d_instances "${dmsq_instances}"
 		done &&
 		[ -z "${cmd_fail}" ] &&
-		[ -n "${d_indexes}" ]
+		[ -n "${d_instances}" ]
 	then
 		:
 	else
@@ -1102,25 +1229,13 @@ dnsmasq_stop_restart_shared()
 		return 0
 	fi
 
-	for index in ${d_indexes}
+	for instance in ${d_instances}
 	do
-		if
-			eval "inst_name=\"\${DNSMASQ_INST_NAME_${index}}\"" &&
-			{
-				[ -n "${inst_name}" ] || { reg_failure "Internal error: dnsmasq instance name unknown for index '${index}'."; false; }
-			}
-		then
-			inst_pr="dnsmasq instance ${lblue}${inst_name}${n_c}"
-		else
-			inst_pr="all dnsmasq instances"
-			inst_name=
-		fi
-		reg_action -purple "" "${cmd_pr} ${inst_pr}." || return 1
+		reg_action -purple "" "${cmd_pr} dnsmasq instance ${lblue}${instance}${n_c}." || return 1
 
 		if /etc/init.d/dnsmasq "${cmd}" "${inst_name}" &> /dev/null
 		then
-			add2list "${inst_names_out_var}" "${inst_name}"
-			add2list "${indexes_out_var}" "${index}"
+			add2list "${instances_out_var}" "${instance}"
 		else
 			reg_failure "Command '/etc/init.d/dnsmasq ${cmd} \"${inst_name}\"' returned code ${?}."
 			rv=1
@@ -1128,8 +1243,8 @@ dnsmasq_stop_restart_shared()
 			then
 				for set_id in ${set_ids}
 				do
-					get_params "${set_id}" dnsmasq_indexes
-					is_included "${index}" "${dnsmasq_indexes}" || continue
+					get_params "${set_id}" dmsq_instances
+					is_included "${instance}" "${dmsq_instances}" || continue
 					set_params "${set_id}" run_state=1
 					add2list d_fail_ids "${set_id}"
 				done
@@ -1145,80 +1260,73 @@ dnsmasq_stop_restart_shared()
 
 stop_dnsmasq()
 {
-	dnsmasq_stop_restart_shared stop "${*}"
+	export -n R_PROCESSED=
+	dmsq_stop_restart_shared stop "${*}"
 }
 
 # 1: new run state
 # 2: var to output OK set ID's
-# 3: indexes (defaults to all)
+# 3: instances (defaults to all)
 restart_dnsmasq()
 {
-	local rv index indexes inst_name inst_names \
-		dnsmasq_indexes \
+	local rv instance instances \
+		dmsq_instances \
 		p1_ok_ids \
 		restart_ok_ids \
 		restart_fail_ids \
-		ns ns4 ns6 \
-		inst_init_pr \
+		wait_printed \
 		res_attempts \
 		new_run_state="${1}" restart_ok_ids_out_var="${2:-_}" set_ids="${3}"
 
 	unset_vars "${restart_ok_ids_out_var}"
-	dnsmasq_stop_restart_shared restart "${set_ids}" p1_ok_ids indexes inst_names || rv=1
+	dmsq_stop_restart_shared restart "${set_ids}" p1_ok_ids instances || rv=1
 	subtract_a_from_b "${p1_ok_ids}" "${set_ids}" restart_fail_ids
 
-	if [ -n "${inst_names}" ] && [ -n "${indexes}" ]
+	export -n R_PROCESSED=
+
+	if [ -n "${instances}" ]
 	then
-		inst_init_pr="initialization of dnsmasq instances: ${lblue}${inst_names// /"${n_c}, ${lblue}"}${n_c}"
-	else
-		indexes=all
-		inst_init_pr="dnsmasq initialization"
-	fi
+		res_attempts=$(seq 1 30)
 
-	res_attempts=$(seq 1 60)
-
-	reg_msg "Waiting for ${inst_init_pr}." || return 1
-	for index in ${indexes}
-	do
-		eval \
-			"inst_name=\"\${DNSMASQ_INST_NAME_${index}}\"" \
-			"ns4=\"\${NS4_${index}}\"" \
-			"ns6=\"\${NS6_${index}}\""
-
-		ns="${ns4:="${ns6}"}"
-
-		: "${ns:="127.0.0.1"}"
-
-		debug_msg "Check cmd: ${NETSTAT_CMD} -plnt | ${SED_CMD} -E 's/^\s+//;s/[^ ]+\s+[^ ]+\s+[^ ]+\s+//' | grep -q \"^${ns}:.*/dnsmasq\s*$\""
-		for i in ${res_attempts:-1 2 3 4 5}
+		for instance in ${instances}
 		do
-			${NETSTAT_CMD:?} -plnt 2>/dev/null | ${SED_CMD:?} -E 's/^\s+//;s/[^ ]+\s+[^ ]+\s+[^ ]+\s+//' | grep -q "^${ns}:.*/dnsmasq\s*$" &&
-				continue 2
-			sleep 1
-		done
+			for i in ${res_attempts:-1 2 3 4 5}
+			do
+				export -n R_PROCESSED=
+				PDR_QUIET=1 parse_dmsq_runtime
+				case ${?} in
+					0) continue 2 ;;
+					1) break ;;
+				esac
+				[ -n "${wait_printed}" ] ||
+					reg_action "Waiting for initialization of dnsmasq instances: ${lblue}${instances// /"${n_c}, ${lblue}"}${n_c}." || return 1
+				wait_printed=1
+				sleep 1
+			done
 
-		rv=1
-		if [ "${index}" != all ]
-		then
+			rv=1
+
 			for set_id in ${set_ids}
 			do
-				get_params "${set_id}" dnsmasq_indexes
-				is_included "${index}" "${dnsmasq_indexes}" || continue
+				get_params "${set_id}" dmsq_instances
+				is_included "${instance}" "${dmsq_instances}" || continue
 				set_params "${set_id}" run_state=1
 				add2list restart_fail_ids "${set_id}"
 			done
-		else
-			[ -n "${SET_IDS}" ] && set_params "${SET_IDS}" run_state=1
-		fi
 
-		index_pr="${index}"
-		[ "${index}" = all ] && index_pr=
-		reg_failure "DNS self-test failed${index_pr:+" for dnsmasq instance ${index_pr}"}${inst_name:+" ('${inst_name}')"}."
-	done
+			reg_failure "DNS self-test failed for dnsmasq instance '${instance}'."
+		done
+	else
+		[ -n "${SET_IDS}" ] && set_params "${SET_IDS}" run_state=1
+	fi
+
+	[ -n "${restart_fail_ids}" ] &&
+		print_msg "netstat output for debug:" "$(${NETSTAT_CMD} -plnt)"
 
 	subtract_a_from_b "${restart_fail_ids}" "${set_ids}" restart_ok_ids
 	[ -n "${new_run_state}" ] && [ -n "${restart_ok_ids}" ] &&
 		set_params "${restart_ok_ids}" run_state="${new_run_state}"
+
 	export -n "${restart_ok_ids_out_var}=${restart_ok_ids}"
 	return "${rv:-0}"
 }
@@ -1234,7 +1342,7 @@ mk_lock()
 	case ${?} in
 		1) return 1 ;;
 		2)
-			report_curr_action -log
+			report_cur_action -log
 			log_msg -yellow "Refusing to open another instance."
 			return 254
 	esac
@@ -1256,7 +1364,7 @@ check_lock()
 	unset LOCK_PID
 	[ ! -f "${PID_FILE:?}" ] && return 0
 
-	read_str_from_file -v "LOCK_PID _" -f "${PID_FILE}" -a 3 -D PID || return 1
+	read_str_from_file -n 64 -v "LOCK_PID _" -f "${PID_FILE}" -a 3 -D PID || return 1
 
 	case "${LOCK_PID}" in
 		"${$}") return 3 ;;
@@ -1292,10 +1400,10 @@ update_action_file()
 }
 
 # 1 (optional): '-log' to log current action as well
-report_curr_action()
+report_cur_action()
 {
 	[ "${MSGS_DEST}" = "/dev/null" ] && [ -z "${ABL_LUCI_SOURCED}" ] && [ "${1}" != "-log" ] && return 0
-	local reported_pid report_cmd=print_msg curr_action
+	local reported_pid report_cmd=print_msg cur_action
 	[ -f "${ACTION_FILE:?}" ] || return 0
 	check_lock
 	case ${?} in
@@ -1305,24 +1413,34 @@ report_curr_action()
 	esac
 	reported_pid="${LOCK_PID:-unknown}"
 
-	read_str_from_file -v curr_action -f "${ACTION_FILE}" -a 2 -D action -V "unknown action"
+	read_str_from_file -F "" -n 256 -v cur_action -f "${ACTION_FILE}" -a 2 -D action -V "unknown action"
 
 	[ "${1}" = -log ] && report_cmd=log_msg
 
-	${report_cmd} "adblock-lean (PID: ${reported_pid}) is performing action '${curr_action}'."
-	luci_pid_action=${curr_action}
+	${report_cmd} "adblock-lean (PID: ${reported_pid}) is performing action '${cur_action}'."
+	luci_pid_action=${cur_action}
 	:
 }
 
-wait_on_pid() {
-	local i=1 \
-		pid="${1}" max_kill_wait_s="${2}"
+wait_on_pids() {
+	local i=1 pids_tmp \
+		pids="${1}" max_kill_wait_s="${2}"
 
-	while [ -d "/proc/${pid}" ] && [ "${i}" -le "${max_kill_wait_s}" ]
+	while :
 	do
-		sleep 1
+		[ "${i}" -le "${max_kill_wait_s}" ] || break
+		pids_tmp=
+		for pid in ${pids}
+		do
+			[ -d "/proc/${pid}" ] && abl_append pids_tmp "${pid}"
+		done
+		[ -n "${pids_tmp}" ] || return 0
+		pids=${pids_tmp}
+		sleep 1 &
+		wait ${!}
 		i=$((i+1))
 	done
+	return 1
 }
 
 # kills any running adblock-lean instances
@@ -1335,7 +1453,7 @@ kill_abl_pids()
 	then
 		reg_msg "Another adblock-lean instance is running. Stopping it..."
 		kill "${LOCK_PID}" 2>/dev/null
-		wait_on_pid "${LOCK_PID}" 5
+		wait_on_pids "${LOCK_PID}" 5
 
 		check_lock
 		lock_res=${?}
@@ -1353,98 +1471,103 @@ kill_abl_pids()
 		abl_pids="$(${PGREP_CMD:-pgrep} -fa "${pgrep_ptrn}" | ${SED_CMD} -E "/\sstop$/d;s/\s+.*//;/^${$}$/d" | tr '\n' ' ')"
 	fi
 
-	if [ -n "${abl_pids}" ]
-	then
-		kill_pids_recursive "${abl_pids}" || { reg_failure "Failed to stop running adblock-lean processes."; return 1; }
-	fi
+	[ -n "${abl_pids}" ] &&
+		term_ppid "${abl_pids}"
 
 	rm_lock
 
 	:
 }
 
-# kills specified pid's and their offspring
-# 1 - whitespace-separated starting list of pid's
-# 2 - pid's to exclude
-kill_pids_recursive()
-{
-	get_running_pids() {
-		unset_vars "${1}"
-		local _pid _pids
-		for _pid in ${2}
-		do
-			[ -d "/proc/${_pid}" ] && _pids="${_pids}${_pid} "
-		done
-		export -n "${1}=${_pids}"
-	}
+# 0 (optional): -[TERM|USR*]
+# Args: PIDs
+term_ppid() {
+	local \
+		sig="KILL" \
+		me=term_ppid \
+		had_f \
+		pid seed_pids all_pids prev_pids found_pids try
 
-	# recursively add child pid's of pid $2 to whitespace-separated list stored in var $1
-	# 1 - var name for output
-	# 2 - pid
-	add_child_pids()
+	case "${1}" in
+		-TERM|-USR*) sig="${1#-}"; shift
+	esac
+
+	has_f && had_f=1
+	set -f
+
+	for pid in ${*}; do
+		is_uint "${pid}" ||
+			{ reg_failure "${me}: ignoring invalid PID '${pid}'."; continue; }
+		abl_append seed_pids "${pid}"
+	done
+	[ -n "${seed_pids}" ] ||
 	{
-		local pid_scan_depth="${pid_scan_depth:=0}" pid prev_pids child_pids
-		pid_scan_depth=$((pid_scan_depth+1))
-		[ "${pid_scan_depth}" -lt "${max_pid_scan_depth}" ] || return 0
-
-		child_pids="$(
-			${PGREP_CMD:-pgrep} -faP "${2}" |
-			# exclude the dnsmasq processes and service calls from results
-			${SED_CMD} -E \
-				'/(^[0-9]+\s+((sh|\/bin\/sh)\s+){0,1}(\/sbin\/service\s+|\/etc\/rc.common\s+\/etc\/init.d\/){0,1}(\/usr\/sbin\/|\/sbin\/service\s){0,1}dnsmasq|\/sbin\/ujail)\s/d;
-				s/\s.*//'
-		)" && [ -n "${child_pids}" ] || return 0
-
-		eval "prev_pids=\"\${${1}}\""
-
-		local IFS="${_NL_}"
-		for pid in ${child_pids}
-		do
-			IFS="${DEFAULT_IFS}"
-			is_included "${pid}" "${prev_pids}" || eval "${1}=\"\${${1}}\${pid} \""
-			add_child_pids "${1}" "${pid}"
-		done
+		[ -n "${had_f}" ] || set +f
+		return 0
 	}
 
-	local IFS="${DEFAULT_IFS}" initial_pids running_pids exclude_pids="${2}" pid max_pid_scan_depth=10 max_k_attempts=10
+	[ "${sig}" = KILL ] ||
+	{
+		kill -"${sig}" ${seed_pids}
+		wait_on_pids "${seed_pids}" 3 && return 0
+	}
 
-	# compile a list of initial pids and recursively child pids
-	for pid in ${1}
-	do
-		is_uint "${pid}" || continue
-		is_included "${pid}" "${exclude_pids}" && continue
+	# Freeze, re-scan to fixpoint, kill
+	all_pids="${seed_pids}"
 
-		initial_pids="${initial_pids}${pid} "
+	for try in 1 2 3; do
+		kill -STOP ${all_pids} 2>/dev/null
+
+		# Get all live descendant PIDs (space-separated, seeds excluded).
+		found_pids="$(
+			set +f
+			${CAT_CMD:-cat} /proc/[0-9]*/stat 2>/dev/null | {
+				set -f
+				# shellcheck disable=SC2016
+				${AWK_CMD:-awk} -v seeds="${all_pids}" '
+				/^[0-9]+ \(/ {
+					pid = $1
+					s = $0
+					# Strip "pid (comm) X " (X = single state char).
+					# comm may contain spaces and parens - the greedy match handles those;
+					#   a line that does not match is a fragment of a newline-containing comm - skip
+					if (!sub(/^[0-9]+ \(.*\) . /, "", s)) next
+					split(s, f, " ")
+					if (f[1] !~ /^[0-9]+$/) next
+					ppid[pid] = f[1]
+					valid++
+				}
+				END {
+					if (!valid) exit 1
+					n = split(seeds, a, " ")
+					for (i = 1; i <= n; i++)
+						if (a[i] ~ /^[0-9]+$/) {
+							seed[a[i]] = 1
+							want[a[i]] = 1
+						}
+					do {
+						changed = 0
+						for (p in ppid)
+							if (!(p in want) && (ppid[p] in want)) { want[p] = 1; changed = 1 }
+					} while (changed)
+					for (p in want) if (!(p in seed)) printf "%s ", p
+				}'
+			}
+		)" || {
+			reg_failure "${me}: /proc scan failed."
+			break
+		}
+
+		abl_append all_pids "${found_pids}"
+		tr_trailing all_pids "${all_pids}" " "
+		[ "${all_pids}" = "${prev_pids}" ] && break
+		prev_pids="${all_pids}"
 	done
-	[ -n "${initial_pids}" ] || return 0
 
-	running_pids="${initial_pids}"
-	k_attempt=0
+	kill -KILL ${all_pids} 2>/dev/null
 
-	while :
-	do
-		for pid in ${running_pids}
-		do
-			add_child_pids running_pids "${pid}"
-		done
-
-		kill "${running_pids}" 2>/dev/null
-
-		get_running_pids running_pids "${running_pids}" || return 1
-
-		[ -n "${running_pids}" ] || return 0
-
-		k_attempt=$((k_attempt+1))
-		[ ${k_attempt} -le ${max_k_attempts} ] || break
-		sleep 1
-	done
-
-	kill -9 "${running_pids}" 2>/dev/null
-	sleep 1
-
-	get_running_pids running_pids "${running_pids}" || return 1
-	[ -z "${running_pids}" ] && return 0
-	return 1
+	[ -n "${had_f}" ] || set +f
+	:
 }
 
 # 1 - types: 'ALL' (doesn't print executable files) or any combination (space-separated) of 'GEN', 'LIB', 'EXTRA', 'EXEC'
@@ -1470,18 +1593,23 @@ print_file_list()
 
 ver_upd_fixup()
 {
-	local me=ver_upd_fixup fix_ver fix_upd_channel md5sums \
-		curr_ver="${1:?}" curr_upd_ch="${2:?}"
+	local \
+		me=ver_upd_fixup \
+		IFS="${DEFAULT_IFS}" \
+		fix_ver \
+		fix_upd_channel \
+		md5sums \
+		cur_ver="${1:?}" cur_upd_ch="${2:?}"
 
 	log_msg -purple "Completing adblock-lean version upgrade..."
 
 	# fix version and upd channel strings in installed files, then make md5sum registry
-	case "${curr_upd_ch}" in
+	case "${cur_upd_ch}" in
 		''|release|latest) fix_upd_channel=release ;;
-		*) fix_upd_channel="${curr_upd_ch}"
+		*) fix_upd_channel="${cur_upd_ch}"
 	esac
 
-	fix_ver="${curr_ver#v}"
+	fix_ver="${cur_ver#v}"
 	: "${fix_ver:=dev}"
 
 	# shellcheck disable=SC2046
@@ -1490,9 +1618,13 @@ ver_upd_fixup()
 		s/^\s*ABL_UPD_CHANNEL=.*/ABL_UPD_CHANNEL=\"${fix_upd_channel}\"/" \
 			"${ABL_SERVICE_PATH}" &&
 	mkdir -p "${ABL_FILES_REG_PATH%/*}" &&
-	set -- $(print_file_list ALL) &&
-	IFS="${DEFAULT_IFS}" &&
-	md5sums="$(${MD5_CMD} "$@")" && [ -n "${md5sums}" ] &&
+	{
+		IFS="${_NL_}"
+		set -- $(print_file_list ALL)
+		IFS="${DEFAULT_IFS}"
+	} &&
+	md5sums="$(${MD5_CMD} "$@")" &&
+	[ -n "${md5sums}" ] &&
 	printf '%s\n' "${md5sums}" > "${ABL_FILES_REG_PATH}" ||
 		reg_failure "${me}: Failed to register new files. Please re-install adblock-lean."
 	:
@@ -1564,14 +1696,14 @@ source_libs()
 # 1 - error
 # 2 - cron job with a different schedule exists
 # 3 - cron job doesn't exist
-get_curr_crontab()
+get_cur_crontab()
 {
-	local curr_cron
-	curr_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "get_curr_crontab: Failed to read crontab."; return 1; }
-	printf '%s\n' "${curr_cron}"
+	local cur_cron
+	cur_cron="$(crontab -u root -l 2>/dev/null)" || { reg_failure "get_cur_crontab: Failed to read crontab."; return 1; }
+	printf '%s\n' "${cur_cron}"
 
 	# check if adblock-lean cron job with same schedule exists
-	case "${curr_cron}" in
+	case "${cur_cron}" in
 		*"${upd_schedule}"*"${ABL_CRON_CMD}"*) return 0 ;;
 		*"${ABL_CRON_CMD}"*) return 2 ;;
 		*) return 3 ;;
@@ -1580,23 +1712,23 @@ get_curr_crontab()
 
 rm_cron_job()
 {
-	local curr_cron
+	local cur_cron
 	crontab -u root -l 1>/dev/null 2>/dev/null || return 0
-	curr_cron="$(get_curr_crontab)"
+	cur_cron="$(get_cur_crontab)"
 	case ${?} in
 		1) return 1 ;;
 		3) return 0
 	esac
 
 	log_msg "" "Removing cron job for adblock-lean."
-	printf '%s\n' "${curr_cron}" | ${SED_CMD} '/adblock-lean start/d;/^$/d' | crontab -u root - ||
+	printf '%s\n' "${cur_cron}" | ${SED_CMD} '/adblock-lean start/d;/^$/d' | crontab -u root - ||
 		{ reg_failure "Failed to update crontab."; return 1; }
 	:
 }
 
 # Delete adblock-lean addnmount entries for dnsmasq instance
 # NOTE: need to run 'uci commit dhcp' after calling this function
-# 1 - dnsmasq instance indexes
+# 1 - dnsmasq instance names
 # return codes:
 # 0 - OK
 # 1 - Error deleting all found entries
@@ -1604,7 +1736,7 @@ rm_cron_job()
 # 3 - No entries found for instance
 del_addnmounts()
 {
-	local set_id rv path paths entry_deleted=0 entry_failed=0 index persist_dir dir fname persist_dirs
+	local set_id rv path paths entry_deleted=0 entry_failed=0 instance persist_dir dir fname persist_dirs
 	[ -n "${SET_IDS}" ] ||
 		ASSERT_NOEXIT=1 load_config
 
@@ -1614,10 +1746,10 @@ del_addnmounts()
 		add2list persist_dirs "${persist_dir}" "${_NL_}"
 	done
 
-	for index in ${1}
+	for instance in ${1}
 	do
 		paths="$(
-			uci -q get "dhcp.@dnsmasq[${index}].addnmount" 2>/dev/null |
+			uci -q get "dhcp.${instance}.addnmount" 2>/dev/null |
 			# handle entries with whitespaces (enclosed in single-quotes) and print each addnmount entry on separate line
 			${AWK_CMD} -v quoted="'[^']*'" '
 				{
@@ -1641,8 +1773,8 @@ del_addnmounts()
 				is_included "${dir}" "${persist_dirs}" "${_NL_}"
 			} ||
 			continue
-			log_msg "Deleting addnmount entry for dnsmasq instance ${index}: ${blue}${path}${n_c}"
-			if uci -q del_list "dhcp.@dnsmasq[${index}].addnmount=${path}"
+			log_msg "Deleting addnmount entry for dnsmasq instance '${instance}': ${blue}${path}${n_c}"
+			if uci -q del_list "dhcp.${instance}.addnmount=${path}"
 			then
 				entry_deleted=1
 			else
@@ -1699,7 +1831,7 @@ init_act()
 		rm_blockset_config) libs_req=1 find_set_configs_req=1 set_ids_req=1 LOCK_REQ=1 ;;
 		boot|create_addnmounts) cfg_req=1 find_set_configs_req=1 set_ids_req=1 LOCK_REQ=1 ;;
 		pause) work_dir_req=1 cfg_req=1 find_set_configs_req=1 set_ids_req=1 LOCK_REQ=1 ;;
-		start|resume|gen_persist_blockset) work_dir_req=1 cfg_req=1 find_set_configs_req=1 set_ids_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
+		start|resume|gen_persist_blockset) work_dir_req=1 cfg_req=1 find_set_configs_req=1 set_ids_req=1 LOCK_REQ=1 ;;
 		stop)
 			check_lock
 			case ${?} in
@@ -1715,10 +1847,10 @@ init_act()
 					2) reg_failure "Failed to kill running adblock-lean processes."; exit 1
 				esac
 			}
-			libs_req=1 find_set_configs_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
+			libs_req=1 find_set_configs_req=1 LOCK_REQ=1 ;;
 		select_dnsmasq_instances) libs_req=1 cfg_req=1 find_set_configs_req=1 set_ids_req=1 LOCK_REQ=1 ;;
 		reload|restart) ;;
-		update) work_dir_req=1 CLEANUP_REQ=1 LOCK_REQ=1 ;;
+		update) work_dir_req=1 LOCK_REQ=1 ;;
 		*) reg_failure "Invalid command '${cur_act}'."; exit 1
 	esac
 
@@ -1750,7 +1882,7 @@ init_act()
 	# make lock if needed
 	if [ -n "${LOCK_REQ}" ]
 	then
-		mk_lock || { local rv=${?}; unset LOCK_REQ CLEANUP_REQ; exit ${rv}; }
+		mk_lock || { local rv=${?}; unset LOCK_REQ; exit ${rv}; }
 		act_pr_short="${cur_act}"
 	fi
 
@@ -2063,7 +2195,9 @@ fetch_abl_dist()
 	assert_set F_fetch_abl_dist tarball_url_fetch dist_dir_fetch || return 1
 
 	rm -f "${ucl_err_file}" "${tarball}"
+	set +f
 	rm -rf "${fetch_dir}/${ABL_REPO_AUTHOR}-adblock-lean-"*
+	set -f
 	try_mkdir -p "${fetch_dir}" || return 1
 
 	${UCL_CMD:?} "${tarball_url_fetch}" -O "${tarball}" 2> "${ucl_err_file}" &&
@@ -2079,8 +2213,10 @@ fetch_abl_dist()
 	rm -f "${ucl_err_file}"
 
 	[ "${fetch_rv}" = 0 ] && {
+		set +f
 		mv "${extract_dir:-?}"/* "${dist_dir_fetch:-?}/" ||
-			{ rm -rf "${extract_dir:-?}"; reg_failure "Failed to move files to dist dir."; return 1; }
+			{ rm -rf "${extract_dir:-?}"; set -f; reg_failure "Failed to move files to dist dir."; return 1; }
+		set -f
 	}
 	rm -rf "${extract_dir:-?}" "${fetch_dir:-?}"
 
@@ -2093,19 +2229,19 @@ get_blockset_timestamp()
 {
 	local me=get_blockset_timestamp \
 		ASSERT_NOEXIT=1 \
-		date_fmt_str curr_path
+		date_fmt_str cur_path
 	case "${1}" in
 		-s) date_fmt_str='+%s' ;;
 		-h) date_fmt_str='+%b %d %Y, %H:%M:%S' ;;
 		*) reg_failure "${me}: unexpected format '${1}'."; return 1
 	esac
 
-	get_params -f "${me}" "${2}" curr_path || return 1
+	get_params -f "${me}" "${2}" cur_path || return 1
 
-	if [ -n "${curr_path}" ]
+	if [ -n "${cur_path}" ]
 	then
-		date -r "${curr_path}" "${date_fmt_str}" && return 0
-		reg_failure "${me}: Failed to get the timestamp of file '${curr_path}'."
+		date -r "${cur_path}" "${date_fmt_str}" && return 0
+		reg_failure "${me}: Failed to get the timestamp of file '${cur_path}'."
 		return 1
 	else
 		reg_failure "${me}: no blockset file found."
@@ -2155,7 +2291,7 @@ do_rm_blockset_config()
 
 	reg_action -purple "Removing blockset ${lblue}${set_id}${n_c}."
 
-	KEEP_PERSIST=0 do_stop "${set_id}" &&
+	KEEP_PERSIST=0 do_stop "${set_id}" || { FAIL_STOP_REQ=1; exit 1; }
 	rm -f "${cfg_path}" ||
 		{ reg_failure "Failed to remove blockset config '${set_id}'."; return 1; }
 
@@ -2228,7 +2364,7 @@ upd_cron_job()
 	local CUR_CMD=${CUR_ACT}
 	init_act "${CUR_ACT}" || return 1
 
-	local me="upd_cron_job" curr_cron cron_line
+	local me="upd_cron_job" cur_cron cron_line
 
 	case "${upd_schedule}" in
 		'') reg_failure "${me}: the \$upd_schedule variable is unset."; return 1 ;;
@@ -2239,11 +2375,11 @@ upd_cron_job()
 	esac
 
 	enable_cron_service || return 1
-	curr_cron="$(get_curr_crontab)"
+	cur_cron="$(get_cur_crontab)"
 	case ${?} in
 		0) print_msg -green "Cron job for adblock-lean with schedule '${upd_schedule}' aldready exists."; return 0 ;;
 		1) return 1 ;;
-		2) curr_cron="$(printf %s "${curr_cron}" | $SED_CMD "s~^.*${ABL_CRON_CMD}.*\$~~")" ;; # remove cron job with a different schedule
+		2) cur_cron="$(printf %s "${cur_cron}" | $SED_CMD "s~^.*${ABL_CRON_CMD}.*\$~~")" ;; # remove cron job with a different schedule
 		3) ;; # no adblock-lean cron job exists
 	esac
 
@@ -2251,7 +2387,7 @@ upd_cron_job()
 
 	#### Create new cron job
 	print_msg "Creating cron job with schedule '${lblue}${upd_schedule}${n_c}'."
-	printf '%s\n' "${curr_cron}${_NL_}${cron_line}" | $SED_CMD '/^$/d' | crontab -u root - ||
+	printf '%s\n' "${cur_cron}${_NL_}${cron_line}" | $SED_CMD '/^$/d' | crontab -u root - ||
 		{ reg_failure "Failed to update crontab."; return 1; }
 	:
 }
@@ -2273,7 +2409,7 @@ select_dnsmasq_instances()
 		set_id \
 		cfg_path \
 		upd_cfg \
-		dnsmasq_indexes conf_dirs \
+		dmsq_instances conf_dirs \
 		set_ids="${*:-"${SET_IDS}"}"
 
 	init_act "${CUR_ACT}" &&
@@ -2282,10 +2418,10 @@ select_dnsmasq_instances()
 	for set_id in ${set_ids}
 	do
 		get_cfg_path cfg_path "${set_id}" &&
-		get_params -f "${me}" "${set_id}" dnsmasq_indexes conf_dirs &&
+		get_params -f "${me}" "${set_id}" dmsq_instances conf_dirs &&
 		upd_cfg="$(
 			${SED_CMD} "
-				s~^\s*dnsmasq_indexes=.*~dnsmasq_indexes=\"${dnsmasq_indexes}\"~
+				s~^\s*dnsmasq_instances=.*~dnsmasq_instances=\"${dmsq_instances}\"~
 				s~^\s*dnsmasq_conf_dirs=.*~dnsmasq_conf_dirs=\"${conf_dirs}\"~
 			" "${cfg_path}"
 		)" &&
@@ -2300,9 +2436,9 @@ gen_stats()
 	local CUR_ACT=gen_stats
 	local CUR_CMD=${CUR_ACT}
 	init_act "${CUR_ACT}" || exit 1
-	local dnsmasq_pid IFS="${DEFAULT_IFS}"
-	dnsmasq_pid="$(${PIDOF_CMD} /usr/sbin/dnsmasq)" || { reg_failure "Failed to detect dnsmasq PID or dnsmasq is not running."; exit 1; }
-	kill -USR1 "${dnsmasq_pid}"
+	local dmsq_pid IFS="${DEFAULT_IFS}"
+	dmsq_pid="$(${PIDOF_CMD} /usr/sbin/dnsmasq)" || { reg_failure "Failed to detect dnsmasq PID or dnsmasq is not running."; exit 1; }
+	kill -USR1 "${dmsq_pid}"
 	print_msg "dnsmasq stats available for reading using 'logread'."
 	[ "${1}" != '-noexit' ] && exit 0
 	:
@@ -2336,7 +2472,7 @@ start()
 # 1 (optional): blockset IDs (defaults to all)
 do_start()
 {
-	# global vars which may be set in set_bl_env()
+	# global vars which may be set in set_blockset_env()
 	BLOCKSETS_TO_INSTALL=
 	BLOCKSETS_TO_GEN=
 
@@ -2344,7 +2480,7 @@ do_start()
 
 	if [ "${RANDOM_DELAY}" = "1" ]
 	then
-		random_delay_mins=$(($(hexdump -n 1 -e '"%u"' </dev/urandom)%60))
+		random_delay_mins=$(( ${RANDOM:-0} % 61))
 		reg_action -1 -purple "Delaying automatic lists update by ${random_delay_mins} minutes (thundering herd prevention)." || exit 1
 		sleep "${random_delay_mins}m" &
 		wait ${!}
@@ -2360,7 +2496,7 @@ do_start()
 		do_start_rv=1 \
 		initial_uptime_cs \
 		elapsed_time \
-		curr_cnt \
+		cur_cnt \
 		install_path \
 		final_compr_to_file \
 		bk_file \
@@ -2386,7 +2522,7 @@ do_start()
 	# gen_blocksets() and install_blocksets() append values to output vars
 
 	[ -n "${BLOCKSETS_TO_GEN}" ] &&
-		gen_blocksets BLOCKSETS_TO_INSTALL "${BLOCKSETS_TO_GEN}" "${initial_uptime_cs}"
+		gen_blocksets BLOCKSETS_TO_INSTALL "${BLOCKSETS_TO_GEN}"
 
 	[ -n "${BLOCKSETS_TO_INSTALL}" ] &&
 		install_blocksets ok_ids perm_fail_ids "${BLOCKSETS_TO_INSTALL}"
@@ -2398,7 +2534,7 @@ do_start()
 	{
 		BLOCKSETS_TO_INSTALL=
 		log_msg -fb "${retry_ids}" "" "Trying again to generate and install blockset files{}."
-		gen_blocksets BLOCKSETS_TO_INSTALL "${retry_ids}" "${initial_uptime_cs}"
+		gen_blocksets BLOCKSETS_TO_INSTALL "${retry_ids}"
 
 		[ -n "${BLOCKSETS_TO_INSTALL}" ] &&
 			install_blocksets ok_ids _ "${BLOCKSETS_TO_INSTALL}"
@@ -2441,7 +2577,7 @@ do_start()
 		[ -n "${fail_ids}" ] &&
 		{
 			rm_bk "${fail_ids}"
-			do_stop "${fail_ids}"
+			do_stop "${fail_ids}" || exit 1
 			reg_failure -fb "${fail_ids}" "Failed to install new blockset files and can not be restore previous files from backup{}."
 		}
 	}
@@ -2455,7 +2591,7 @@ do_start()
 		reg_success -fb "${installed_ids}" "" "${green}Successfully installed blockset files${n_c}{}."
 	}
 
-	commit_metadata || { do_stop; do_start_rv=1; }
+	commit_metadata || exit 1
 
 	# if [ "${installed_path%/*}" = "${persist_blockset_dir}" ]
 	# then
@@ -2564,17 +2700,11 @@ do_stop()
 			return 0
 	}
 
-	[ -n "${force_stop_all}" ] ||
-	{ [ "${CUR_CMD}" = stop ] && subtract_a_from_b "${set_ids}" "${SET_IDS}"; } ||
-	{
-		[ -n "${set_ids}" ] && rm_conf_scripts "${set_ids}"
-		commit_metadata
-		return 1
-	}
-
 	reg_action -1 -purple "" "Stopping adblocking for any adblock-lean blocksets."
 
+	set +f
 	rm -f "${META_FILE}" "${ABL_RUN_DIR:?}/${BLOCKSET_BASE_FNAME:-???}"*
+	set -f
 
 	[ -n "${SET_IDS}" ] && [ -n "${CONFIG_LOADED}" ] &&
 	{
@@ -2582,18 +2712,28 @@ do_stop()
 		rm_bk
 	}
 
+	parse_dmsq_cfg
+
+	set +f
 	IFS="${_NL_}"
-	for dir in ${ALL_CONF_DIRS}${_NL_}/tmp/dnsmasq.d${_NL_}/tmp/dnsmasq.cfg*.d
+	for dir in ${C_CONF_DIRS}${_NL_}${R_CONF_DIRS}${_NL_}/tmp/dnsmasq.d${_NL_}/tmp/dnsmasq.cfg*.d
 	do
 		[ -n "${dir}" ] || continue
 		IFS="${DEFAULT_IFS}"
-		rm -f "${dir}/${CS_BASE_FNAME:-???}"* "${dir}/${BLOCKSET_BASE_FNAME:-???}"*
+		rm -f "${dir}/${CS_BASE_FNAME:-???}"* "${dir}/${BLOCKSET_BASE_FNAME:-???}"* "${dir}/.abl-extract_blocklist"
 	done
 	IFS="${DEFAULT_IFS}"
+	set -f
 
 	restart_dnsmasq 4 # all dnsmasq instances
 
-	:
+	[ -n "${SET_IDS}" ] &&
+	{
+		unset_metadata "${set_ids}"
+		commit_metadata
+	}
+
+	return 1
 }
 
 # Env vars: FORCE_STOP
@@ -2604,7 +2744,7 @@ stop_blocksets()
 		stop_fail_ids \
 		stop_ids \
 		stop_rv \
-		curr_path \
+		cur_path \
 		run_state \
 		set_ids="${1}"
 
@@ -2640,7 +2780,7 @@ stop_blocksets()
 	[ -n "${stop_ok_ids}" ] &&
 		log_msg -fb "${stop_ok_ids}" "Successfully stopped adblocking{}."
 
-	[ -n "${stop_fail_ids}" ] && reg_failure -fb "${stop_fail_ids}" "Failed to stop adblocking{}."
+	[ -n "${stop_fail_ids}" ] && { reg_failure -fb "${stop_fail_ids}" "Failed to stop adblocking{}."; exit 1; }
 	return ${stop_rv}
 }
 
@@ -2668,7 +2808,7 @@ status()
 	case ${?} in
 		1) exit 1 ;;
 		2)
-			report_curr_action
+			report_cur_action
 			exit 2
 	esac
 
@@ -2682,9 +2822,9 @@ status()
 		1) print_msg -yellow "" "adblock-lean service is disabled."
 	esac
 
-	local timestamp curr_cnt_human \
+	local timestamp cur_cnt_human \
 		status_rv=0 \
-		run_state curr_path curr_cnt persist_dir persist_mode \
+		run_state cur_path cur_cnt persist_dir persist_mode \
 		set_id set_id_pr \
 		ASSERT_NOEXIT=1 \
 		set_ids \
@@ -2711,12 +2851,12 @@ status()
 		do
 			set_id_pr="blockset ${lblue}${set_id}${n_c}"
 			print_msg "" "Status of ${set_id_pr}:"
-			get_params "${set_id}" run_state curr_path curr_cnt persist_dir persist_mode
+			get_params "${set_id}" run_state cur_path cur_cnt persist_dir persist_mode
 
-			: "${curr_cnt:=0}"
+			: "${cur_cnt:=0}"
 			case "${run_state}" in 0|3)
-				[ -n "${curr_path}" ] || run_state=1
-				[ "${curr_cnt}" -gt 0 ] ||
+				[ -n "${cur_path}" ] || run_state=1
+				[ "${cur_cnt}" -gt 0 ] ||
 				{
 					log_msg -warn "  Blockset file for ${set_id_pr} not found or no entries found in the blockset file."
 					run_state=1
@@ -2724,14 +2864,14 @@ status()
 			esac
 
 			case "${run_state}" in 0|3)
-				int2human curr_cnt_human "${curr_cnt}" || return 1
+				int2human cur_cnt_human "${cur_cnt}" || return 1
 				timestamp="$(get_blockset_timestamp -h "${set_id}")"
 				print_msg \
-					"  Blockset file: ${blue}${curr_path}${n_c}" \
-					"  Entries count: ${blue}${curr_cnt_human}${n_c}" \
-					"  Timestamp: ${blue}${timestamp:-"${red}Unknown"}${n_c}"
+					"  Blockset file: ${blue}${cur_path}${n_c}" \
+					"  Timestamp: ${blue}${timestamp:-"${red}Unknown"}${n_c}" \
+					"  Entries count: ${orange}${cur_cnt_human}${n_c}"
 
-				[ -n "${persist_dir}" ] && [ "${persist_mode}" = managed ] && [ "${curr_path%/*}" != "${persist_dir}" ] &&
+				[ -n "${persist_dir}" ] && [ "${persist_mode}" = managed ] && [ "${cur_path%/*}" != "${persist_dir}" ] &&
 					print_msg -warn "Persistent blockset directory '${persist_dir}' for ${set_id_pr} is configured but not currently used."
 			esac
 
@@ -2744,8 +2884,8 @@ status()
 					reg_failure "Blockset '${set_id}' is not working correctly. Consider running 'service adblock-lean restart ${set_id}' in order to restore adblocking." ;;
 			esac
 
-			luci_good_entries=${curr_cnt:-0}
-			luci_dnsmasq_status=${run_state}
+			luci_good_entries=${cur_cnt:-0}
+			luci_dmsq_status=${run_state}
 			[ "${run_state}" = 1 ] && status_rv=1
 		done
 	fi
@@ -2784,11 +2924,12 @@ pause_resume()
 		prep_fail_ids \
 		act_ok_ids \
 		act_fail_ids \
+		extra_ids \
 		\
 		set_id set_id_pr \
 		run_state \
-		curr_path \
-		curr_cnt \
+		cur_path \
+		cur_cnt \
 		install_path \
 		install_1_instance \
 		pause_path \
@@ -2796,7 +2937,6 @@ pause_resume()
 		state_ok_msg \
 		state_changed_pr \
 		state_progr_pr \
-		dnsmasq_indexes \
 		FAIL_STOP_REQ=1 \
 		final_compr_to_file \
 		set_ids_arg="${*:-"${SET_IDS?}"}"
@@ -2847,8 +2987,8 @@ pause_resume()
 		log_msg -fb "${set_id}" "Preparing to ${cmd} adblocking{}."
 
 		get_params -f "${cmd}" "${set_id}" \
-			curr_path \
-			curr_cnt \
+			cur_path \
+			cur_cnt \
 			pause_path \
 			install_path || return 1
 		get_params "${set_id}" final_compr_to_file install_1_instance
@@ -2856,12 +2996,12 @@ pause_resume()
 		case "${cmd}" in
 			pause)
 				rm_conf_scripts "${set_id}"
-				mv_blockset "${curr_path}" "${pause_path}" "${final_compr_to_file}" "${set_id}" ;;
+				mv_blockset "${cur_path}" "${pause_path}" "${final_compr_to_file}" "${set_id}" ;;
 			resume)
-				mv_blockset "${curr_path}" "${install_path}" "${final_compr_to_file}" "${set_id}" &&
-				set_params "${set_id}" "install_cnt=${curr_cnt}" ;;
+				mv_blockset "${cur_path}" "${install_path}" "${final_compr_to_file}" "${set_id}" &&
+				set_params "${set_id}" "install_cnt=${cur_cnt}" ;;
 		esac &&
-		set_params "${set_id}" curr_single_instance="${install_1_instance}" ||
+		set_params "${set_id}" cur_1_instance="${install_1_instance}" ||
 		{
 			add2list prep_fail_ids
 			continue
@@ -2881,8 +3021,12 @@ pause_resume()
 		reg_action -1 -purple -fb "${prep_ok_ids}" "" "${state_progr_pr} adblocking{}."
 
 		case "${cmd}" in
-			pause) restart_dnsmasq 3 act_ok_ids "${prep_ok_ids}" ;;
 			resume) install_blocksets act_ok_ids _ "${prep_ok_ids}" ;;
+			pause)
+				restart_dnsmasq 3 act_ok_ids "${prep_ok_ids}"
+				get_affected_set_ids extra_ids "${act_ok_ids}"
+				[ -z "${extra_ids}" ] || check_active_blocksets _ "${extra_ids}" 25 || return 1
+				;;
 		esac
 
 		[ -n "${act_ok_ids}" ] &&
@@ -2938,7 +3082,7 @@ update()
 
 	unexp_arg() { upd_failed "update: unexpected argument '${1}'."; }
 
-	local file req_ver ver_str_arg ver_type dist_dir upd_ver tarball_url \
+	local OPTIND file req_ver ver_str_arg ver_type dist_dir upd_ver tarball_url \
 		upd_channel req_upd_channel force_upd_channel upd_nostop \
 		cur_main_cfg_path cur_blockset_cfg_files cfg_found
 
@@ -3062,6 +3206,9 @@ update()
 		[ "${REPLY}" = y ] || exit 0
 
 		clean_abl_env
+		# for compatibility with older versions
+		set +o pipefail
+		set +f
 		. "${ABL_SERVICE_PATH}" || return 1
 		start
 		exit ${?}
@@ -3072,7 +3219,9 @@ update()
 		[ "$REPLY" = y ]
 	then
 		clean_abl_env
-		set +o pipefail # for compatibility with older versions
+		# for compatibility with older versions
+		set +o pipefail
+		set +f
 		# shellcheck source=/dev/null
 		. "${ABL_SERVICE_PATH}"
 		setup
@@ -3085,6 +3234,18 @@ update()
 
 uninstall()
 {
+	# shellcheck disable=SC2329
+	addnm_del_cb()
+	{
+		del_addnmounts "${1}"
+		case ${?} in
+			0) addnm_deleted=1 ;;
+			3) ;;
+			1) addnm_del_fail=1 ;;
+			2) addnm_deleted=1 addnm_del_fail=1
+		esac
+	}
+
 	local ASSERT_NOEXIT=1
 	local CUR_ACT=uninstall
 	local CUR_CMD=${CUR_ACT}
@@ -3092,7 +3253,7 @@ uninstall()
 	find_set_configs
 	source_libs
 	load_config
-	KEEP_PERSIST=0 do_stop
+	KEEP_PERSIST=0 FORCE_STOP_ALL=1 do_stop
 	if rc_enabled
 		then
 		log_msg "Disabling adblock-lean."
@@ -3116,19 +3277,9 @@ uninstall()
 		rm -rf "${ABL_CFG_DIR:-???}"
 	fi
 
-	local i="-1" addnm_deleted addnm_del_fail
-	while [ ${i} -lt 128 ]
-	do
-		i=$((i+1))
-		uci -q get dhcp.@dnsmasq[${i}] >/dev/null || break
-		del_addnmounts "${i}"
-		case ${?} in
-			0) addnm_deleted=1 ;;
-			3) ;;
-			1) addnm_del_fail=1 ;;
-			2) addnm_deleted=1 addnm_del_fail=1
-		esac
-	done
+	local addnm_deleted addnm_del_fail
+	config_load_a dhcp &&
+	config_foreach addnm_del_cb dnsmasq
 
 	if [ -n "${addnm_deleted}" ]
 	then
@@ -3208,6 +3359,8 @@ export -n \
 	MAIN_UTILS_DETECTED='' \
 	CDI_FATAL=''
 
+set -f
+set -o pipefail
 set_ansi
 
 # $luci_skip_dialogs is set if sourced from external RPC script for luci

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -33,15 +33,6 @@ tolower()
 	export -n "${1}=${tl_str}"
 }
 
-trim_spaces()
-{
-	local tr_in tr_out
-	eval "tr_in=\"\${$1}\""
-	tr_out="${tr_in%"${tr_in##*[! 	]}"}"
-	tr_out="${tr_out#"${tr_out%%[! 	]*}"}"
-	export -n "${1}=${tr_out}"
-}
-
 try_mv()
 {
 	local mv_q=
@@ -263,26 +254,26 @@ disable_hotplug_script()
 
 do_create_addnmounts()
 {
-	create_addnmount() { uci add_list "dhcp.@dnsmasq[${1}].addnmount=${2}"; }
 	process_addnm()
 	{
-		local missing_addnm index indexes="${1}" req_addnm="${2}"
-		check_addnmounts missing_addnm "${indexes}" "${req_addnm}" || return 1
-		for index in ${indexes}
+		local missing_addnm instance \
+			instances="${1}" req_addnm="${2}"
+		check_addnmounts missing_addnm "${instances}" "${req_addnm}" || return 1
+		for instance in ${instances}
 		do
-			add2list "req_addnm_${index}" "${req_addnm}" "${_NL_}"
+			add2list "req_addnm_${instance}" "${req_addnm}" "${_NL_}"
 		done
 		[ -z "${missing_addnm}" ] || is_included "${missing_addnm}" "${all_missing_addnm}" "${_NL_}" && return 0
 		add2list all_missing_addnm "${missing_addnm}" "${_NL_}"
-		all_missing_addnm_pr="${all_missing_addnm_pr}${all_missing_addnm_pr:+"${_NL_}"}${lblue}${missing_addnm}${n_c} (required for ${3})"
+		abl_append all_missing_addnm_pr "${lblue}${missing_addnm}${n_c} (required for ${3})" "${_NL_}"
 	}
 
 	local me=create_addnmounts \
 		IFS="${DEFAULT_IFS}" \
 		REPLY \
 		conf_dirs \
-		index dnsmasq_indexes all_dnsmasq_indexes \
-		req_addnm_index \
+		instance dmsq_instances all_dmsq_instances \
+		req_addnm_instance \
 		\
 		set_id \
 		bl_full_fname \
@@ -298,14 +289,14 @@ do_create_addnmounts()
 		add_list_failed \
 		path
 
-	# reset req_addnm_${index} vars, compile list of indexes
+	# reset req_addnm_${instance} vars, compile list of instances
 	for set_id in ${SET_IDS:?}
 	do
-		get_params -f "${me}" "${set_id}" dnsmasq_indexes || return 1
-		for index in ${dnsmasq_indexes}
+		get_params -f "${me}" "${set_id}" dmsq_instances || return 1
+		for instance in ${dmsq_instances}
 		do
-			local "req_addnm_${index}=" &&
-			add2list all_dnsmasq_indexes "${index}"
+			local "req_addnm_${instance}=" &&
+			add2list all_dmsq_instances "${instance}"
 		done
 	done
 
@@ -313,12 +304,12 @@ do_create_addnmounts()
 	for set_id in ${SET_IDS:?}
 	do
 		path_ram='' ignore_paths=''
-		get_params -f "${me}" "${set_id}" dnsmasq_indexes conf_dirs &&
+		get_params -f "${me}" "${set_id}" dmsq_instances conf_dirs &&
 		get_params "${set_id}" persist_mode persist_dir &&
 		get_compr_util_spec cra_compr_util_path cra_compr_ext "${compression_util:?}" || return 1
 
 		# Logger
-		process_addnm "${dnsmasq_indexes}" "${LOG_CMD}" "logging failed attempts by dnsmasq to load the blockset" || return 1
+		process_addnm "${dmsq_instances}" "${LOG_CMD}" "logging failed attempts by dnsmasq to load the blockset" || return 1
 
 		bl_full_fname=${BLOCKSET_BASE_FNAME:?}-${set_id}${cra_compr_ext}
 
@@ -326,14 +317,14 @@ do_create_addnmounts()
 		if [ -n "${cra_compr_ext}" ]
 		then
 			path_ram=${ABL_RUN_DIR:?}/${bl_full_fname}
-			process_addnm "${dnsmasq_indexes}" "${cra_compr_util_path%% *}${_NL_}${path_ram}" "final blockset compression" || return 1
+			process_addnm "${dmsq_instances}" "${cra_compr_util_path%% *}${_NL_}${path_ram}" "final blockset compression" || return 1
 		fi
 
 		# Multiple dnsmasq instances
-		case "${dnsmasq_indexes}" in
-			*[0-9]*" "*[0-9]*)
+		case "${dmsq_instances}" in
+			*[0-9a-zA-Z_]*[" 	"]*[0-9a-zA-Z_]*)
 				path_ram=${ABL_RUN_DIR:?}/${bl_full_fname}
-				process_addnm "${dnsmasq_indexes}" "${path_ram}" "final blockset compression or blockset loading by multiple dnsmasq instances" || return 1 ;;
+				process_addnm "${dmsq_instances}" "${path_ram}" "final blockset compression or blockset loading by multiple dnsmasq instances" || return 1 ;;
 			*)
 				first_conf_dir="${conf_dirs%% *}"
 				is_valid_dir "${first_conf_dir}" || return 1
@@ -355,7 +346,7 @@ do_create_addnmounts()
 			is_included "${path_ram}" "${ignore_paths}" "${_NL_}" ||
 				ram_addnm="${_NL_}${path_ram}"
 			[ -n "${cra_compr_ext}" ] || cat_addnm="${_NL_}${CAT_CMD}"
-			process_addnm "${dnsmasq_indexes}" "${persist_dir}${ram_addnm}${cat_addnm}" "persistent blockset functionality" || return 1
+			process_addnm "${dmsq_instances}" "${persist_dir}${ram_addnm}${cat_addnm}" "persistent blockset functionality" || return 1
 		}
 	done
 
@@ -377,21 +368,22 @@ do_create_addnmounts()
 	fi
 	[ "${REPLY}" = y ] || return 0
 
-	del_addnmounts "${all_dnsmasq_indexes}"
+	del_addnmounts "${all_dmsq_instances}"
 	case ${?} in 0|3) : ;; *) false; esac &&
 
 	## Create addnmounts
-	for index in ${all_dnsmasq_indexes}
+	for instance in ${all_dmsq_instances}
 	do
-		eval "req_addnm_index=\"\${req_addnm_${index}}\""
-		[ -n "${req_addnm_index}" ] || continue
+		eval "req_addnm_instance=\"\${req_addnm_${instance}}\""
+		[ -n "${req_addnm_instance}" ] || continue
 
-		log_msg "" "Creating addnmount entries for dnsmasq instance ${index}:${_NL_}${blue}${req_addnm_index}${n_c}"
+		log_msg "" "Creating addnmount entries for dnsmasq instance '${instance}':${_NL_}${blue}${req_addnm_instance}${n_c}"
 		IFS="${_NL_}"
-		for path in ${req_addnm_index}
+		for path in ${req_addnm_instance}
 		do
 			IFS="${DEFAULT_IFS}"
-			create_addnmount "${index}" "${path}" || { add_list_failed=1; break 2; }
+			uci add_list "dhcp.${instance}.addnmount=${path}" ||
+				{ add_list_failed=1; break 2; }
 		done
 		IFS="${DEFAULT_IFS}"
 	done &&
@@ -404,9 +396,9 @@ do_create_addnmounts()
 		return 1
 	}
 
-	unset ADDNMOUNTS_SET DHCP_LOADED
-	DDI_FORCE=1 detect_dnsmasq_instances &&
-	check_dnsmasq_instances || return 1
+	unset C_PROCESSED
+	parse_dmsq_cfg &&
+	check_dmsq_instances || return 1
 
 	:
 }
@@ -479,7 +471,7 @@ do_setup()
 					get_pkg_name pkg_name "${util}" || return 1
 					add2list missing_utils "${util}"
 					add2list missing_packages "${orange}${pkg_name}${n_c}" ", "
-					missing_utils_print="${missing_utils_print}${missing_utils_print:+, }${lblue}GNU ${util}${n_c}"
+					abl_append missing_utils_print "${lblue}GNU ${util}${n_c}" ", "
 			esac
 		done
 
@@ -509,7 +501,7 @@ do_setup()
 				REPLY=n
 				if [ "${DO_DIALOGS}" = 1 ]
 				then
-					eval "util_size_B=\"\${${util}_size_B}\""
+					set_int "util_size_B = ${util}_size_B"
 					bytes2human util_size_human "${util_size_B}" || return 1
 					print_msg "Would you like to install ${lblue}GNU ${util}${n_c} automatically? Installed size: ${yellow}${util_size_human}${n_c}. (y|n)"
 					pick_opt "y|n"
@@ -564,6 +556,22 @@ do_setup()
 		:
 	}
 
+	# shellcheck disable=SC2329
+	add_found_cfg()
+	{
+		local cfg_id
+		split_path _ cfg_id _  "${1}"
+		cfg_id="${cfg_id#"blockset-"}"
+		is_alphanum "${cfg_id}" ||
+		{
+			reg_failure "Invalid blockset name '${cfg_id}' in file '${1}'. Only English letters, numbers and underlines are allowed. Deleting the file."
+			rm -f "${1}"
+			return 0
+		}
+		abl_append bl_cfgs_found "${1}" "${_NL_}"
+	}
+
+
 	local CUR_CMD=setup
 
 	[ -f "${ABL_SERVICE_PATH}" ] || { reg_failure "adblock-lean service file doesn't exist at ${ABL_SERVICE_PATH}."; return 1; }
@@ -597,24 +605,8 @@ do_setup()
 		gen_global_config || return 2
 	fi
 
-	local bl_cfgs_found='' cfg_id cfg_path
-	for cfg_path in "${ABL_CFG_DIR:?}"/blockset-*.conf
-	do
-		case "${cfg_path}" in
-			*"*"*)
-				continue ;;
-			"${ABL_CFG_DIR}"/*)
-				split_path _ cfg_id _  "${cfg_path}"
-				cfg_id="${cfg_id#"blockset-"}"
-				is_alphanum "${cfg_id}" ||
-				{
-					reg_failure "Invalid blockset name '${cfg_id}' in file '${cfg_path}'. Only English letters, numbers and underlines are allowed. Deleting the file."
-					rm -f "${cfg_path}"
-					continue
-				}
-				bl_cfgs_found="${bl_cfgs_found}${bl_cfgs_found:+"${_NL_}"}${cfg_path}"
-		esac
-	done
+	FF_EXEC=add_found_cfg find_files _ "${ABL_CFG_DIR:?}/blockset-" "*" ".conf"
+	[ ${?} = 1 ] && return 1
 
 	REPLY=
 	if [ -n "${bl_cfgs_found}" ]
@@ -634,7 +626,7 @@ do_setup()
 
 	if [ "${REPLY}" = n ]
 	then
-		do_stop
+		FORCE_STOP_ALL=1 do_stop
 		# Remove and forget old configs
 		rm -f "${META_FILE}"
 		local set_id
@@ -708,7 +700,7 @@ do_setup()
 #  9: min line count
 get_preset()
 {
-	local gp_mem gp_lists_cnt gp_entr_cnt gp_lim_coeff gp_lists gp_entr_cnt_human gp_max_part_size gp_max_bl_size gp_min_lines
+	local gp_mem gp_lists_cnt gp_entr_cnt gp_lim_coeff gp_lists gp_entr_cnt_human gp_max_part_size gp_max_set_size gp_min_entries
 
 	eval "gp_mem=\"\${${1}_mem}\"
 		gp_lists_cnt=\"\${${1}_lists_cnt}\"
@@ -722,7 +714,7 @@ get_preset()
 
 	unset_vars "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}"
 
-	do_calculate_limits "${gp_entr_cnt}" "${gp_lists_cnt}" "${gp_lim_coeff}" gp_min_lines gp_max_bl_size gp_max_part_size || return 1
+	do_calculate_limits "${gp_entr_cnt}" "${gp_lists_cnt}" "${gp_lim_coeff}" gp_min_entries gp_max_set_size gp_max_part_size || return 1
 
 	[ -n "${GP_PRINT_DESC}" ] && print_msg "" "${purple}${1}${n_c}: recommended for devices with ${gp_mem} MB of memory."
 
@@ -732,8 +724,8 @@ get_preset()
 		print_msg "${blue}Elements count:${n_c} ~${gp_entr_cnt_human}" \
 			"${blue}raw_block_lists${n_c}=\"${gp_lists}\"" \
 			"${blue}max_part_size_KB${n_c}=\"${gp_max_part_size}\"" \
-			"${blue}max_blockset_file_size_KB${n_c}=\"${gp_max_bl_size}\"" \
-			"${blue}min_good_entries${n_c}=\"${gp_min_lines}\""
+			"${blue}max_blockset_size_KB${n_c}=\"${gp_max_set_size}\"" \
+			"${blue}min_entries${n_c}=\"${gp_min_entries}\""
 	}
 
 	export -n \
@@ -743,8 +735,8 @@ get_preset()
 		"${5:-_}=${gp_mem}" \
 		"${6:-_}=${gp_lists}" \
 		"${7:-_}=${gp_max_part_size}" \
-		"${8:-_}=${gp_max_bl_size}" \
-		"${9:-_}=${gp_min_lines}" || return 1
+		"${8:-_}=${gp_max_set_size}" \
+		"${9:-_}=${gp_min_entries}" || return 1
 	:
 }
 
@@ -766,7 +758,7 @@ do_calculate_limits()
 	reasonable_round()
 	{
 		local input factor neg me=reasonable_round
-		eval "input=\"\${${1}}\""
+		set_int "input = ${1}"
 		case "${input}" in -*) neg='-' input="${input#-}"; esac
 		input="${input#"${input%%[!0]*}"}"
 		: "${input:=0}"
@@ -782,7 +774,7 @@ do_calculate_limits()
 	}
 
 	local me=calculate_limits lists_cnt tgt_entries_cnt tgt_entries_cnt_human lim_coeff final_entry_size_B source_entry_size_B \
-		cl_min_lines cl_max_bl_size_kb cl_max_part_size_kb \
+		cl_min_entries cl_max_set_size_kb cl_max_part_size_kb \
 		tgt_entries_cnt="${1}" lists_cnt="${2}" lim_coeff="${3:-1}"
 
 	unset_vars "${4}" "${5}" "${6}"
@@ -812,19 +804,19 @@ do_calculate_limits()
 	# Values are rounded down to reasonable degree
 
 	final_entry_size_B=20 # assumption
-	source_entry_size_B=20 # assumption for raw domains format. dnsmasq source format not used by default
+	source_entry_size_B=20 # assumption for raw domains format - TODO: distinguish from hosts format
 
 	# tgt_entries_cnt / 3.5
-	cl_min_lines=$((tgt_entries_cnt*10/35))
-	reasonable_round cl_min_lines || return 1
+	cl_min_entries=$((tgt_entries_cnt*10/35))
+	reasonable_round cl_min_entries || return 1
 
 	# (tgt_entries_cnt * final_entry_size_B * lim_coeff * 1.25)/1024
-	cl_max_bl_size_kb=$(( (tgt_entries_cnt*final_entry_size_B*lim_coeff*125)/(1024*100) + 1 ))
-	reasonable_round cl_max_bl_size_kb || return 1
+	cl_max_set_size_kb=$(( (tgt_entries_cnt*final_entry_size_B*lim_coeff*125)/(1024*100) + 1 ))
+	reasonable_round cl_max_set_size_kb || return 1
 
 	if [ "${lists_cnt}" -eq 1 ]
 	then
-		cl_max_part_size_kb=${cl_max_bl_size_kb}
+		cl_max_part_size_kb=${cl_max_set_size_kb}
 	else
 		# (tgt_entries_cnt * source_entry_size_B * lim_coeff * 1.03)/1024
 		cl_max_part_size_kb=$(( (tgt_entries_cnt*source_entry_size_B*lim_coeff*103)/(1024*100) + 1 ))
@@ -838,11 +830,11 @@ do_calculate_limits()
 		[ "${lists_cnt}" = 1 ] && lists_pr=list
 		print_msg "" "Recommended values for ${lists_cnt} ${lists_pr} with ${tgt_entries_cnt_human} total entries:" \
 			"${blue}max_part_size_KB${n_c}=\"${cl_max_part_size_kb}\"" \
-			"${blue}max_blockset_file_size_KB${n_c}=\"${cl_max_bl_size_kb}\"" \
-			"${blue}min_good_entries${n_c}=\"${cl_min_lines}\""
+			"${blue}max_blockset_size_KB${n_c}=\"${cl_max_set_size_kb}\"" \
+			"${blue}min_entries${n_c}=\"${cl_min_entries}\""
 	}
 
-	export -n "${4:-_}=${cl_min_lines}" "${5:-_}=${cl_max_bl_size_kb}" "${6:-_}=${cl_max_part_size_kb}" || return 1
+	export -n "${4:-_}=${cl_min_entries}" "${5:-_}=${cl_max_set_size_kb}" "${6:-_}=${cl_max_part_size_kb}" || return 1
 	:
 }
 
@@ -863,20 +855,20 @@ print_def_cfg()
 # -i <blockset_ID>
 # (optional) -d to print with allowed value types (otherwise print without)
 # (optional) -p to print with values from preset
-# (optional) -n to print with dnsmasq_indexes
-# (optional) -c to print with dnsmasq_conf_dirs
+# (optional) -n to print with dmsq_instances
+# (optional) -c to print with dmsq_conf_dirs
 print_def_cfg_blockset()
 {
 	local me=print_def_cfg_blockset \
-		preset print_types dnsmasq_indexes dnsmasq_conf_dirs \
-		pdc_lists pdc_max_part_size pdc_max_set_size pdc_min_lines \
-		opt set_id
+		preset print_types dmsq_instances conf_dirs \
+		pdc_lists pdc_max_part_size pdc_max_set_size pdc_min_entries \
+		OPTIND opt set_id
 
 	while getopts ":i:n:c:p:d" opt; do
 		case "${opt}" in
 			i) set_id=$OPTARG ;;
-			n) dnsmasq_indexes=$OPTARG ;;
-			c) dnsmasq_conf_dirs=$OPTARG ;;
+			n) dmsq_instances=$OPTARG ;;
+			c) conf_dirs=$OPTARG ;;
 			p) preset=$OPTARG ;;
 			d) print_types=1 ;;
 			*) bad_args "${me}" "${@}" ;;
@@ -888,8 +880,8 @@ print_def_cfg_blockset()
 	: "${preset:=small}"
 	is_included "${preset}" "${ALL_PRESETS:?}" || { reg_failure "${me}: invalid preset '${preset}'."; return 1; }
 
-	get_preset "${preset}" _ _ _ _ pdc_lists _ pdc_max_set_size pdc_min_lines &&
-	assert_set "F_${me}" pdc_lists pdc_max_set_size pdc_min_lines || return 1
+	get_preset "${preset}" _ _ _ _ pdc_lists pdc_max_part_size pdc_max_set_size pdc_min_entries &&
+	assert_set "F_${me}" pdc_lists pdc_max_set_size pdc_min_entries || return 1
 
 	cat <<-EOT | if [ -n "${print_types}" ]; then cat; else ${SED_CMD} 's/[ \t]*@.*//'; fi
 
@@ -910,11 +902,6 @@ print_def_cfg_blockset()
 	raw_allow_lists="" @ string
 	raw_ipv4_block_lists="" @ string
 
-	# One or more *dnsmasq* format [blocklist]/[ipv4 blocklist]/[allowlist] URLs and/or short list identifiers separated by spaces
-	dnsmasq_block_lists="" @ string
-	dnsmasq_allow_lists="" @ string
-	dnsmasq_ipv4_block_lists="" @ string
-
 	# One or more *hosts* format blocklist URLs and/or short list identifiers separated by spaces
 	hosts_block_lists="" @ string
 
@@ -923,6 +910,12 @@ print_def_cfg_blockset()
 	# site2.com
 	local_allowlist_path="${ABL_CFG_DIR}/local-allowlist-${set_id}" @ string
 	local_blocklist_path="${ABL_CFG_DIR}/local-blocklist-${set_id}" @ string
+
+
+	# Path to optional local *ipv4* blocklist files in the form:
+	# <ipv4_address>
+	# <ipv4_address>
+	local_ipv4_blocklist_path="${ABL_CFG_DIR}/local-ipv4-blocklist-${set_id}" @ string
 
 	# Governs whether and how persistent blockset is used
 	# 'disable' (default): persistent blockset will not be used. The blockset file will be stored on the ramdisk.
@@ -945,11 +938,14 @@ print_def_cfg_blockset()
 	# Leaving this empty will disable verification
 	test_domains="google.com microsoft.com amazon.com" @ string
 
-	# Minimum number of good lines in final postprocessed blockset
-	min_good_entries="${pdc_min_lines}" @ uint
+	# Maximum size of any downloaded blockset part
+	max_part_size_KB="${pdc_max_part_size}" @ uint
 
 	# Maximum total size of combined, processed blockset
-	max_blockset_file_size_KB="${pdc_max_set_size}" @ uint
+	max_blockset_size_KB="${pdc_max_set_size}" @ uint
+
+	# Minimum number of entries in final postprocessed blockset
+	min_entries="${pdc_min_entries}" @ uint
 
 	# If a path to custom script is specified and that script defines functions
 	# 'report_success()', 'report_failure()' or 'report_update()',
@@ -959,10 +955,10 @@ print_def_cfg_blockset()
 	# Recommended path is '/usr/libexec/abl_custom-script.sh' which the luci app has permission to access
 	custom_script="" @ string
 
-	# dnsmasq instance indexes and config directories
+	# dnsmasq instance names and config directories
 	# normally this should be set automatically by the 'setup' command
-	dnsmasq_indexes="${dnsmasq_indexes}" @ uint_list
-	dnsmasq_conf_dirs="${dnsmasq_conf_dirs}" @ string
+	dnsmasq_instances="${dmsq_instances}" @ string
+	dnsmasq_conf_dirs="${conf_dirs}" @ string
 
 	EOT
 }
@@ -970,7 +966,7 @@ print_def_cfg_blockset()
 # (optional) -d to print with allowed value types (otherwise print without)
 print_def_cfg_global()
 {
-	local me=print_def_cfg_global print_types pdc_max_part_size preset
+	local me=print_def_cfg_global print_types preset OPTIND
 	while getopts ":i:n:c:p:d" opt; do
 		case "${opt}" in
 			i|n|c) : ;; # ignore these options
@@ -982,9 +978,6 @@ print_def_cfg_global()
 
 	: "${preset:=small}"
 	is_included "${preset}" "${ALL_PRESETS:?}" || { reg_failure "${me}: invalid preset '${preset}'."; return 1; }
-
-	get_preset "${preset}" _ _ _ _ _ pdc_max_part_size &&
-	assert_set "F_${me}" pdc_max_part_size || return 1
 
 	cat <<-EOT | if [ -n "${print_types}" ]; then cat; else ${SED_CMD} 's/[ \t]*@.*//'; fi
 
@@ -1010,11 +1003,8 @@ print_def_cfg_global()
 	min_ipv4_block_part_entries="1" @ uint
 	min_allow_part_entries="1" @ uint
 
-	# Maximum size of any individual downloaded part
-	max_part_size_KB="${pdc_max_part_size}" @ uint
-
 	# Maximum number of download retries
-	max_download_retries="3" @ uint
+	max_download_attempts="3" @ uint
 
 	# Default download mirrors
 	# Hagezi mirror: 'github' or 'gitlab'
@@ -1081,7 +1071,7 @@ do_gen_blockset_config()
 
 		for _preset in $(printf %s "${ALL_PRESETS}" | tr ' ' '\n' | ${SED_CMD} 'x;1!H;$!d;x') # loop over presets in reverse order
 		do
-			eval "_mem=\"\${${_preset}_mem}\""
+			set_int "_mem = ${_preset}_mem"
 			# multiplying by 800 rather than 1024 to account for some memory not available to the kernel
 			[ "${_totalmem}" -ge $((_mem * 800)) ] && break
 		done
@@ -1091,7 +1081,7 @@ do_gen_blockset_config()
 	}
 
 	local cnt totalmem totalmem_human preset \
-		dnsmasq_indexes conf_dirs \
+		dmsq_instances conf_dirs \
 		new_cfg\
 		set_id="${1:-"${luci_new_blockset_name}"}"
 
@@ -1155,9 +1145,9 @@ do_gen_blockset_config()
 	add2list SET_IDS "${set_id}"
 	do_select_dnsmasq_instances "${set_id}" || return 1
 
-	get_params -f gen_blockset_config "${set_id}" dnsmasq_indexes conf_dirs &&
+	get_params -f gen_blockset_config "${set_id}" dmsq_instances conf_dirs &&
 	reg_action -purple "" "Generating new blockset config ${lblue}${set_id}${n_c} from preset '${preset}'." &&
-	new_cfg="$(print_def_cfg bl -i "${set_id}" -p "${preset}" -n "${dnsmasq_indexes}" -c "${conf_dirs}")" &&
+	new_cfg="$(print_def_cfg bl -i "${set_id}" -p "${preset}" -n "${dmsq_instances}" -c "${conf_dirs}")" &&
 	confirm_cfg_write "${set_id}" &&
 	write_config bl "${set_id}" "${new_cfg}" || return 1
 
@@ -1213,8 +1203,10 @@ parse_config()
 	local me=parse_config \
 		IFS="${DEFAULT_IFS}" \
 		cfg_pr \
-		curr_config \
+		cur_config \
 		i keys entries entries_type_pr entries_pr \
+		depr_keys depr_entries \
+		depr_opts="dnsmasq_block_lists${_DELIM_}dnsmasq_allow_lists${_DELIM_}dnsmasq_ipv4_block_lists" \
 		dup_keys dup_entries \
 		unexp_keys unexp_entries \
 		missing_keys missing_entries \
@@ -1225,7 +1217,7 @@ parse_config()
 			cfg_type="${1:?}" cfg_id="${2:?}" cfg_path="${3}" fixes_out_var="${4}" replace_keys_out_var="${5}"
 
 	: "${missing_entries}" "${bad_val_entries}" "${corrected_entries}"
-	: "${dup_keys}" "${dup_entries}" "${unexp_keys}" "${unexp_entries}"
+	: "${dup_keys}" "${dup_entries}" "${unexp_keys}" "${unexp_entries}" "${depr_keys}" "${depr_entries}"
 
 	[ -n "${cfg_path}" ] || get_cfg_path cfg_path "${cfg_id}" || return 1
 
@@ -1245,11 +1237,11 @@ parse_config()
 	{
 		def_cfg_format="$(print_def_cfg global | get_config_format)" || return 1
 		export -n "luci_def_cfg_format"="${def_cfg_format}"
-		curr_cfg_format="$(get_config_format "${cfg_path}")" || return 1
-		export -n "luci_curr_cfg_format_${cfg_id}"="${curr_cfg_format}"
-		is_uint "${curr_cfg_format}" ||
+		cur_cfg_format="$(get_config_format "${cfg_path}")" || return 1
+		export -n "luci_cur_cfg_format_${cfg_id}"="${cur_cfg_format}"
+		is_uint "${cur_cfg_format}" ||
 		{
-			log_msg -warn "" "Config format version '${curr_cfg_format}' is unknown or invalid."
+			log_msg -warn "" "Config format version '${cur_cfg_format}' is unknown or invalid."
 			add_cfg_fix "Update config format version"
 			force_upd_cfg_format=1
 		}
@@ -1258,10 +1250,10 @@ parse_config()
 	try_mkdir -p "${ABL_CFG_STAGING_DIR}" || return 1
 
 	# read and sanitize current config
-	curr_config="$(san_config "${cfg_path}")" || { reg_failure "Failed to read the ${cfg_pr}."; return 1; }
+	cur_config="$(san_config "${cfg_path}")" || { reg_failure "Failed to read the ${cfg_pr}."; return 1; }
 
 	local bad_newline=
-	case "${curr_config}" in
+	case "${cur_config}" in
 		*"${CR_LF}"*) bad_newline="Windows-style (CR_LF)" ;;
 		*"${CR}"*) bad_newline="MacOS-style (CR)" ;;
 	esac
@@ -1272,13 +1264,13 @@ parse_config()
 	}
 
 	# parse config
-	local parse_vars entry_type \
+	local parse_line parse_lines entry_type \
 		valid_lines \
 		parser_err_file="${ABL_CFG_STAGING_DIR}/parser_err" \
 		awk_err_file="${ABL_CFG_STAGING_DIR}/awk_err" \
 		inval_entry_file="${ABL_CFG_STAGING_DIR}/inval_entry"
 	rm -f "${parser_err_file}" "${awk_err_file}" "${inval_entry_file}"
-	for entry_type in unexp bad_val missing dup
+	for entry_type in unexp bad_val missing dup depr
 	do
 		rm -f "${ABL_CFG_STAGING_DIR}/${entry_type}_entries"
 	done
@@ -1286,8 +1278,8 @@ parse_config()
 	# extract valid values from default config
 	valid_lines="$(print_def_cfg "${cfg_type}" -i "${cfg_id}" -d | san_config | tr '\n' "${_DELIM_:?}")" || return 1
 
-	parse_vars="$(
-		printf '%s\n' "${curr_config}" |
+	parse_lines="$(
+		printf '%s\n' "${cur_config}" |
 		${AWK_CMD:?} -F"=" \
 			-v q="'" \
 			-v blue="${blue}" \
@@ -1297,6 +1289,7 @@ parse_config()
 			-v DELIM="${_DELIM_:?}" \
 			-v V="${valid_lines}" \
 			-v M="${CFG_MIGRATE_OPTS}" \
+			-v D="${depr_opts}" \
 			-v A="${ABL_CFG_STAGING_DIR:?}" '
 		# return codes: 0=OK, 1=awk or default config error, 253=check double-quotes, 254=Invalid entry detected
 
@@ -1390,6 +1383,10 @@ parse_config()
 				}
 			}
 
+			# Create depr_keys_arr
+			split(D,d_tmp,DELIM)
+			for (ind in d_tmp)
+				depr_keys_arr[d_tmp[ind]]
 		}
 
 		# Process user config
@@ -1422,18 +1419,26 @@ parse_config()
 			split($2,tmp,"\"")
 			val=tmp[2]
 
-			# Handle migrated keys
+			# Deprecated keys
+			if ($1 in depr_keys_arr) {
+				if (! val) next
+				depr_keys=depr_keys $1 " "
+				print $0 >> A"/depr_entries"
+				next
+			}
+
+			# Migrated keys
 			if ($1 in migrate_keys_arr) {
 				new_key=migrate_keys_arr[$1]
 				if (check_value(new_key,val) == 0)
 				{
 					config_keys[new_key]
-					print get_var_name(new_key) "=\"" val "\""
+					print get_var_name(new_key) "=" val
 					next
 				}
 			}
 
-			# Handle duplicate keys
+			# Duplicate keys
 			if ($1 in config_keys) {
 				if (IGN) next
 				dup_keys=dup_keys $1 " "
@@ -1441,7 +1446,7 @@ parse_config()
 				next
 			}
 
-			# Handle unexpected keys
+			# Unexpected keys
 			if ($1 in def_arr) {} else {
 				if (IGN) next
 				unexp_keys=unexp_keys $1 " "
@@ -1452,7 +1457,7 @@ parse_config()
 			# Register the key
 			config_keys[$1]
 
-			# Handle unexpected values
+			# Unexpected values
 			if (check_value($1,val) != 0)
 			{
 				if (IGN) next
@@ -1462,7 +1467,7 @@ parse_config()
 				next
 			}
 
-			print get_var_name($1) "=\"" val "\""
+			print get_var_name($1) "=" val
 		}
 
 		END{
@@ -1473,10 +1478,11 @@ parse_config()
 					missing_keys=missing_keys key " "
 				}
 			}
-			print "missing_keys=\"" missing_keys "\" " \
-				"unexp_keys=\"" unexp_keys "\" " \
-				"dup_keys=\"" dup_keys "\" " \
-				"bad_val_keys=\"" bad_val_keys "\" "
+			print "missing_keys=" missing_keys
+			print "unexp_keys=" unexp_keys
+			print "dup_keys=" dup_keys
+			print "depr_keys=" depr_keys
+			print "bad_val_keys=" bad_val_keys
 			exit rv
 		}'
 	)" &&
@@ -1500,11 +1506,17 @@ parse_config()
 
 	rm -f "${parser_err_file}"
 
-	eval "${parse_vars}" ||
-	{
-		reg_failure "Failed to parse ${cfg_pr}."
-		return 3
-	}
+	debug_msg "" "parse_lines:" "${parse_lines}" ""
+
+	# Parse config lines into vars
+	IFS="${_NL_}"
+	for parse_line in ${parse_lines}
+	do
+		[ -n "${parse_line}" ] || continue
+		IFS="${DEFAULT_IFS}"
+		export -n "${parse_line?}" || { reg_failure "Failed to parse '${parse_line}'"; return 3; }
+	done
+	IFS="${DEFAULT_IFS}"
 
 	# remove trailing '/' from dir path
 	[ "${cfg_id}" = global ] ||
@@ -1518,8 +1530,9 @@ parse_config()
 
 	for i in \
 		"bad_val||Replace unexpected values with defaults" \
-		"dup|Duplicate|Remove duplicate entries from the config" \
-		"unexp|Unexpected|Remove unexpected entries from the config" \
+		"depr|Deprecated|Remove deprecated entries from config" \
+		"dup|Duplicate|Remove duplicate entries from config" \
+		"unexp|Unexpected|Remove unexpected entries from config" \
 		"missing|Missing|Add missing config entries with default values"
 	do
 		entry_type="${i%%|*}"
@@ -1554,9 +1567,9 @@ parse_config()
 
 	p_cfg_fixes="${p_cfg_fixes%$'\n'}"
 
-	if [ -z "${p_cfg_fixes}" ] && [ -z "${force_upd_cfg_format}" ] && [ "${curr_cfg_format}" != "${def_cfg_format}" ]
+	if [ -z "${p_cfg_fixes}" ] && [ -z "${force_upd_cfg_format}" ] && [ "${cur_cfg_format}" != "${def_cfg_format}" ]
 	then
-		log_msg -yellow "" "Current config format version '${curr_cfg_format}' differs from default config version '${def_cfg_format}'."
+		log_msg -yellow "" "Current config format version '${cur_cfg_format}' differs from default config version '${def_cfg_format}'."
 		add_cfg_fix "Update config format version"
 	fi
 
@@ -1707,11 +1720,11 @@ get_cfg_type()
 
 # 1: config type
 # 2: config ID
-# 3: keys to replace (whitespace-separated)
+# 3: keys to replace (space-separated)
 fix_config()
 {
 	local var_suffix \
-		dnsmasq_indexes conf_dirs \
+		dmsq_instances conf_dirs \
 		fixed_cfg \
 		bk_prefix \
 		cfg_type \
@@ -1722,14 +1735,14 @@ fix_config()
 
 	[ "${cfg_type}" = global ] || var_suffix="_${cfg_id}"
 
-	if is_included dnsmasq_indexes "${replace_keys}" || is_included dnsmasq_conf_dirs "${replace_keys}"
+	if is_included dnsmasq_instances "${replace_keys}" || is_included dnsmasq_conf_dirs "${replace_keys}"
 	then
 		do_select_dnsmasq_instances "${cfg_id}" || return 1
 	fi
 
 	[ "${cfg_type}" = bl ] &&
 	{
-		get_params "${cfg_id}" dnsmasq_indexes conf_dirs
+		get_params "${cfg_id}" dmsq_instances conf_dirs
 		bk_prefix="blockset-"
 	}
 
@@ -1750,10 +1763,10 @@ fix_config()
 
 	# recreate config from default while replacing values with values from the existing config
 	fixed_cfg="$(
-		print_def_cfg "${cfg_type}" -i "${cfg_id}" -n "${dnsmasq_indexes}" -c "${conf_dirs}" |
+		print_def_cfg "${cfg_type}" -i "${cfg_id}" -n "${dmsq_instances}" -c "${conf_dirs}" |
 		while IFS="${_NL_}" read -r def_line
 		do
-			curr_val=
+			cur_val=
 			case "${def_line}" in
 				\#*|'') printf '%s\n' "${def_line}"; continue ;;
 				*=*)
@@ -1764,8 +1777,8 @@ fix_config()
 						continue
 					fi
 
-					eval "curr_val=\"\${${key}${var_suffix}}\""
-					printf '%s\n' "${key}=\"${curr_val}\""
+					eval "cur_val=\"\${${key}${var_suffix}}\""
+					printf '%s\n' "${key}=\"${cur_val}\""
 					continue
 			esac
 		done
@@ -1861,8 +1874,7 @@ get_abl_version()
 	# Requires adblock-lean v0.7.3 and later (config format 9 or higher)
 	if \
 		cfg_format="$(get_config_format "${1}")" &&
-		is_uint "${cfg_format}" &&
-		[ "${cfg_format}" -ge 9 ] &&
+		is_gr_eq 9 "${cfg_format}" &&
 		grep -q '^\s*ABL_UPD_CHANNEL=' "${1}" &&
 		get_ver_str gv_upd_ch gv_ver "${1}"
 	then
@@ -1882,9 +1894,9 @@ get_abl_version()
 # 3 - automatic updates check is disabled for current update channel
 check_for_updates()
 {
-	local tarball_url curr_ver upd_ver upd_channel no_upd
+	local tarball_url cur_ver upd_ver upd_channel no_upd
 	unset UPD_AVAIL UPD_DIRECTIONS
-	get_abl_version "${ABL_SERVICE_PATH}" curr_ver upd_channel
+	get_abl_version "${ABL_SERVICE_PATH}" cur_ver upd_channel
 	case "${upd_channel}" in
 		release|latest|snapshot|branch=*) ;;
 		commit) no_upd="was installed from a specific Git commit" ;;
@@ -1907,12 +1919,12 @@ check_for_updates()
 		return 2
 	}
 
-	if [ "${upd_ver}" = "${curr_ver}" ]
+	if [ "${upd_ver}" = "${cur_ver}" ]
 	then
 		reg_msg "The locally installed adblock-lean is the latest version."
 		return 0
 	else
-		local upd_details="(update channel: ${upd_channel}, installed: '${curr_ver}', latest: '${upd_ver}')"
+		local upd_details="(update channel: ${upd_channel}, installed: '${cur_ver}', latest: '${upd_ver}')"
 		UPD_DIRECTIONS="Consider running: 'service adblock-lean update' to update it to the latest version."
 		export -n UPD_AVAIL_MSG="adblock-lean update is available ${upd_details}"
 		reg_msg -2 -yellow "The locally installed adblock-lean seems to be outdated ${upd_details}."

--- a/usr/lib/adblock-lean/abl-manage.sh
+++ b/usr/lib/adblock-lean/abl-manage.sh
@@ -8,7 +8,7 @@ META_FILE="${ABL_RUN_DIR}/${META_FNAME}"
 META_PARAMS="PATH SINGLE_INSTANCE MD5 CNT"
 META_PARAMS_PERSIST="PATH MD5 CNT"
 
-IP_REGEX_4='((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])'
+IP_REGEX_4='((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])'
 IP_REGEX_6='([0-9a-f]{0,4})(:[0-9a-f]{0,4}){2,7}'
 
 VAR2CFG_MAP="$(
@@ -18,19 +18,18 @@ VAR2CFG_MAP="$(
 		raw_block_lists
 		raw_allow_lists
 		raw_ipv4_block_lists
-		dnsmasq_block_lists
-		dnsmasq_allow_lists
-		dnsmasq_ipv4_block_lists
 		hosts_block_lists
 		local_allowlist_path
 		local_blocklist_path
+		local_ipv4_blocklist_path
 		persist_mode=persist_blockset_mode
 		persist_dir=persist_blockset_dir
 		test_domains
-		min_good_entries
-		max_blockset_file_size_KB
+		max_part_size=max_part_size_KB
+		max_set_size=max_blockset_size_KB
+		min_entries
 		custom_script
-		dnsmasq_indexes
+		dmsq_instances=dnsmasq_instances
 		conf_dirs=dnsmasq_conf_dirs
 	" |
 	${AWK_CMD:?} '{$1=$1; split($0,a,"="); if (!a[1]) next; if (!a[2]) a[2] = a[1]; print a[1] "=" a[2]}'
@@ -44,15 +43,14 @@ BL_PARAMS_MAP="
 	bk_file=BK_FILE
 	bk_cnt=BK_CNT
 	bk_ext=BK_EXT
-	curr_persist_path=PERSIST_PATH
-	curr_persist_cnt=PERSIST_CNT
-	curr_persist_md5=PERSIST_MD5
-	curr_path=PATH
-	curr_md5=MD5
-	curr_cnt=CNT
-	curr_single_instance=SINGLE_INSTANCE
+	cur_persist_path=PERSIST_PATH
+	cur_persist_cnt=PERSIST_CNT
+	cur_persist_md5=PERSIST_MD5
+	cur_path=PATH
+	cur_md5=MD5
+	cur_cnt=CNT
+	cur_1_instance=SINGLE_INSTANCE
 	install_path=INSTALL_PATH
-	install_md5=INSTALL_MD5
 	install_cnt=INSTALL_CNT
 	install_path_ram=INSTALL_PATH_RAM
 	install_1_instance=INSTALL_SINGLE_INSTANCE
@@ -234,20 +232,30 @@ try_extract()
 	${cmd} ${opts} "${te_file}" ||
 
 	{
-		[ -n "${stdout}" ] || rm_if_writable "${te_set_id}" "${te_fname}"*
+		[ -n "${stdout}" ] || rm_if_writable "${te_file}" # removes src and dest files
 		reg_failure "try_extract: ${te_err}${te_err:+ }Failed to extract '${te_file}'."
 		return 1
 	}
 }
 
+detect_all_ifaces()
+{
+	[ -n "${ALL_IFACES}" ] && return 0
+	ALL_IFACES="$(${SED_CMD:?} -n '/^\s*[^\s]*:/{s/^\s*//;s/:.*//p}' < /proc/net/dev | tr '\n' ' ')" &&
+	trim_spaces ALL_IFACES &&
+	[ -n "${ALL_IFACES}" ] &&
+		return 0
+	reg_failure "Failed to detect network interfaces."
+	return 1
+}
+
 
 ### dnsmasq support implementation
 
-# Sets blockset-specific dnsmasq context
-# Verifies that configured dnsmasq instances are running and that their indexes and conf-dirs match the config
+# Verifies that configured dnsmasq instances are running and that their names and conf-dirs match the config
 #
 # 1 - (optional) '-q' to quiet
-check_dnsmasq_instances()
+check_dmsq_instances()
 {
 	cdi_fatal() {
 		CDI_FATAL=1
@@ -262,23 +270,28 @@ check_dnsmasq_instances()
 
 	what_failed()
 	{
-		local set_id index dnsmasq_indexes cfg_opt _fail_ind _fail_sets
+		local set_id instance dmsq_instances cfg_opt _fail_ind _fail_sets
 		unset_vars "${1}" "${2}"
 		for set_id in ${SET_IDS}
 		do
-			get_params "${set_id}" dnsmasq_indexes
-			[ -n "${dnsmasq_indexes}" ] ||
-				{ get_cfg_opt cfg_opt "dnsmasq_indexes"; cdi_fail "'${cfg_opt}' config option is not set{}." "${set_id}"; cdi_fatal "${set_id}"; return 1; }
+			get_params "${set_id}" dmsq_instances
+			[ -n "${dmsq_instances}" ] ||
+				{
+					get_cfg_opt cfg_opt dmsq_instances
+					cdi_fail "'${cfg_opt}' config option is not set{}." "${set_id}"
+					cdi_fatal "${set_id}"
+					return 1
+				}
 
-			for index in ${dnsmasq_indexes}
+			for instance in ${dmsq_instances}
 			do
-				eval "[ \"\${RUNNING_${index}}\" = 1 ]" && continue
-				add2list _fail_ind "${index}"
+				eval "[ \"\${RUNNING_${instance}}\" = 1 ]" && continue
+				add2list _fail_ind "${instance}"
 				add2list _fail_sets "${set_id}"
 			done
 		done
 		[ -n "${_fail_ind}" ] &&
-		cdi_fail "dnsmasq instances with indexes '${_fail_ind//" "/"', '"}' are not running."
+		cdi_fail "dnsmasq instances '${_fail_ind//" "/"', '"}' are not running."
 		export -n "${1}=${_fail_ind}" "${2}=${_fail_sets}"
 		:
 	}
@@ -287,36 +300,39 @@ check_dnsmasq_instances()
 	[ -n "${SET_IDS}" ] || return 0
 	[ -n "${CDI_FATAL}" ] && return 1
 
-	local me=check_dnsmasq_instances \
-		quiet instance index dir \
+	local me=check_dmsq_instances \
+		quiet instance dir \
 		set_id \
 		instance_conf_dirs conf_dir_reg \
 		conf_dirs \
 		all_bl_conf_dirs \
-		dnsmasq_indexes \
-		failed_indexes failed_set_ids \
+		dmsq_instances \
+		failed_instances failed_set_ids \
 		skip_conf_dir_check \
-		inst_ind="dnsmasq instance with index"
+		inst_pr
 
 	[ "${1:-??}" = '-q' ] && quiet=1
 
-	detect_dnsmasq_instances
-	[ ${?} = 2 ] && return 1
+	parse_dmsq_cfg || return 1
+	parse_dmsq_runtime
+	[ ${?} = 1 ] && return 1
 
-	what_failed failed_indexes failed_set_ids || return 1
-	[ -n "${failed_indexes}" ] &&
+	what_failed failed_instances failed_set_ids || return 1
+	[ -n "${failed_instances}" ] &&
 	{
-		[ -n "${DNSMASQ_RESTART_TRIED}" ] && return 1
+		[ -n "${DMSQ_RESTART_TRIED}" ] && return 1
 		case "${CUR_CMD}" in
 			start|pause|resume|setup) ;;
 			*) return 1
 		esac
-		DNSMASQ_RESTART_TRIED=1
+		DMSQ_RESTART_TRIED=1
 
-		do_stop "${failed_set_ids}" &&
-		detect_dnsmasq_instances &&
-		what_failed failed_indexes failed_set_ids || return 1
-		[ -z "${failed_indexes}" ] ||
+		do_stop "${failed_set_ids}" || exit 1
+		parse_dmsq_runtime
+		[ ${?} = 1 ] && return 1
+
+		what_failed failed_instances failed_set_ids || return 1
+		[ -z "${failed_instances}" ] ||
 		{
 			# TODO: make sure stop all is executed on failure
 			cdi_fail "dnsmasq service is not working correctly."
@@ -336,24 +352,25 @@ check_dnsmasq_instances()
 
 	for set_id in ${SET_IDS}
 	do
-		get_params -f "${me}" "${set_id}" conf_dirs dnsmasq_indexes || return 1
+		get_params -f "${me}" "${set_id}" conf_dirs dmsq_instances || return 1
 		all_bl_conf_dirs=
 
-		for index in ${dnsmasq_indexes}
+		for instance in ${dmsq_instances}
 		do
+			inst_pr="dnsmasq instance '${instance}'"
 			# check if config section exists in /etc/config/dhcp
-			uci show "dhcp.@dnsmasq[${index}]" &>/dev/null ||
+			uci show "dhcp.${instance}" &>/dev/null ||
 			{
-				cdi_fail "${inst_ind} ${index} is running but not registered in /etc/config/dhcp. Use the command 'service dnsmasq restart' and then re-try."
+				cdi_fail "${inst_pr} is running but not registered in /etc/config/dhcp. Use the command 'service dnsmasq restart' and then re-try."
 				return 1
 			}
 
 			[ -n "${skip_conf_dir_check}" ] && continue
 
-			eval "instance_conf_dirs=\"\${CONF_DIRS_${index}}\""
+			eval "instance_conf_dirs=\"\${R_CONF_DIRS_${instance}}\""
 			[ -n "${instance_conf_dirs}" ] ||
-				{ cdi_fail "Config directory is not set for dnsmasq instance with index ${index}."; return 1; }
-			all_bl_conf_dirs="${all_bl_conf_dirs}${instance_conf_dirs}${_NL_}"
+				{ cdi_fail "Failed to detect conf-dirs for ${inst_pr}."; return 1; }
+			abl_append all_bl_conf_dirs "${instance_conf_dirs}" "${_NL_}"
 
 			conf_dir_reg=
 			local IFS="${_NL_}"
@@ -365,7 +382,7 @@ check_dnsmasq_instances()
 				is_included "${dir}/" "${conf_dirs}" && conf_dir_reg=1
 				[ -d "${dir}" ] ||
 				{
-					cdi_fail "Conf-dir '${dir}' does not exist. ${inst_ind} ${index} is misconfigured."
+					cdi_fail "Conf-dir '${dir}' does not exist. ${inst_pr} is misconfigured."
 					cdi_fatal "${set_id}"
 					return 1
 				}
@@ -374,7 +391,7 @@ check_dnsmasq_instances()
 
 			[ -n "${conf_dir_reg}" ] ||
 			{
-				cdi_fail "Conf-dirs for ${inst_ind} ${index} changed."
+				cdi_fail "Conf-dirs for ${inst_pr} changed."
 				cdi_fatal "${set_id}"
 				return 1
 			}
@@ -388,7 +405,7 @@ check_dnsmasq_instances()
 			is_included "${dir}" "${all_bl_conf_dirs}" "${_NL_}" ||
 			is_included "${dir}/" "${all_bl_conf_dirs}" "${_NL_}" ||
 			{
-				cdi_fail "conf-dir directory '${dir}' is set in config{} but not used by configured dnsmasq instances '${dnsmasq_indexes}'." "${set_id}"
+				cdi_fail "conf-dir directory '${dir}' is set in config{} but not used by configured dnsmasq instances '${dmsq_instances}'." "${set_id}"
 				cdi_fatal "${set_id}"
 				return 1
 			}
@@ -399,160 +416,480 @@ check_dnsmasq_instances()
 
 }
 
-# Env vars: DDI_FORCE
+# Sets vars:
+#   C_PROCESSED
+#   C_CONF_DIRS
+#   C_CONF_DIRS_${inst}
+#   C_IFACES_${inst}
+#   ADDNMOUNTS_${inst}
+# shellcheck disable=SC2329
+parse_dmsq_cfg()
+{
+	accum_list_nl()
+	{
+		add2list "${2}" "${1}" "${_NL_}"
+	}
+
+	config_get_list_nl()
+	{
+		config_list_foreach "${2}" "${3}" accum_list_nl "${1}"
+	}
+
+	process_instance()
+	{
+		local confdirs ifaces notifaces
+
+		unset "C_CONF_DIRS_${1}" "C_IFACES_${1}" "ADDNMOUNTS_${1}"
+
+		config_get_list_nl confdirs "${1}" confdir
+		add2list C_CONF_DIRS "${confdirs}" "${_NL_}"
+		export -n "C_CONF_DIRS_${1}=${confdirs}"
+
+		config_get_list_nl "ADDNMOUNTS_${1}" "${1}" addnmount
+
+		config_get ifaces "${1}" interface
+		config_get notifaces "${1}" notinterface
+
+		: "${ifaces:="${ALL_IFACES}"}"
+		subtract_a_from_b "${notifaces}" "${ifaces}" ifaces
+		export -n "C_IFACES_${1}=${ifaces}"
+	}
+
+
+	[ -n "${C_PROCESSED}" ] && return 0
+
+	unset C_CONF_DIRS C_PROCESSED
+
+	debug_msg "" "Parsing dnsmasq config."
+
+	detect_all_ifaces || return 1
+
+	dbg_off
+
+	# gather conf dirs from /etc/config/dhcp
+	config_load_a dhcp || return 2
+	config_foreach process_instance dnsmasq
+
+	C_PROCESSED=1
+	dbg_on
+	:
+}
+
+# Env vars: PDR_QUIET
 #
-# populates global vars:
-#   ALL_CONF_DIRS, DNSMASQ_RUNNING_INDEXES, DNSMASQ_RUNNING_INST_CNT
-#   DNSMASQ_INST_NAME_${index}, IFACES_${index}, CONF_DIRS_${index}, CONF_DIRS_CNT_${index}, RUNNING_${index}, ADDNMOUNTS_${index}
-#   ADDNMOUNTS_SET, DNSMASQ_INST_SET
-#   DHCP_LOADED
+# Populates global vars:
+#   R_CONF_DIRS, DMSQ_RUNNING_INSTANCES, DMSQ_RUNNING_INST_CNT
+#   R_IFACES_${instance}, R_CONF_DIRS_${instance}, R_CONF_DIRS_CNT_${instance}, RUNNING_${instance}
+#   R_PROCESSED
 #
 # return codes:
 # 0: OK
-# 1: No running instances
-# 2: Fatal error
-detect_dnsmasq_instances()
+# 1: Fatal error
+# 2: No running instances
+parse_dmsq_runtime()
 {
-	# shellcheck disable=SC2317,SC2329
-	add_conf_dir_and_addnmounts()
-	{
-		local confdir
-		config_get confdir "${1}" confdir
-		[ -n "${confdir}" ] && add2list ALL_CONF_DIRS "${confdir}" "${_NL_}"
-		config_get "ADDNMOUNTS_${index}" "${1}" addnmount
-		index=$((index+1))
+	parse_fail() { reg_failure "Failed to process info for dnsmasq instance '${1}'${2:+ (code ${2})}."; }
+	no_running_inst() {
+		[ -n "${PDR_QUIET}" ] && return
+		reg_failure "No running dnsmasq instances found in dnsmasq runtime info${1:+ (code ${1})}."
+		reg_msg "netstat output:" "'${netstat_output}'"
 	}
 
-	[ -z "${DDI_FORCE}" ] && [ -n "${DNSMASQ_INST_SET}" ] && [ -n "${ADDNMOUNTS_SET}" ] &&
-		is_uint "${DNSMASQ_RUNNING_INST_CNT}" && [ "${DNSMASQ_RUNNING_INST_CNT}" -gt 0 ] && return 0
+	[ -n "${R_PROCESSED}" ] &&
+		is_gr_eq 0 "${DMSQ_RUNNING_INST_CNT}" && return 0
 
-	local me=detect_dnsmasq_instances \
-		nonempty instance instances running running_instances index l1_conf_file l1_conf_files conf_dirs i s f dir
+	local me=parse_dmsq_runtime \
+		IFS="${DEFAULT_IFS}" \
+		nonempty instance instances running l1_conf_file l1_conf_files conf_dirs_cnt conf_dirs i s f dir ujail_pid line \
+		ns_parse_res \
+		ifaces not_ifaces ifaces_by_instance instances_by_ujail_pid
 
-	unset DNSMASQ_RUNNING_INDEXES ALL_CONF_DIRS ADDNMOUNTS_SET DNSMASQ_INST_SET
-	DNSMASQ_RUNNING_INST_CNT=0
-	reg_action "" "Checking dnsmasq instances."
+	assert_set "F_${me}" C_PROCESSED || exit 1
 
-	dbg_off
-	[ -n "${DHCP_LOADED}" ] ||
-	{
-		# gather conf dirs from /etc/config/dhcp
-		{ check_func config_load 1>/dev/null || { [ -f /lib/functions.sh ] && . /lib/functions.sh; }; } &&
-		config_load dhcp ||
-			{ reg_failure "Failed to load /etc/config/dhcp"; return 2; }
-		DHCP_LOADED=1
-	}
-
-	index=0
-	config_foreach add_conf_dir_and_addnmounts dnsmasq
-	export -n ADDNMOUNTS_SET=1
+	unset DMSQ_RUNNING_INSTANCES R_CONF_DIRS R_PROCESSED
+	DMSQ_RUNNING_INST_CNT=0
+	debug_msg "" "Parsing dnsmasq runtime info."
 
 	# gather conf dirs from /tmp/
+	set +f
 	for dir in /tmp/dnsmasq.d /tmp/dnsmasq.cfg*
 	do
+		set -f
 		case "${dir}" in ''|*".cfg*") continue; esac
-		add2list ALL_CONF_DIRS "${dir}" "${_NL_}"
+		add2list R_CONF_DIRS "${dir}" "${_NL_}"
 	done
+	set -f
 
-	# gather info from '/etc/init.d/dnsmasq info'
+	# gather info from: ubus call service list
 
 	. /usr/share/libubox/jshn.sh &&
-	json_load "$(/etc/init.d/dnsmasq info)" &&
+	json_load "$(ubus call service list '{"name":"dnsmasq"}')" &&
 	json_get_keys nonempty &&
 	[ -n "${nonempty}" ] &&
+	json_is_a dnsmasq object &&
 	json_select dnsmasq &&
+	json_is_a instances object &&
 	json_select instances &&
 	json_get_keys instances &&
-	[ -n "${instances}" ] || { reg_failure "No running dnsmasq instances found."; return 1; }
+	[ -n "${instances}" ] || { no_running_inst 1; return 2; }
 
-	index=0
+	detect_all_ifaces || return 1
+
 	for instance in ${instances}
 	do
-		unset "DNSMASQ_INST_NAME_${index}" "RUNNING_${index}" "IFACES_${index}" "CONF_DIRS_${index}" "CONF_DIRS_CNT_${index}"
+		json_is_a "${instance}" object &&
+		is_alphanum "${instance}" ||
+			continue
+		unset "RUNNING_${instance}" "R_IFACES_${instance}" "R_CONF_DIRS_${instance}" "R_CONF_DIRS_CNT_${instance}"
+		conf_dirs=
+		conf_dirs_cnt=0
+		ifaces=
+		not_ifaces=
 
-		case "${instance}" in
-			*[!a-zA-Z0-9_]*) log_msg -warn "" "Detected dnsmasq instance with invalid name '${instance}'. Ignoring."; continue
-		esac
-		json_is_a "${instance}" object || continue # skip if $instance is not object
 		json_select "${instance}" &&
-		json_get_var running running &&
-		json_is_a command array &&
-		json_select command || { reg_failure "Failed to process info for dnsmasq instance '${instance}'."; return 2; }
+		json_get_var running running ||
+			{ parse_fail "${instance}" A; return 1; }
 
-		export -n "RUNNING_${index}=${running}"
-		[ -n "${running}" ] &&
+		[ "${running}" = 1 ] &&
 		{
-			add2list running_instances "${instance}" "${_NL_}"
-			add2list DNSMASQ_RUNNING_INDEXES "${index}"
+			json_get_var ujail_pid pid &&
+			json_is_a command array &&
+			json_select command &&
+			[ -n "${ujail_pid}" ] ||
+				{ parse_fail "${instance}" B; return 1; }
+
+			is_included "${instance}" "${DMSQ_RUNNING_INSTANCES}" ||
+				DMSQ_RUNNING_INST_CNT=$((DMSQ_RUNNING_INST_CNT+1))
+			abl_append DMSQ_RUNNING_INSTANCES "${instance}"
+
+			abl_append instances_by_ujail_pid "${ujail_pid}=${instance}" "${_DELIM_}"
+
+			# look for '-C' in values, get next value which is instance's conf file
+			l1_conf_files=
+			i=0
+			while json_is_a $((i+1)) string
+			do
+				i=$((i+1))
+				json_get_var s ${i}
+				[ "${s}" = '-C' ] || continue
+				json_get_var l1_conf_file $((i+1)) || return 1
+				add2list l1_conf_files "${l1_conf_file}" "${_NL_}"
+			done
+
+			json_select ..
+
+			IFS="${_NL_}"
+			set -- ${l1_conf_files}
+			IFS="${DEFAULT_IFS}"
+
+			# get ifaces for instance
+			ifaces="$( ${SED_CMD:?} -n '/^\s*interface=/{s/^.*=//;s/\s*$//;/^\s*$/d;p}' "${@}")"
+			: "${ifaces:="${ALL_IFACES}"}"
+			not_ifaces="$( ${SED_CMD:?} -n '/^\s*except-interface=/{s/^.*=//;s/\s*$//;/^\s*$/d;p}' "${@}")"
+			subtract_a_from_b "${not_ifaces//"${_NL_}"/ }" "${ifaces//"${_NL_}"/ }" ifaces
+			abl_append ifaces_by_instance "${instance}=${ifaces}" "${_DELIM_}"
+
+			debug_msg "${me}: ${instance} ifaces: '${ifaces}'"
+
+			# get conf-dirs for instance
+			conf_dirs="$(
+				for f in "${@}"
+				do
+					${SED_CMD} -n '/^\s*conf-dir=/{s/.*=//;/[^\s]/p;}' "${f}"
+				done | ${SORT_CMD:?} -u
+			)"
+
+			IFS="${_NL_}"
+			set -- ${conf_dirs}
+			IFS="${DEFAULT_IFS}"
+			for dir in "${@}"
+			do
+				[ -n "${dir}" ] || continue
+				add2list R_CONF_DIRS "${dir}" "${_NL_}"
+				conf_dirs_cnt=$((conf_dirs_cnt + 1))
+			done
 		}
 
-		# look for '-C' in values, get next value which is instance's conf file
-		l1_conf_files=
-		i=0
-		while json_is_a $((i+1)) string
-		do
-			i=$((i+1))
-			json_get_var s ${i}
-			[ "${s}" = '-C' ] || continue
-			json_get_var l1_conf_file $((i+1)) || return 2
-			add2list l1_conf_files "${l1_conf_file}" "${_NL_}"
-		done
-		json_select ..
 		json_select ..
 
-		IFS="${_NL_}"
-		set -- ${l1_conf_files}
-		IFS="${DEFAULT_IFS}"
-
-		# get ifaces for instance
-		ifaces="$( ${SED_CMD} -n '/^\s*interface=/{s/^.*=//;s/\s*$//;/^\s*$/d;p}' "${@}" | sort -u )"
-		: "${ifaces:="$(fw4 zone lan)"}" # fall back to all LAN interfaces
-
-		# get conf-dirs for instance
-		conf_dirs="$(
-			for f in "${@}"
-			do
-				$SED_CMD -n '/^\s*conf-dir=/{s/.*=//;/[^\s]/p;}' "${f}"
-			done | $SORT_CMD -u
-		)"
-
-		IFS="${_NL_}"
-		set -- ${conf_dirs}
-		IFS="${DEFAULT_IFS}"
-		for dir in "${@}"
-		do
-			add2list ALL_CONF_DIRS "${dir}" "${_NL_}"
-		done
-
-		export -n "DNSMASQ_INST_NAME_${index}=${instance}" \
-			"CONF_DIRS_${index}=${conf_dirs}" \
-			"IFACES_${index}=${ifaces}"
-		cnt_lines "CONF_DIRS_CNT_${index}" "${conf_dirs}"
-		index=$((index+1))
+		export -n \
+			"RUNNING_${instance}=${running}" \
+			"R_CONF_DIRS_${instance}=${conf_dirs}" \
+			"R_IFACES_${instance}=${ifaces}" \
+			"R_CONF_DIRS_CNT_${instance}=${conf_dirs_cnt}"
 	done
 	json_cleanup
-	cnt_lines DNSMASQ_RUNNING_INST_CNT "${running_instances}"
+
+	# Get nameserver IP's
+
+	# shellcheck disable=SC2155
+	local \
+		ip_output="$(${IP_CMD:?} -o addr show)" \
+		netstat_output="$(${NETSTAT_CMD:?} -plnt 2>/dev/null)"
+
+	[ "${DMSQ_RUNNING_INST_CNT}" -gt 0 ] || { no_running_inst 2; return 2; }
+
+
+	ns_parse_res="$(
+		set +f
+		{ cat /proc/[0-9]*/stat 2>/dev/null || true; } |
+	    ${AWK_CMD:?} \
+			-v delim="${_DELIM_}" \
+			-v instances_by_ujail_pid_str="${instances_by_ujail_pid}" \
+			-v ifaces_by_instance_str="${ifaces_by_instance}" \
+			-v netstat_output="${netstat_output}" \
+			-v ip_output="${ip_output//"\ "/ }" \
+			-v regex_4="^${IP_REGEX_4}(%[^:]+){0,1}#[0-9]+$" -v regex_6="^${IP_REGEX_6}(%[^:]+){0,1}#[0-9]+$" '
+
+		function append(cur,new) {
+			if (! cur) return new
+			if (! new) return cur
+			return cur " " new
+		}
+
+		function rank_ip(ip, inst_name,     iface, port) {
+			# rank:
+			# 0 = lo
+			# 1 = RFC1918 ipv4
+			# 2 = ULA ipv6
+			# 3 = other ipv4
+			# 4 = other ipv6
+
+			if (inst_name !~ /^[a-zA-Z0-9_]+$/) {exit 1}
+
+			ip=tolower(ip)
+
+			# Use <ip%iface> syntax for ipv6 link-local unicast
+			if (ip ~ /^fe[89ab]/) {
+				match (ip, /#.*$/)
+				port=substr(ip, RSTART, RLENGTH)
+				sub(/#.*/, "", ip)
+				iface = iface_by_ip[ip]
+				if (iface) iface = "%" iface
+				ip = ip iface port
+			}
+
+			if (ip ~ regex_4)
+				if (ip ~ /^127\./)
+					reg_ip(ip,"lo",inst_name)
+
+				else if (ip ~ /^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)/)
+					reg_ip(ip,"rfc1918",inst_name)
+				else
+					reg_ip(ip,"other_4",inst_name)
+			else if (ip ~ regex_6)
+				if (ip ~ /^::1#[0-9]+$/)
+					reg_ip(ip,"lo",inst_name)
+
+				else if (ip ~ /^(fc|fd)/)
+					reg_ip(ip,"ula",inst_name)
+
+				else
+					reg_ip(ip,"other_6",inst_name)
+			# ignore non-matching input
+		}
+
+		function reg_ip(ip,type,inst_name) {
+			cnt_local = cnt[inst_name "-" type] + 1
+			cnt_global= cnt[inst_name] + 1
+			if (cnt_local > max_local[type] || cnt_global > max_global) return
+			cnt[inst_name "-" type]++
+			cnt[inst_name]++
+
+			instances[inst_name]
+			ips_arr[inst_name "_" type "_" cnt_local] = ip
+		}
+
+		BEGIN {
+			types[1] = "lo"
+			types[2] = "rfc1918"
+			types[3] = "ula"
+			types[4] = "other_4"
+			types[5] = "other_6"
+			types_cnt=5
+
+			max_global = 16
+			max_local["lo"] = 2
+			max_local["rfc1918"] = 5
+			max_local["ula"] = 3
+			max_local["other_4"] = 3
+			max_local["other_6"] = 3
+
+			# map ujail PIDs to instance names
+			split( instances_by_ujail_pid_str, p, delim )
+			for (e in p) {
+				pair = p[e]
+				if (! pair) continue
+				split(pair,p_el,"=")
+				instances_by_ujail_pid[p_el[1]] = p_el[2]
+			}
+
+			# map [iface] to [IP]
+			split( ip_output, I, "\n" )
+			for (e in I) {
+				line = I[e]
+				if (! line) continue
+				split( line, l_el, " ")
+				iface=l_el[2]
+				ip = tolower( l_el[4] )
+				sub(/\/.*/, "", ip)
+				if (! ip) continue
+				iface_by_ip[ip] = iface
+				if (i2i_seen[ip]++) continue
+				ips_by_iface[iface] = append( ips_by_iface[iface], ip )
+			}
+
+			# map [instance name] to <[IP] [IP] ...>
+			split( ifaces_by_instance_str, f, delim )
+			for (e in f) {
+				pair = f[e]
+				if (! pair) continue
+				split( pair, f_el, "=" )
+				inst_name=f_el[1]
+				ifaces_str=f_el[2]
+				if (! inst_name || ! ifaces_str) continue
+				split( ifaces_str, ifaces_arr, " ")
+				for (i in ifaces_arr) {
+					iface=ifaces_arr[i]
+					if (! iface) continue
+					ips_by_instance[inst_name] = append( ips_by_instance[inst_name], ips_by_iface[iface] )
+				}
+			}
+		}
+
+		# find dnsmasq PIDs (children of ujail PIDs);
+		# map PIDs to instance names
+		/\([ 	]*dnsmasq[ 	]*\)/ {
+			pid=$1
+			sub(/^.*\) /, "", $0)
+			$0 = $0
+			ppid = $2
+			if (ppid in instances_by_ujail_pid) {} else next
+			inst_name = instances_by_ujail_pid[ppid]
+			instances_by_pid[pid] = inst_name
+		}
+
+		END {
+			n = split(netstat_output, n_lines, "\n")
+
+			for (i=1; i<=n; i++) {
+				line=n_lines[i]
+				if ( line !~ /LISTEN[ ].*\/dnsmasq$/) continue
+				$0 = line
+
+				pid = $7
+				if (pid !~ /\/dnsmasq$/) continue
+				sub("/dnsmasq","",pid)
+
+				inst_name=instances_by_pid[pid]
+				if (! inst_name) continue
+
+				ip = $4
+
+				# separate port from ip
+				port=ip
+				sub(/:[0-9]+$/, "", ip)
+				sub("^" ip ":", "", port)
+
+				if (port !~ /^[0-9]+$/) {exit 1}
+
+				# non-wildcard listeners
+				if (ip != "0.0.0.0" && ip != "::") {
+					# use port of the listener
+					ip = ip "#" port
+					# deduplicate
+					if (seen[ip]++) continue
+					rank_ip( ip, inst_name )
+					continue
+				}
+
+				# wildcard listeners
+				# uses port of the wildcard listener, per-instance IPs of ifaces gathered from l1_conf_files
+				split( ips_by_instance[inst_name], ips_tmp_arr, " " )
+				for (j in ips_tmp_arr) {
+					ip=ips_tmp_arr[j] "#" port
+					if (seen[ip]++) continue
+					rank_ip( ip, inst_name )
+				}
+			}
+
+			for (inst_name in instances) {
+				printf "%s=", inst_name
+				for (i = 1; i <= types_cnt; i++) {
+					type = types[i]
+					for (j = 1; j <= cnt[inst_name "-" type]; j++) {
+						printf "%s ", ips_arr[inst_name "_" type "_" j]
+					}
+				}
+				printf "\n"
+			}
+		}'
+	)" ||
+	{
+		reg_failure "" "Failed to get nameserver IPs for dnsmasq instances."
+		reg_msg \
+			"For diagnostics:" \
+			"" "ifaces_by_instance:" "'${ifaces_by_instance//"${_DELIM_}"/"${_NL_}"}'" \
+			"" "netstat output:" "'${netstat_output}'" \
+			"" "ip output:" "'${ip_output}'"
+		return 1
+	}
+
+
+	debug_msg "ns_parse_res:${_NL_}'${ns_parse_res}'"
+
+	[ -n "${ns_parse_res}" ] ||
+		{ no_running_inst 3; return 2; }
+
+	IFS="${_NL_}"
+	for line in ${ns_parse_res}
+	do
+		IFS="${DEFAULT_IFS}"
+		line="${line% }"
+
+		case "${line}" in
+			'') continue ;;
+		esac
+
+		instance="${line%%=*}"
+		ns="${line#"${instance}="}"
+
+		[ -n "${instance}" ] &&
+		is_included "${instance}" "${instances}" ||
+			{ reg_failure "${me}: invalid line in parser output: '${line}'."; return 1; }
+		[ -n "${ns}" ] ||
+			{ reg_failure "${me}: failed to detect active nameserver IP's for dnsmasq instance '${instance}'"; return 1; }
+		export -n "NS_${instance}=${ns}"
+	done
+	IFS="${DEFAULT_IFS}"
+
 	dbg_on
 
-	export -n DNSMASQ_INST_SET=1
+	PRIMARY_NS=$( ${SED_CMD:?} -En '/^\s*nameserver/{s/\s*nameserver\s+//;s/\s+$//;/^$/d;p}' /etc/resolv.conf )
+	export -n PRIMARY_NS="${PRIMARY_NS//"${_NL_}"/ }"
+	: "${PRIMARY_NS:="127.0.0.1 ::1"}"
 
-	[ "${DNSMASQ_RUNNING_INST_CNT}" -gt 0 ] && return 0
-	reg_failure "No running dnsmasq instances found."
-	return 1
+	export -n R_PROCESSED=1
 }
 
-# analyze dnsmasq instances and set $dnsmasq_conf_dirs
+# analyze dnsmasq instances and set params for each blockset: dmsq_instances, conf_dirs
 # 1 (optional): blockset ID's (defaults to all)
 do_select_dnsmasq_instances() {
-	validate_indexes() { printf '%s\n' "${1}" | grep -qE "^ *(a|${indexes_regex})( +(${indexes_regex}))*$"; }
+	validate_input()
+	{
+		printf '%s\n' "${1}" |
+		${SED_CMD} -E 's/\s+/ /g;s/^\s+//;s/\s+$//' |
+		grep -E "^(${2// /|})( +(${2// /|}))*$"
+	}
 
 	local me=select_dnsmasq_instances \
+		index indexes \
 		conf_dirs conf_dirs_instance \
 		conf_dirs_cnt \
 		select_conf_dirs \
 		select_skip_msg \
-		select_indexes \
-		instance index luci_indexes indexes_regex \
+		select_instances \
+		instance luci_instances \
 		ifaces \
 		REPLY \
 		first diff \
@@ -564,24 +901,25 @@ do_select_dnsmasq_instances() {
 
 	assert_set "F_${me}" SET_IDS &&
 	get_valid_set_ids set_ids "${set_ids_arg}" &&
-	detect_dnsmasq_instances || return 1
+	parse_dmsq_cfg &&
+	parse_dmsq_runtime || return 1
 
 	for set_id in ${set_ids}
 	do
 		select_skip_msg="Detected only 1 dnsmasq instance"
-		first=1 diff='' conf_dirs_cnt='' REPLY='' select_indexes='' indexes_regex='' conf_dirs='' conf_dirs_seen=''
+		first=1 diff='' conf_dirs_cnt='' REPLY='' select_instances='' conf_dirs='' conf_dirs_seen=''
 			ifaces='' select_ifaces=''
 			select_conf_dirs=''
 		if \
 		{
-			[ "${DNSMASQ_RUNNING_INST_CNT}" = 1 ] &&
-				select_indexes="${DNSMASQ_RUNNING_INDEXES%% *}"
+			[ "${DMSQ_RUNNING_INST_CNT}" = 1 ] &&
+				select_instances="${DMSQ_RUNNING_INSTANCES%% *}"
 		} ||
 		{
 			# check if all instances share same conf-dirs
-			for index in ${DNSMASQ_RUNNING_INDEXES}
+			for instance in ${DMSQ_RUNNING_INSTANCES}
 			do
-				eval "conf_dirs_instance=\"\${CONF_DIRS_${index}}\""
+				eval "conf_dirs_instance=\"\${R_CONF_DIRS_${instance}}\""
 				case "${first}" in
 					1)
 						first=
@@ -596,68 +934,83 @@ do_select_dnsmasq_instances() {
 			done
 			[ -n "${conf_dirs_seen}" ] &&
 			[ -z "${diff}" ] &&
-			select_indexes="${DNSMASQ_RUNNING_INDEXES}" &&
+			select_instances="${DMSQ_RUNNING_INSTANCES}" &&
 			select_skip_msg="Detected multiple dnsmasq instances which are using the same conf-dirs: ${_NL_}${blue}${conf_dirs// /" ${_NL_}"}${n_c}"
 		}
 		then
-			reg_msg "" "${select_skip_msg}" "Skipping manual dnsmasq instance selection."
+			reg_msg "" "${select_skip_msg}." "Skipping manual dnsmasq instance selection."
 		elif [ -z "${conf_dirs_seen}" ]
 		then
-			reg_failure "Failed to detect dnsmasq conf-dir paths for dnsmasq indexes '${DNSMASQ_RUNNING_INDEXES}'."
+			reg_failure "Failed to detect dnsmasq conf-dir paths for dnsmasq instances '${DMSQ_RUNNING_INSTANCES}'."
 			return 1
 		else
 			# Ask the user
 			reg_msg -blue "Multiple dnsmasq instances detected."
-			eval "luci_indexes=\"\${luci_dnsmasq_indexes_${set_id}}\""
+			eval "luci_instances=\"\${luci_dmsq_instances_${set_id}}\""
 			REPLY=a
 			if [ "${DO_DIALOGS}" = 1 ]
 			then
-				reg_msg "" "Existing dnsmasq instances and assigned network interfaces:"
-				for index in ${DNSMASQ_RUNNING_INDEXES}
+				reg_msg "" "Running dnsmasq instances and assigned network interfaces:"
+				index=1
+				for instance in ${DMSQ_RUNNING_INSTANCES}
 				do
-					eval "instance=\"\${DNSMASQ_INST_NAME_${index}}\"" \
-						"ifaces=\"\${IFACES_${index}}\""
+					local "instance_${index}=${instance}"
+					eval "ifaces=\"\${C_IFACES_${instance}}\""
 					ifaces="${ifaces//"${_NL_}"/, }"
-					reg_msg "${index}. Instance '${instance}': network interfaces '${ifaces}'"
-					indexes_regex="${indexes_regex}${indexes_regex:+|}${index}"
+					reg_msg "${index}: Instance '${instance}': network interfaces '${ifaces}'"
+					abl_append indexes "${index}"
+					index=$((index+1))
 				done
 				print_msg -fb "${set_id}" "" "Please select which dnsmasq instance should have active adblocking{}, or 'a' to abort." \
-					"To adblock on multiple instances, enter their indexes separated by whitespaces."
+					"To adblock on multiple instances, enter multiple instances separated by spaces."
 				while :
 				do
-					printf %s "${indexes_regex}|a: " > "${MSGS_DEST}"
+					printf %s "${indexes// /|}|a: " > "${MSGS_DEST}"
 					read -r REPLY
-					validate_indexes "${REPLY}" ||
-						{ printf '\n%s\n\n' "Please enter ${indexes_regex}|a" > "${MSGS_DEST}"; continue; }
+					if [ "${REPLY}" = a ]
+					then
+						reg_msg "Aborted config generation."
+						exit 0
+					elif REPLY="$(validate_input "${REPLY}" "${indexes}")"
+					then
+						for index in ${REPLY}
+						do
+							eval "instance=\"\${instance_${index}}\""
+							add2list select_instances "${instance}"
+						done
+					elif REPLY="$(validate_input "${REPLY}" "${DMSQ_RUNNING_INSTANCES}")"
+					then
+						add2list select_instances "${REPLY}"
+					else
+						printf '\n%s\n\n' "Please enter any combination of [${indexes}], or 'a' to abort." > "${MSGS_DEST}"
+						continue
+					fi
 					break
 				done
-			elif [ -n "${luci_indexes}" ]
+			elif [ -n "${luci_instances}" ]
 			then
-				REPLY="${luci_indexes}"
-				validate_indexes "${REPLY}" ||
-					{ reg_failure "Invalid dnsmasq instance indexes '${REPLY}'."; return 1; }
+				REPLY="$(validate_input "${luci_instances}" "{DMSQ_RUNNING_INSTANCES}")" ||
+					{ reg_failure "Invalid dnsmasq instances '${luci_instances}' (running instances: '${DMSQ_RUNNING_INSTANCES}')."; return 1; }
+				add2list select_instances "${REPLY}"
 			else
-				reg_failure -fb "${set_id}" "dnsmasq indexes not specified{}."
+				reg_failure -fb "${set_id}" "dnsmasq instances not specified{}."
 				return 1
 			fi
-
-			[ "${REPLY}" = a ] && { reg_msg "Aborted config generation."; exit 0; }
-			select_indexes="${REPLY}"
 		fi
 
-		for index in ${select_indexes}
+		for instance in ${select_instances}
 		do
-			eval "ifaces=\"\${IFACES_${index}}\""
+			eval "ifaces=\"\${C_IFACES_${instance}}\""
 			add2list select_ifaces "${ifaces}"
 		done
 
-		log_msg -fb "${set_id}" "Selected dnsmasq indexes{}: '${select_indexes}' (network intefaces: ${select_ifaces//" "/, })."
+		log_msg -fb "${set_id}" "Selected dnsmasq instances{}: '${select_instances}' (network intefaces: ${select_ifaces//" "/, })."
 
-		for index in ${select_indexes}
+		for instance in ${select_instances}
 		do
 			add_dir=
-			eval "conf_dirs=\"\${CONF_DIRS_${index}}\"
-				conf_dirs_cnt=\"\${CONF_DIRS_CNT_${index}}\""
+			eval "conf_dirs=\"\${R_CONF_DIRS_${instance}}\"
+				conf_dirs_cnt=\"\${R_CONF_DIRS_CNT_${instance}}\""
 
 			if [ "${conf_dirs_cnt}" = 1 ]
 			then
@@ -677,196 +1030,40 @@ do_select_dnsmasq_instances() {
 			[ -n "${add_dir}" ] && add2list select_conf_dirs "${add_dir}" "${_NL_}"
 		done
 
-		[ -n "${select_conf_dirs}" ] || { reg_failure "Failed to detect conf-dirs for dnsmasq indexes '${select_indexes}'."; return 1; }
+		[ -n "${select_conf_dirs}" ] || { reg_failure "Failed to detect conf-dirs for dnsmasq instances '${select_instances}'."; return 1; }
 
 		log_msg "Selected dnsmasq conf-dirs: '${select_conf_dirs//"${_NL_}"/"', '"/}'"
-		set_params "${set_id}" dnsmasq_indexes="${select_indexes}" conf_dirs="${select_conf_dirs}"
+		set_params "${set_id}" dmsq_instances="${select_instances}" conf_dirs="${select_conf_dirs}"
 	done
 
-	check_dnsmasq_instances "${set_ids}" || return 1
-
-	:
-}
-
-# Get interfaces each dnsmasq instance is listening on and associated IP addresses
-# Populates global vars: NS4_${dnsmasq_index}, NS6_${dnsmasq_index}
-get_dnsmasq_ips()
-{
-	local me=get_dnsmasq_ips \
-		IFS="${DEFAULT_IFS}" \
-		wan_devs odevs linux_ifaces dnp_res \
-		set_ids="${*:-"${SET_IDS}"}"
-
-	# get list of OpenWrt device names, store in $odevs
-	# shellcheck disable=SC2329
-	get_odevs_cb()
-	{
-		local dev section_id="$1"
-		config_get dev "${section_id}" name
-		odevs="${odevs}${odevs:+$'\n'}${dev}"
-	}
-
-	wan_devs="$(
-		{
-			${IP_CMD:?} -4 route show table all to match 0.0.0.0
-			${IP_CMD:?} -6 route show table all to match ::
-		} |
-		${SED_CMD:?} -nE '/.*\s+dev\s+/{s/.*\s+dev\s+//;s/\s+.*//;p}' |
-		grep -vE '^(127.0.0.1|::1)$' |
-		${SORT_CMD:?} -u
-	)"
-
-	debug_msg "wan_devs: '${wan_devs}'"
-
-	dbg_off
-	config_load network &&
-	config_foreach get_odevs_cb device &&
-
-	# get list of all linux ifaces + IP addresses
-	linux_ifaces="$(
-		${IP_CMD} -o addr show |
-		${SED_CMD} -nE "/^\s*[0-9]+:\s*/{s/^\s*[0-9]+\s*:\s+//;s/inet[6]*\s+//;s/\s(${IP_REGEX_4:?}|${IP_REGEX_6:?})(\/[0-9]+)\s.*/\1/;s/\s+/ /;s/\s+$//;p;}"
-	)" &&
-
-	dnp_res="$(
-		${NETSTAT_CMD} -plnt 2>/dev/null |
-		${AWK_CMD} -v regex_4="${IP_REGEX_4//\\./.}" -v regex_6="${IP_REGEX_6}" -v l_ifaces="${linux_ifaces}" -v odevs_str="${odevs}" -v wan_devs_str="${wan_devs}" '
-			function print_id(id)
-			{
-				if (out_4[id]) {rv = 0; out_val_4 = out_4[id]} else out_val_4 = "NIL"
-				if (out_6[id]) {rv = 0; out_val_6 = out_6[id]} else out_val_6 = "NIL"
-				print id " " out_val_4 " " out_val_6
-			}
-
-			BEGIN {
-				rv = 1
-
-				# array with WAN device names as keys
-				split(odevs_str,o,"\n")
-				for (d in o) { odevs[o[d]] }
-
-				# array with OpenWrt device names as keys
-				split(wan_devs_str,w,"\n")
-				for (d in w) { wan_devs[w[d]] }
-
-				# parse linux ifaces w/ ips into array keyed by ips, ignore WAN devices, prioritize OpenWrt devices
-				split(l_ifaces,a,"\n")
-				for (e in a) {
-					i=a[e]
-					n = index(i, " ")
-					if(n != 0) {
-						ip = substr(i, n + 1)
-						if_name=substr(i, 1, n - 1)
-						if (if_name in wan_devs) continue
-						if ( ips[ip] == "" || if_name in odevs ) {ips[ip] = if_name}
-					}
-				}
-			}
-
-			/LISTEN[ ].*\/dnsmasq$/ {
-				ip = $4
-				sub(/:[^:]+$/,"",ip)
-				if (ip in ips) {} else next
-				iface=ips[ip]
-
-				pid = $7
-				if (pid !~ /\/dnsmasq$/) next
-				sub("/dnsmasq","",pid)
-				if (! iface || ! pid) next
-
-				id = pid " " iface
-
-				if (iface in odevs) odevs_out[id]
-				else out[id]
-
-				if (ip ~ regex_4)
-				{
-					if (out_4[id] != "") {next}
-					out_4[id] = ip
-				}
-				else if (ip ~ regex_6)
-				{
-					if (out_6[id] != "") {next}
-					out_6[id] = ip
-				}
-				else next
-			}
-
-			END {
-				for (id in odevs_out) print_id(id)
-				for (id in out) print_id(id)
-				exit rv
-			}
-		'
-	)" &&
-	[ -n "${dnp_res}" ] ||
-		{ reg_failure "Failed to get network params for dnsmasq instances. Found Linux ifaces: '${linux_ifaces//"${_NL_}"/ }', OpenWrt devices: '${odevs}', "; return 1; }
-	dbg_on
-
-	debug_msg "get_dnsmasq_ips: all found entries:${_NL_}${dnp_res}" ""
-
-	# dnsmasq nameserver IP's
-	local line index dnsmasq_indexes \
-		all_dnsmasq_indexes \
-		set_id \
-		inst_name inst_pid inst_iface \
-		inst_ip_4 inst_ip_6
-
-	for set_id in ${set_ids}
-	do
-		get_params -f "${me}" "${set_id}" dnsmasq_indexes || continue
-		add2list all_dnsmasq_indexes "${dnsmasq_indexes}"
-	done
-
-	for index in ${all_dnsmasq_indexes}
-	do
-		# iface and nameservers
-		inst_ip_4='' inst_ip_6=''
-
-		eval "inst_name=\"\${DNSMASQ_INST_NAME_${index}}\""
-		inst_pid="$(${PGREP_CMD:?} -f '^/usr/sbin/dnsmasq.*'"${inst_name:-???}"'.pid$')" ||
-			{ reg_failure "No PID found for dnsmasq instance with index '${index}' (name: '${inst_name}')."; return 1; }
-
-		IFS="${_NL_}"
-		for line in ${dnp_res}
-		do
-			IFS="${DEFAULT_IFS}"
-			set -- ${line}
-			[ "${1}" = "${inst_pid}" ] || continue
-
-			inst_iface="${2}"
-			ip4_tmp="${3%"NIL"}"
-			ip6_tmp="${4%"NIL"}"
-
-			[ -n "${inst_iface}" ] &&
-				{ [ -n "${ip4_tmp}" ] || [ -n "${ip6_tmp}" ]; } ||
-					continue
-
-			# Prioritize loopback adresses
-			[ "${inst_iface}" = lo ] &&
-			{
-				inst_ip_4="${ip4_tmp:-"${inst_ip_4}"}"
-				inst_ip_6="${ip6_tmp:-"${inst_ip_6}"}"
-				continue
-			}
-
-			inst_ip_4="${inst_ip_4:-"${ip4_tmp}"}"
-			inst_ip_6="${inst_ip_6:-"${ip6_tmp}"}"
-		done
-		IFS="${DEFAULT_IFS}"
-
-		[ -n "${inst_ip_4}" ] || [ -n "${inst_ip_6}" ] || { reg_failure "${me}: Failed to detect IP addresses which dnsmasq instance ${index} ('${inst_name}') is listening on."; return 1; }
-
-		export -n \
-			"NS4_${index}=${inst_ip_4}" \
-			"NS6_${index}=${inst_ip_6}"
-	done
+	check_dmsq_instances "${set_ids}" || return 1
 
 	:
 }
 
 
 ### GENERAL HELPER FUNCTIONS
+
+get_affected_set_ids()
+{
+	local ges_id ges_all ges_inst ges_inst_tmp ges_state
+	unset_vars "${1}"
+	for ges_id in ${2}
+	do
+		get_params "${ges_id}" ges_inst=dmsq_instances
+		add2list ges_all "${ges_inst}"
+	done
+
+	for ges_id in ${SET_IDS}
+	do
+		is_included "${ges_id}" "${2}" && continue
+		get_params "${ges_id}" ges_state=run_state ges_inst=dmsq_instances
+		[ "${ges_state}" = 0 ] || continue
+		subtract_a_from_b "${ges_inst}" "${ges_all}" ges_inst_tmp
+		[ "${#ges_inst_tmp}" = "${#ges_all}" ] && continue
+		abl_append "${1}" "${ges_id}"
+	done
+}
 
 # shellcheck disable=SC2046,SC2086
 unset_param_vars()
@@ -907,7 +1104,7 @@ mv_blockset()
 
 	debug_msg "${me} end"
 	[ "${mv_rv}" = 0 ] &&
-		{ set_params "${mv_set_id}" curr_path="${mv_dst_f}"; return 0; }
+		{ set_params "${mv_set_id}" cur_path="${mv_dst_f}"; return 0; }
 
 	rm_if_writable "${mv_set_id}" "${mv_src_f}" "${mv_dst_f}"
 	reg_failure "Failed to move blockset '${mv_set_id}' from '${mv_src_f}' to '${mv_dst_f}' (cmd: '${mv_compr_cmd}')."
@@ -924,7 +1121,7 @@ try_mv_blockset()
 {
 	local transfer_cmd="try_mv -q" \
 		md5_changed \
-		curr_md5 \
+		cur_md5 \
 		mv_src_d mv_src_ext \
 		mv_dst_d mv_dst_ext \
 		mv_src_f="${1}" mv_dst_f="${2}" mv_compr_cmd="${3}" mv_set_id="${4:?}"
@@ -960,8 +1157,8 @@ try_mv_blockset()
 
 	[ -n "${md5_changed}" ] &&
 	{
-		get_md5 curr_md5 "${mv_dst_f}" || return 1
-		set_params "${mv_set_id}" curr_md5
+		get_md5 cur_md5 "${mv_dst_f}" || return 1
+		set_params "${mv_set_id}" cur_md5
 	}
 
 	:
@@ -1006,19 +1203,19 @@ check_persist_dir()
 
 check_persist_blockset()
 {
-	local max_blockset_file_size_KB min_good_entries min_good_entries_human \
+	local max_set_size min_entries min_entries_human \
 		persist_check_rv \
-		persist_ext persist_mode curr_persist_path curr_persist_cnt curr_persist_cnt_human curr_persist_size_b \
+		persist_ext persist_mode cur_persist_path cur_persist_cnt cur_persist_cnt_human cur_persist_size_b \
 		run_state \
-		curr_cnt \
+		cur_cnt \
 		set_id="${1}" final_compr_ext="${2}"
 
-	get_params -f "check_persist_blockset" "${set_id}" persist_mode min_good_entries max_blockset_file_size_KB run_state || return 1
-	get_params "${set_id}" curr_persist_path
-	debug_msg "Checking persistent blockset file: ${blue}${curr_persist_path}${n_c}"
+	get_params -f "check_persist_blockset" "${set_id}" persist_mode min_entries max_set_size run_state || return 1
+	get_params "${set_id}" cur_persist_path
+	debug_msg "Checking persistent blockset file: ${blue}${cur_persist_path}${n_c}"
 
 	{
-		[ -n "${curr_persist_path}" ] ||
+		[ -n "${cur_persist_path}" ] ||
 			{
 				[ "${run_state}" != 4 ] || [ "${persist_mode}" = manual ] && [ "${CUR_ACT}" != gen_persist_blockset ] &&
 					reg_failure -fb "${set_id}" "Persistent blockset file{} not found in directory '${persist_dir}'."
@@ -1027,37 +1224,37 @@ check_persist_blockset()
 	} &&
 
 	{
-		get_compr_spec persist_ext _ "${curr_persist_path}" ||
-			{ reg_failure "Can not find utility to extract persistent blockset file '${curr_persist_path}'."; false; }
+		get_compr_spec persist_ext _ "${cur_persist_path}" ||
+			{ reg_failure "Can not find utility to extract persistent blockset file '${cur_persist_path}'."; false; }
 	} &&
 
 	{
 		[ "${persist_ext}" = "${final_compr_ext}" ] ||
 		{
-			reg_failure "Extension '${persist_ext}' of persistent blockset file '${curr_persist_path}' does not match required extension '${final_compr_ext}'."
+			reg_failure "Extension '${persist_ext}' of persistent blockset file '${cur_persist_path}' does not match required extension '${final_compr_ext}'."
 			persist_check_rv=1
 		}
 	} &&
 
-	curr_persist_size_b="$(get_file_size "${curr_persist_path}")" &&
+	cur_persist_size_b="$(get_file_size "${cur_persist_path}")" &&
 	{
-		[ $(( curr_persist_size_b/1024 )) -le "${max_blockset_file_size_KB}" ] ||
-		{ reg_failure "Persistent blockset file '${curr_persist_path}' is larger than the maximum value set in config (${max_blockset_file_size_KB} KiB)."; false; }
+		[ $(( cur_persist_size_b/1024 )) -le "${max_set_size}" ] ||
+		{ reg_failure "Persistent blockset file '${cur_persist_path}' is larger than the maximum value set in config (${max_set_size} KiB)."; false; }
 	} &&
 
 	{
-		read_blockset_metadata -persist "${curr_persist_path%/*}/${META_FNAME_PERSIST:?}" "${set_id}" &&
-		get_params "${set_id}" curr_persist_cnt &&
-		[ -n "${curr_persist_cnt}" ] ||
-		{ reg_failure "Failed to process metadata for persistent blockset file '${curr_persist_path}'."; false; }
+		read_blockset_metadata -persist "${cur_persist_path%/*}/${META_FNAME_PERSIST:?}" "${set_id}" &&
+		get_params "${set_id}" cur_persist_cnt &&
+		[ -n "${cur_persist_cnt}" ] ||
+		{ reg_failure "Failed to process metadata for persistent blockset file '${cur_persist_path}'."; false; }
 	} &&
 
 	{
-		[ "${curr_persist_cnt}" -ge "${min_good_entries}" ] ||
+		[ "${cur_persist_cnt}" -ge "${min_entries}" ] ||
 			{
-				int2human curr_persist_cnt_human "${curr_persist_cnt}"
-				int2human min_good_entries_human "${min_good_entries}" || return 1
-				reg_failure "Entries count (${curr_persist_cnt_human}) in the persistent blockset file '${curr_persist_path}' is below the minimum value set in config (${min_good_entries_human})."
+				int2human cur_persist_cnt_human "${cur_persist_cnt}"
+				int2human min_entries_human "${min_entries}" || return 1
+				reg_failure "Entries count (${cur_persist_cnt_human}) in the persistent blockset file '${cur_persist_path}' is below the minimum value set in config (${min_entries_human})."
 				false
 			}
 	} &&
@@ -1067,84 +1264,8 @@ check_persist_blockset()
 	return 1
 }
 
-# Env vars:
-#   CA_CHECK_DOMAINS: test DNS resolution
-#   CA_NOERR: do not print error for test domain lookup failing
-#
-# return values:
-# 0: All checks passed
-# 1: General error
-# 2: The blockset test domain failed to resolve (blockset not loaded)
-# 3: One of the test domains failed to resolve
-check_active_blockset()
-{
-	lookup_failed() { reg_failure "Lookup of test domain '${1}' failed (dnsmasq instance ${2}, IP addresses '${3}')."; }
-
-	local me=check_active_blockset \
-		test_domains \
-		family index dnsmasq_indexes instance_ns def_ns ns_ips ca_ns_4 ca_ns_6 ns_ips_sp ca_test_dom ca_id \
-		set_id="${1:?}" ca_md5="${2:?}" ca_single_instance="${3}"
-
-	reg_action -purple -fb "${set_id}" "" "Checking if adblocking is active{}." || return 1
-
-	check_dnsmasq_instances || return 1
-
-	get_params -f "${me}" "${set_id}" dnsmasq_indexes || return 1
-	get_params "${set_id}" test_domains
-
-	if [ "${ca_single_instance}" = 1 ]
-	then
-		ca_id="${set_id}" # blockset ID is used in test domain for single instance
-	else
-		ca_id="${ca_md5}"
-	fi
-	ca_test_dom="${ca_id}-${ABL_TEST_DOM_BASE:?}"
-
-	debug_msg "${me}: set_id:${set_id}; indexes:${dnsmasq_indexes}; id:${ca_id}; ca_single_instance:${ca_single_instance};"
-
-	for index in ${dnsmasq_indexes}
-	do
-		ns_ips='' ns_ips_sp=''
-
-		eval "ca_ns_4=\"\${NS4_${index}}\"" "ca_ns_6=\"\${NS6_${index}}\""
-		debug_msg "${me}: ips:${ca_ns_4};${ca_ns_6};"
-
-		for family in 4 6
-		do
-			case "${family}" in
-				4) def_ns=127.0.0.1 ;;
-				6) def_ns=::1
-			esac
-			eval "instance_ns=\"\${ca_ns_${family}:-${def_ns}}\""
-			add2list ns_ips "${instance_ns}" "${_NL_}"
-			add2list ns_ips_sp "${blue}${instance_ns}${n_c}" ", "
-		done
-
-		debug_msg "Testing dnsmasq instance ${index}." \
-			"Using following nameservers for DNS resolution verification: ${ns_ips_sp}" \
-			"Testing adblocking."
-
-		try_lookup_domain "${ca_test_dom}" "${ns_ips}" 10 -n ||
-			{
-				[ -n "${CA_NOERR}" ] || lookup_failed "${ca_test_dom}" "${index}" "${ns_ips_sp}"
-				return 2
-			}
-
-		[ -n "${CA_CHECK_DOMAINS}" ] &&
-		{
-			debug_msg "Testing DNS resolution."
-			for domain in ${test_domains}
-			do
-				try_lookup_domain "${domain}" "${ns_ips}" 5 || { lookup_failed "${domain}"; return 3; }
-			done
-		}
-	done
-
-	:
-}
-
 # 1: var name for printable missing paths output
-# 2: dnsmasq instance indexes to check
+# 2: dnsmasq instances to check
 # 3: list of newline-separated paths
 # shellcheck disable=SC2120
 check_addnmounts()
@@ -1156,24 +1277,24 @@ try_check_addnmounts()
 {
 	local me=check_addnmounts \
 		IFS="${DEFAULT_IFS}" \
-		ca_index ca_path ca_addnmounts \
-		ca_missing_var="${1}" ca_indexes="${2}" ca_req_addnm="${3}"
+		ca_instance ca_path ca_addnmounts \
+		ca_missing_var="${1}" ca_instances="${2}" ca_req_addnm="${3}"
 
 	unset_vars "${ca_missing_var}"
-	assert_set "F_${me}" ca_indexes ADDNMOUNTS_SET || return 1
+	assert_set "F_${me}" ca_instances C_PROCESSED || return 1
 
 	[ -n "${ca_req_addnm}" ] || return 0
 
-	for ca_index in ${ca_indexes}
+	for ca_instance in ${ca_instances}
 	do
-		is_uint "${ca_index}" || { reg_failure "${me}: Invalid dnsmasq index '${ca_index}'."; return 1; }
+		is_alphanum "${ca_instance}" || { reg_failure "${me}: Invalid dnsmasq instance name '${ca_instance}'."; return 1; }
 		IFS="${_NL_}"
 		for ca_path in ${ca_req_addnm}
 		do
 			[ -n "${ca_path}" ] || continue
 			IFS="${DEFAULT_IFS}"
 
-			eval "ca_addnmounts=\"\${ADDNMOUNTS_${ca_index}}\""
+			eval "ca_addnmounts=\"\${ADDNMOUNTS_${ca_instance}}\""
 			case "${ca_path}" in
 				/*) ;;
 				*) reg_failure "${me}: invalid path '${ca_path}'."; return 1
@@ -1184,7 +1305,7 @@ try_check_addnmounts()
 			while [ -n "${ca_path_tmp}" ] && [ "${i}" -le 10 ]
 			do
 				i=$((i+1))
-				is_included "${ca_path_tmp}" "${ca_addnmounts}" && continue 2
+				is_included "${ca_path_tmp}" "${ca_addnmounts}" "${_NL_}" && continue 2
 				ca_path_tmp="${ca_path_tmp%/*}"
 			done
 
@@ -1226,8 +1347,6 @@ set_global_env()
 
 	assert_set "F_${me}" CONFIG_LOADED || return 1
 
-	set -o pipefail
-
 	[ -n "${ABL_HOSTNAME_SET}" ] || ABL_HOSTNAME="$(uci get system.@system[0].hostname)"
 	export -n ABL_HOSTNAME ABL_HOSTNAME_SET=1
 
@@ -1251,7 +1370,7 @@ set_global_env()
 	get_compr_util_spec compr_util_path compr_ext "${compression_util:?}" || return 1
 
 	# dnsmasq instances
-	check_dnsmasq_instances || return 1
+	check_dmsq_instances || return 1
 
 	# check for missing addnmounts during version update
 	if [ -n "${ABL_IN_INSTALL:-"${upd_channel}"}" ] && [ -n "${SET_IDS}" ] && [ -z "${ADDNMOUNTS_CHECKED}" ]
@@ -1278,13 +1397,122 @@ set_global_env()
 	:
 }
 
+# Run states:
+# 0 - running
+# 1 - error
+# 2 - (reserved)
+# 3 - paused
+# 4 - stopped
+#
+# 1: blockset ID
+# 2: IDs of blocksets known to be active, or '?' to check now
+# 3-5 (optional): var names for output of run state, path, single-instance flag
+get_run_state()
+{
+	local me=get_run_state \
+		grs_cur_path grs_single_inst \
+		cur_md5 bk_file \
+		bl_check_res \
+		grs_state \
+		bl_in_conf_dir \
+		cs_res \
+		cd_state \
+		bl_file_exists=0 \
+		dns_check_res=0 \
+		conf_dir conf_dirs \
+			set_id="${1:?}" grs_active_ids="${2?}" \
+			state_out_var="${3:-_}" path_out_var="${4:-_}" single_inst_out_var="${5:-_}"
+
+	debug_msg "Checking state of blockset ${lblue}${set_id}${n_c}."
+
+	unset_vars "${state_out_var}" "${path_out_var}" "${single_inst_out_var}"
+	assert_set "F_${me}" GLOBAL_ENV_SET || return 1
+
+	get_params "${set_id}" grs_cur_path=cur_path grs_single_inst=cur_1_instance cur_md5 conf_dirs bk_file
+
+	# only the install record describes how the blockset was installed - config says nothing about it
+	: "${grs_single_inst:=0}"
+
+	debug_msg "${me}: grs_single_inst=${grs_single_inst};cur_md5=${cur_md5}"
+
+	# Test adblocking. '?' means the caller has no up-to-date result to share
+	[ "${grs_active_ids}" = '?' ] &&
+		{ check_active_blocksets grs_active_ids "${set_id}" 0 || return 1; }
+	is_included "${set_id}" "${grs_active_ids}" && dns_check_res=1
+
+	[ -n "${grs_cur_path}" ] && [ -f "${grs_cur_path}" ] || grs_cur_path=
+
+	# conf-scripts codes:
+	# 0: all conf-scripts not found
+	# 1: all conf-scripts found
+	# 2: inconsistent state
+	for conf_dir in ${conf_dirs}
+	do
+		[ -f "${conf_dir}/${CS_BASE_FNAME}-${set_id}" ] && cd_state=1 || cd_state=0
+		[ -n "${cs_res}" ] || { cs_res="${cd_state}"; continue; }
+
+		[ "${cs_res}" = "${cd_state}" ] || cs_res=2
+	done
+	: "${cs_res:=0}"
+
+	local all_conf_dirs
+	add2list all_conf_dirs "${R_CONF_DIRS}${_NL_}${C_CONF_DIRS}" "${_NL_}"
+
+	[ -n "${grs_cur_path}" ] ||
+		# Look for blockset file in all conf-dirs
+		{
+			for conf_dir in ${all_conf_dirs}
+			do
+				FF_FIRST=1 find_files grs_cur_path "${conf_dir}" "${BLOCKSET_BASE_FNAME}-${set_id}" ||
+				FF_FIRST=1 find_files grs_cur_path "${conf_dir}" "${BLOCKSET_BASE_FNAME}-${set_id}." "*" ||
+					continue
+				[ -n "${bl_in_conf_dir}" ] && grs_state=1 # blockset in conf-dir should only be found once, otherwise contradicts single-instance
+				bl_in_conf_dir=1
+				grs_single_inst=1
+			done
+		}
+
+	[ -n "${grs_cur_path}" ] && bl_file_exists=1
+
+	# Summarize
+	bl_check_res="${dns_check_res}${bl_file_exists}${cs_res}${grs_single_inst}"
+
+	[ "${grs_state}" = 1 ] ||
+		case "${bl_check_res}" in
+			1110|1101) grs_state=0 ;; # running
+			0100|0101)
+				if [ -n "${bl_in_conf_dir}" ]
+				then
+					grs_state=1
+				elif [ "${grs_cur_path}" = "${bk_file}" ]
+				then
+					grs_state=4 # stopped
+				else
+					grs_state=3  # paused
+				fi ;;
+			0000|0001) grs_state=4 ;; # stopped
+			*) grs_state=1 ;;
+		esac
+
+	[ "${grs_state}" = 1 ] &&
+		reg_failure "Unexpected state for blockset '${set_id}' (path '${grs_cur_path}')." \
+			"DNS:${dns_check_res};file_exists:${bl_file_exists};conf-scripts:${cs_res};single_inst:${grs_single_inst};"
+
+	export -n "${state_out_var}=${grs_state}" "${path_out_var}=${grs_cur_path}" "${single_inst_out_var}=${grs_single_inst}"
+
+	debug_msg "${me}: set_id:${set_id}; run_state:${grs_state}; check res:${bl_check_res};"
+
+	:
+}
+
 set_blocksets_env()
 {
 	local \
 		me=set_blocksets_env \
-		valid_ids \
+		valid_ids active_ids \
 		set_id \
-		sbe_rv cur_sbe_rv \
+		rv cur_rv \
+		run_state cur_path cur_1_instance \
 		compr_util_path compr_ext compr_cmd_to_file compr_cmd_stdout extr_cmd_stdout \
 		set_ids="${*:-"${SET_IDS}"}"
 
@@ -1310,27 +1538,36 @@ set_blocksets_env()
 		PART_EXTR_OR_CAT_STDOUT="try_extract -stdout"
 	}
 
-	read_blockset_metadata "${META_FILE:?}" "${valid_ids}" &&
-	get_dnsmasq_ips "${valid_ids}" || sbe_rv=1
+	read_blockset_metadata "${META_FILE:?}" "${valid_ids}" || rv=1
+
+	# check if abl_test_domain is resolved, for all blocksets at once
+	CA_NOERR=1 check_active_blocksets active_ids "${SET_IDS}" 0 || rv=1
+
+	for set_id in ${SET_IDS}
+	do
+		CA_NOERR=1 get_run_state "${set_id}" "${active_ids}" run_state cur_path cur_1_instance || return 1
+		set_params "${set_id}" run_state cur_path cur_1_instance
+	done
 
 	for set_id in ${valid_ids}
 	do
-		set_bl_env "${set_id}" "${compr_ext}" "${extr_cmd_stdout}" "${compr_cmd_stdout}" "${compr_cmd_to_file}"
-		cur_sbe_rv=${?}
-		[ "${cur_sbe_rv}" = 0 ] || reg_failure -fb "${set_id}" "Failed to load environment{}."
-		sbe_rv=$(( ${sbe_rv:-0} + cur_sbe_rv ))
+		set_blockset_env "${set_id}" "${compr_ext}" "${extr_cmd_stdout}" "${compr_cmd_stdout}" "${compr_cmd_to_file}"
+		cur_rv=${?}
+		[ "${cur_rv}" = 0 ] || reg_failure -fb "${set_id}" "Failed to load environment{}."
+		rv=$(( ${rv:-0} + cur_rv ))
 	done
 
-	debug_msg "${me} end" ""
+	debug_msg "${me} end, rv: ${rv}" ""
 
-	return ${sbe_rv}
+	return ${rv}
 }
 
 
+# Sets blockset-specific dnsmasq context
 # Populates global vars for individual blockset IDs
 # Env vars:
 #   SBE_STATUS: do not exit on non-critical errors
-set_bl_env()
+set_blockset_env()
 {
 	rebuild_req_notice() { log_msg -warn "Please run 'service adblock-lean ${2} ${1}' to rebuild the ${3}${3:+ }blockset file."; }
 	wont_work() {
@@ -1338,122 +1575,13 @@ set_bl_env()
 			"Please run 'service adblock-lean create_addnmounts' to create required addnmount entries."
 	}
 
-	# Run states:
-	# 0 - running
-	# 1 - error
-	# 2 - (reserved)
-	# 3 - paused
-	# 4 - stopped
-	#
-	get_run_state()
-	{
-		local me=get_run_state \
-			grs_curr_path grs_single_inst \
-			curr_md5 install_1_instance bk_file \
-			bl_check_res \
-			grs_state \
-			bl_in_conf_dir \
-			cs_res \
-			cd_state \
-			bl_file_exists=0 \
-			dns_check_res=0 \
-			conf_dir conf_dirs \
-			set_id="${1:?}" state_out_var="${2:-_}" path_out_var="${3:-_}" single_inst_out_var="${4:-_}"
-
-		debug_msg "Checking state of blockset ${lblue}${set_id}${n_c}."
-
-		unset_vars "${state_out_var}" "${path_out_var}" "${single_inst_out_var}"
-		assert_set "F_${me}" GLOBAL_ENV_SET || return 1
-
-		get_params "${set_id}" grs_curr_path=curr_path grs_single_inst=curr_single_instance curr_md5 install_1_instance conf_dirs bk_file
-
-		: "${grs_single_inst:="${install_1_instance}"}"
-		: "${grs_single_inst:=0}"
-
-		debug_msg "${me}: grs_single_inst=${grs_single_inst};curr_md5=${curr_md5}"
-
-		# Test adblocking
-		if [ -n "${curr_md5}" ]
-		then
-			check_active_blockset "${set_id}" "${curr_md5}" "${grs_single_inst}"
-			case ${?} in
-				0) dns_check_res=1 ;; # pass
-				2) dns_check_res=0 ;; # not pass
-				*) dns_check_res=2 ;; # error
-			esac
-		fi
-
-		[ -n "${grs_curr_path}" ] && [ -f "${grs_curr_path}" ] || grs_curr_path=
-
-		# conf-scripts codes:
-		# 0: all conf-scripts not found
-		# 1: all conf-scripts found
-		# 2: inconsistent state
-		for conf_dir in ${conf_dirs}
-		do
-			[ -f "${conf_dir}/${CS_BASE_FNAME}-${set_id}" ] && cd_state=1 || cd_state=0
-			[ -n "${cs_res}" ] || { cs_res="${cd_state}"; continue; }
-
-			[ "${cs_res}" = "${cd_state}" ] || cs_res=2
-		done
-		: "${cs_res:=0}"
-
-		[ -n "${grs_curr_path}" ] ||
-			# Look for blockset file in all conf-dirs
-			for conf_dir in ${ALL_CONF_DIRS}
-			do
-				for file in "${conf_dir}/${BLOCKSET_BASE_FNAME}-${set_id}" "${conf_dir}/${BLOCKSET_BASE_FNAME}-${set_id}."*
-				do
-					case "${file}" in *"*"*) continue; esac
-					[ -f "${file}" ] && { grs_curr_path="${file}"; break; }
-				done
-				[ -n "${bl_in_conf_dir}" ] && grs_state=1 # blockset in conf-dir should only be found once, otherwise contradicts single-instance
-				[ -n "${grs_curr_path}" ] && { bl_in_conf_dir=1 grs_single_inst=1; }
-			done
-
-		[ -n "${grs_curr_path}" ] && bl_file_exists=1
-
-		# Summarize
-		bl_check_res="${dns_check_res}${bl_file_exists}${cs_res}${grs_single_inst}"
-
-		[ "${grs_state}" = 1 ] ||
-			case "${bl_check_res}" in
-				1110|1101) grs_state=0 ;; # running
-				0100|0101)
-					if [ -n "${bl_in_conf_dir}" ]
-					then
-						grs_state=1
-					elif [ "${grs_curr_path}" = "${bk_file}" ]
-					then
-						grs_state=4 # stopped
-					else
-						grs_state=3  # paused
-					fi ;;
-				0000|0001) grs_state=4 ;; # stopped
-				*) grs_state=1 ;;
-			esac
-
-		[ "${grs_state}" = 1 ] &&
-			reg_failure "Unexpected state for blockset '${set_id}' (path '${grs_curr_path}')." \
-				"DNS:${dns_check_res};file_exists:${bl_file_exists};conf-scripts:${cs_res};single_inst:${grs_single_inst};"
-
-		export -n "${state_out_var}=${grs_state}" "${path_out_var}=${grs_curr_path}" "${single_inst_out_var}=${grs_single_inst}"
-
-		debug_msg "${me}: set_id:${set_id}; run_state:${grs_state}; check res:${bl_check_res};"
-		set_params "${set_id}" run_state="${grs_state}"
-
-		:
-	}
-
 	local set_id="${1:?}" compr_ext="${2}" extr_cmd_stdout="${3}" compr_cmd_stdout="${4}" compr_cmd_to_file="${5}"
 
-	local me=set_bl_env \
+	local me=set_blockset_env \
 		IFS="${DEFAULT_IFS}" \
 		\
-		dnsmasq_indexes \
+		dmsq_instances \
 		conf_dirs \
-		\
-		run_state \
 		\
 		conf_script_log_avail \
 		\
@@ -1478,11 +1606,12 @@ set_bl_env()
 		persist_dir \
 		persist_mode \
 		\
-		curr_path \
-		curr_single_instance \
+		run_state \
+		cur_path \
+		cur_1_instance \
 		\
-		curr_persist_path \
-		curr_persist_cnt \
+		cur_persist_path \
+		cur_persist_cnt \
 		\
 		final_compress \
 		final_compr_ext \
@@ -1501,7 +1630,7 @@ set_bl_env()
 	debug_msg -fb "${set_id}" "Preparing blockset environment{}." "CUR_ACT: ${CUR_ACT}" "CUR_CMD: ${CUR_CMD}"
 
 	get_params -f "${me}" "${set_id}" \
-		dnsmasq_indexes \
+		dmsq_instances \
 		conf_dirs \
 		persist_mode || return 1
 
@@ -1510,7 +1639,7 @@ set_bl_env()
 	set_base_fname=${BLOCKSET_BASE_FNAME:?}-${set_id}
 
 	# conf-script error logging
-	check_addnmounts sbe_missing_addnm "${dnsmasq_indexes}" "${LOG_CMD:?}" || return 1
+	check_addnmounts sbe_missing_addnm "${dmsq_instances}" "${LOG_CMD:?}" || return 1
 	[ -z "${sbe_missing_addnm}" ] && conf_script_log_avail=1
 
 	# Compression
@@ -1519,7 +1648,7 @@ set_bl_env()
 		assert_set "F_${me}" compr_cmd_to_file compr_cmd_stdout extr_cmd_stdout || return 1
 		bl_full_fname_check=${set_base_fname:?}${compr_ext}
 		install_path_ram_check=${ABL_RUN_DIR:?}/${bl_full_fname_check}
-		check_addnmounts sbe_missing_addnm "${dnsmasq_indexes}" "${extr_cmd_stdout%% *}${_NL_}${install_path_ram_check}" || return 1
+		check_addnmounts sbe_missing_addnm "${dmsq_instances}" "${extr_cmd_stdout%% *}${_NL_}${install_path_ram_check}" || return 1
 
 		if [ -z "${sbe_missing_addnm}" ]
 		then
@@ -1541,10 +1670,10 @@ set_bl_env()
 	: "${bl_full_fname:="${set_base_fname:?}"}"
 
 	# Multiple dnsmasq instances
-	case "${dnsmasq_indexes}" in
+	case "${dmsq_instances}" in
 		*[0-9]*" "*[0-9]*)
 			install_path_ram_check=${ABL_RUN_DIR:?}/${bl_full_fname:?}
-			check_addnmounts sbe_missing_addnm "${dnsmasq_indexes}" "${install_path_ram_check}" || return 1
+			check_addnmounts sbe_missing_addnm "${dmsq_instances}" "${install_path_ram_check}" || return 1
 			if [ -z "${sbe_missing_addnm}" ]
 			then
 				install_path_ram=${install_path_ram_check}
@@ -1567,19 +1696,20 @@ set_bl_env()
 	# addnmount for blockset on ramdisk - required regardless of compr/persist/multi_inst availability
 	sbe_missing_addnm=
 	is_included "${install_path_ram}" "${addnm_ignore_paths}" "${_NL_}" ||
-		check_addnmounts sbe_missing_addnm "${dnsmasq_indexes}" "${install_path_ram}" || return 1
+		check_addnmounts sbe_missing_addnm "${dmsq_instances}" "${install_path_ram}" || return 1
 	[ -z "${sbe_missing_addnm}" ] || { wont_work "adblock-lean" "${sbe_missing_addnm}"; [ -n "${SBE_STATUS}" ] || return 1; }
 
-	CA_NOERR=1 get_run_state "${set_id}" run_state curr_path curr_single_instance || return 1
+	get_params "${set_id}" run_state cur_path cur_1_instance
 	case "${run_state}" in
 		0|3|4) ;;
 		*)
 			case "${CUR_CMD}" in start|pause|resume)
 				KEEP_PERSIST=1 stop_blocksets "${set_id}"
-				CA_NOERR=1 get_run_state "${set_id}" run_state curr_path curr_single_instance || return 1
+				# stopping the blockset invalidated the earlier result
+				CA_NOERR=1 get_run_state "${set_id}" '?' run_state cur_path cur_1_instance || return 1
+				set_params "${set_id}" run_state cur_path cur_1_instance
 			esac
 	esac
-	set_params "${set_id}" curr_path curr_single_instance="${curr_single_instance}"
 
 	# Persistent blockset
 	case "${persist_mode}" in manual|managed)
@@ -1588,7 +1718,7 @@ set_bl_env()
 			then
 				local cat_addnm=''
 				[ "${final_compress}" = 1 ] || cat_addnm="${_NL_}${CAT_CMD}"
-				check_addnmounts sbe_missing_addnm "${dnsmasq_indexes}" "${persist_dir}${cat_addnm}" || return 1
+				check_addnmounts sbe_missing_addnm "${dmsq_instances}" "${persist_dir}${cat_addnm}" || return 1
 				if [ -z "${sbe_missing_addnm}" ]
 				then
 					persist_req=1
@@ -1616,9 +1746,9 @@ set_bl_env()
 		*) false
 	esac &&
 		{
-			FF_RM_EXTRA=1 find_files curr_persist_path "${persist_dir}" "${set_base_fname}." "*" ||
-			FF_RM_EXTRA=1 find_files curr_persist_path "${persist_dir}" "${set_base_fname}"
-			set_params "${set_id}" curr_persist_path
+			FF_RM_EXTRA=1 find_files cur_persist_path "${persist_dir}" "${set_base_fname}." "*" ||
+			FF_RM_EXTRA=1 find_files cur_persist_path "${persist_dir}" "${set_base_fname}"
+			set_params "${set_id}" cur_persist_path
 			[ "${persist_req}" = 1 ] &&
 			{
 				check_persist_blockset "${set_id}" "${final_compr_ext}"
@@ -1635,7 +1765,7 @@ set_bl_env()
 			[ "${ABL_INIT_ACT}" = boot ] ||
 			case "${CUR_ACT}" in
 				status|pause) : ;;
-				resume) [ "${run_state}" = 3 ] && is_persist "${curr_path}" "${set_id}" ;;
+				resume) [ "${run_state}" = 3 ] && is_persist "${cur_path}" "${set_id}" ;;
 				*) false
 			esac
 		then
@@ -1644,17 +1774,17 @@ set_bl_env()
 				[ "${CUR_ACT}" = resume ] || [ "${ABL_INIT_ACT}" = boot ] &&
 				{
 					start_action=load
-					install_path=${curr_persist_path}
+					install_path=${cur_persist_path}
 					install_1_instance=0
-					get_params "${set_id}" curr_persist_cnt
-					set_params "${set_id}" install_cnt="${curr_persist_cnt}"
+					get_params "${set_id}" cur_persist_cnt
+					set_params "${set_id}" install_cnt="${cur_persist_cnt}"
 				}
 			else
 				[ "${CUR_ACT}" = status ] ||
 				{
-					KEEP_PERSIST=0 rm_if_writable "${set_id}" "${curr_persist_path}" "${curr_persist_path%/*}/${META_FNAME_PERSIST}"
-					[ "${curr_path}" = "${curr_persist_path}" ] && unset_metadata "${set_id}"
-					set_params "${set_id}" curr_persist_path= curr_persist_cnt=
+					KEEP_PERSIST=0 rm_if_writable "${set_id}" "${cur_persist_path}" "${cur_persist_path%/*}/${META_FNAME_PERSIST}"
+					[ "${cur_path}" = "${cur_persist_path}" ] && unset_metadata "${set_id}"
+					set_params "${set_id}" cur_persist_path= cur_persist_cnt=
 				}
 
 				[ "${CUR_CMD}" = start ] &&
@@ -1689,8 +1819,8 @@ set_bl_env()
 	esac
 
 	pause_path="${install_path}"
-	[ "${persist_mode}" = manual ] && [ -n "${curr_path}" ] && [ "${curr_path}" = "${curr_persist_path}" ] &&
-		pause_path="${curr_persist_path}"
+	[ "${persist_mode}" = manual ] && [ -n "${cur_path}" ] && [ "${cur_path}" = "${cur_persist_path}" ] &&
+		pause_path="${cur_persist_path}"
 	[ "${install_path}" = "${install_path_ram}" ] && [ "${install_1_instance}" = 1 ] &&
 		pause_path="${ABL_RUN_DIR}/${bl_full_fname}"
 
@@ -1897,20 +2027,23 @@ try_install_blocksets()
 		me=install_blocksets \
 		\
 		installed_ids \
-		dnsmasq_ok_ids \
-		dnsmasq_fail_ids \
+		dmsq_ok_ids \
+		dmsq_fail_ids \
+		active_ids checked_ok_ids extra_ids \
+		test_domains td_doms td_recs td_passed_ids \
 		\
-		dnsmasq_stop_ids \
+		dmsq_stop_ids \
 		\
-		dnsmasq_indexes \
+		run_state \
+		dmsq_instances \
 		persist_mode \
 		skip_load_stop \
 		\
-		curr_path \
+		cur_path \
+		cur_md5 \
 		\
 		install_path \
 		install_path_ram \
-		install_md5 \
 		install_cnt \
 		install_1_instance \
 		\
@@ -1927,21 +2060,21 @@ try_install_blocksets()
 	for set_id in ${set_ids}
 	do
 		get_params "${set_id}" skip_load_stop
-		[ -n "${skip_load_stop}" ] || add2list dnsmasq_stop_ids "${set_id}"
+		[ -n "${skip_load_stop}" ] || add2list dmsq_stop_ids "${set_id}"
 	done
 
-	[ -z "${dnsmasq_stop_ids}" ] || stop_dnsmasq "${dnsmasq_stop_ids}" || return 1
+	[ -z "${dmsq_stop_ids}" ] || stop_dnsmasq "${dmsq_stop_ids}" || return 1
 
 	printf '\n' > "${MSGS_DEST}"
 
 	for set_id in ${set_ids}
 	do
-		get_params -f "${me}" "${set_id}" dnsmasq_indexes conf_dirs final_extr_or_cat_stdout install_path || { inst_failed "${set_id}"; continue; }
+		get_params -f "${me}" "${set_id}" dmsq_instances conf_dirs final_extr_or_cat_stdout install_path install_cnt || { inst_failed "${set_id}"; continue; }
 		get_params "${set_id}" install_1_instance conf_script_log_avail
 
 		log_msg "Installing blockset ${lblue}${set_id}${n_c} at ${blue}${install_path}${n_c}"
 
-		get_md5 install_md5 "${install_path}" || { inst_failed "${set_id}"; continue; }
+		get_md5 cur_md5 "${install_path}" || { inst_failed "${set_id}"; continue; }
 
 		[ "${install_1_instance}" = 1 ] ||
 		# Make conf-script
@@ -1952,43 +2085,61 @@ try_install_blocksets()
 			cat <<-EOF | ${SED_CMD} -E 's/\t+//g' > "${conf_dir}/${CS_BASE_FNAME}-${set_id}" || { reg_failure "Failed to create conf-script in directory '${conf_dir}'."; return 1; }
 				conf-script="\
 				${final_extr_or_cat_stdout} \"${install_path}\" && \
-				printf '%s\\n' \"address=/${install_md5}-${ABL_TEST_DOM_BASE}/#\" && \
+				printf '%s\\n' \"address=/${cur_md5}-${ABL_TEST_DOM_BASE}/#\" && \
 				exit 0; \
 				${conf_script_log_avail:+"${LOG_CMD} -t adblock-lean-conf-script -p user.err \\\"conf-script at '${conf_dir}/${CS_BASE_FNAME}-${set_id}' failed.\\\";"} \
 				exit 0"
 			EOF
 		done
 
-		set_params "${set_id}" install_md5
+		set_params "${set_id}" \
+			cur_md5 \
+			cur_path="${install_path}" \
+			cur_1_instance="${install_1_instance}" \
+			cur_cnt="${install_cnt}"
 
 		add2list installed_ids "${set_id}"
 	done
 
-	[ -n "${installed_ids}" ] && restart_dnsmasq 5 dnsmasq_ok_ids "${installed_ids}"
-	subtract_a_from_b "${dnsmasq_ok_ids}" "${installed_ids}" dnsmasq_fail_ids
-	[ -n "${dnsmasq_fail_ids}" ] && inst_failed "${dnsmasq_fail_ids}"
-	[ -n "${dnsmasq_ok_ids}" ] || return 1
+	[ -n "${installed_ids}" ] && restart_dnsmasq 5 dmsq_ok_ids "${installed_ids}"
+	subtract_a_from_b "${dmsq_ok_ids}" "${installed_ids}" dmsq_fail_ids
+	[ -n "${dmsq_fail_ids}" ] && inst_failed "${dmsq_fail_ids}"
+	[ -n "${dmsq_ok_ids}" ] || return 1
 
-	for set_id in ${dnsmasq_ok_ids}
+	# Test all blocksets related to restarted dnsmasq instances
+	get_affected_set_ids extra_ids "${dmsq_ok_ids}"
+	check_active_blocksets active_ids "${dmsq_ok_ids} ${extra_ids}" 25 || return 1
+	subtract_a_from_b "${extra_ids}" "${active_ids}" active_ids
+
+	# Only worth testing DNS resolution where adblocking works, so passing this check implies both
+	for set_id in ${active_ids}
 	do
-		get_params -f "${me}" "${set_id}" install_path install_1_instance install_md5 install_cnt ||
-			{ inst_failed "${set_id}"; continue; }
+		get_params "${set_id}" test_domains
+		# a blockset with no valid test domains configured has nothing which could fail
+		validate_doms td_doms "${test_domains}" &&
+			abl_append td_recs "${set_id}=${td_doms}" "${_NL_}" ||
+			add2list checked_ok_ids "${set_id}"
+	done
 
-		CA_CHECK_DNS=1 check_active_blockset "${set_id}" "${install_md5}" "${install_1_instance}" ||
-			{
-				reg_failure -fb "${set_id}" "Active blockset check failed{}."
-				inst_failed "${set_id}"
-				continue
-			}
+	[ -n "${td_recs}" ] &&
+	{
+		LT_ACTION_MSG="Testing DNS resolution." \
+			lookup_test_doms td_passed_ids 5 "${td_recs}" || return 1
+		add2list checked_ok_ids "${td_passed_ids}"
+	}
+
+	for set_id in ${dmsq_ok_ids}
+	do
+		if ! is_included "${set_id}" "${checked_ok_ids}"
+		then
+			reg_failure -fb "${set_id}" "Active blockset check failed{}."
+			inst_failed "${set_id}"
+			continue
+		fi
 
 		rm_bk "${set_id}"
 
-		set_params "${set_id}" \
-			curr_path="${install_path}" \
-			curr_single_instance="${install_1_instance}" \
-			curr_md5="${install_md5}" \
-			curr_cnt="${install_cnt}" \
-			run_state=0
+		set_params "${set_id}" run_state=0
 
 		add2list "${try_inst_ok_ids_out_var}" "${set_id}"
 	done
@@ -1996,34 +2147,422 @@ try_install_blocksets()
 	:
 }
 
-# 1 - domain
-# 2 - nameservers
-# 3 - max attempts
-# 4 - (optional) '-n': don't check if result is 127.0.0.1 or 0.0.0.0
-try_lookup_domain()
+# Builds a dom name list for lookup_targets records
+# Returns 1 if no valid dom name found
+# 1: out-var for the space-separated list
+# 2: domain names
+validate_doms()
 {
-	local ns_res ip lookup_ok i=0 IFS="${DEFAULT_IFS}"
+	local dom invalid_doms \
+		vd_doms_var="${1:?}" vd_doms="${2}"
 
-	while :
+	unset_vars "${vd_doms_var}"
+
+	for dom in ${vd_doms}
 	do
-		for ip in ${2}
-		do
-			ns_res="$(${NSLOOKUP_CMD} "${1}" "${ip}" 2>/dev/null)" && { lookup_ok=1; break 2; }
-		done
-		i=$((i+1))
-		[ "${i}" -ge "${3}" ] && break
-		sleep 1
+		case "${dom}" in
+			*[!A-Za-z0-9._-]*) abl_append invalid_doms "'${dom}'" ", "; continue
+		esac
+		abl_append "${vd_doms_var}" "${dom}"
 	done
 
-	[ -n "${lookup_ok}" ] || return 2
+	[ -n "${invalid_doms}" ] && reg_failure "Ignoring invalid domain name(s): ${invalid_doms}"
+	eval "[ -n \"\${${vd_doms_var}}\" ]"
+}
 
-	[ "${4}" = '-n' ] && return 0
+# Checks whether adblocking is active for each blockset
+#
+# Env vars:
+#   CA_NOERR: do not print error for test domain lookup failing
+#
+# 1: out-var for active blockset IDs
+# 2: input blockset IDs
+# 3 (optional): lookup timeout in seconds
+#
+# return values:
+# 0: All blocksets tested OK
+# 1: Some blockset tests failed
+check_active_blocksets()
+{
+	local set_id md5 single_inst doms recs \
+		ab_active_out_var="${1:?}"
 
-	printf %s "${ns_res}" | grep -A1 ^Name | grep -qE '^Address: *(0\.0\.0\.0|127\.0\.0\.1)$' &&
-		{ reg_failure "Lookup of '${1}' resulted in 0.0.0.0 or 127.0.0.1."; return 3; }
+	shift
+
+	local ab_set_ids="${1:?}" timeout_s="${2}"
+
+	unset_vars "${ab_active_out_var}"
+
+	check_dmsq_instances || return 1
+
+	for set_id in ${ab_set_ids}
+	do
+		get_params "${set_id}" md5=cur_md5 single_inst=cur_1_instance
+
+		# In single-instance mode the test domain is identified by blockset ID, otherwise by checksum.
+		# With no record of how the blockset was installed, try both
+		case "${single_inst}" in
+			1) doms="${set_id}-${ABL_TEST_DOM_BASE:?}" ;;
+			'') doms="${set_id}-${ABL_TEST_DOM_BASE:?}${md5:+" ${md5}-${ABL_TEST_DOM_BASE}"}" ;;
+			*) [ -n "${md5}" ] || continue
+				doms="${md5}-${ABL_TEST_DOM_BASE:?}"
+		esac
+
+		abl_append recs "${set_id}=${doms}" "${_NL_}"
+	done
+
+	[ -n "${recs}" ] || return 0
+
+	debug_msg "recs='${recs}'"
+
+	LOOKUP_NOERR="${CA_NOERR}" \
+	LT_ACTION_MSG="Checking if adblocking is active." \
+		lookup_test_doms "${ab_active_out_var}" "${timeout_s:-0}" "${recs}"
+}
+
+# Looks up test domains for multiple blocksets, in one go across all associated dnsmasq instances
+# A blockset passes when, on every instance it uses, at least one of its domains resolved.
+#
+# Env vars:
+#   LT_ACTION_MSG: message to print before the lookups
+#   LOOKUP_NOERR: do not report the blocksets which failed
+#
+# 1: var name for output of IDs of blocksets which passed
+# 2: lookup timeout in seconds
+# 3: newline-separated records: '<blockset ID>=<domain>...'
+#
+# return values:
+# 0: Every blockset was checked
+# 1: Lookups could not be performed
+lookup_test_doms()
+{
+	local me=lookup_test_doms \
+		IFS="${_NL_}" \
+		set_id lt_checked_ids resolved_ids \
+		rec lu_recs \
+		instance instances set_insts failed_insts \
+		dom doms set_doms ns_ips \
+		hit ok cnt fail_report \
+		lt_out_var="${1:?}" timeout_s="${2:-0}" recs="${3:?}"
+
+	unset_vars "${lt_out_var}"
+
+	for rec in ${recs}
+	do
+		IFS="${DEFAULT_IFS}"
+		case "${rec}" in *=?*) ;; *) continue; esac # record without domains
+		set_id="${rec%%=*}" doms="${rec#*=}"
+
+		get_params "${set_id}" instances=dmsq_instances
+		[ -n "${instances}" ] || continue
+
+		local \
+			"doms_${set_id}=${doms}" \
+			"insts_${set_id}=${instances}"
+
+		check_var_names ${instances}
+		for instance in ${instances}
+		do
+			eval "ns_ips=\"\${NS_${instance}}\""
+			: "${ns_ips:="127.0.0.1 ::1"}"
+
+			debug_msg "Testing blockset '${set_id}' on dnsmasq instance '${instance}'." \
+				"Nameservers: ${blue}${ns_ips// /"${n_c}, ${blue}"}${n_c}" \
+				"Domains: ${doms}"
+
+			# blocksets with identical contents share a domain, so the same target ID can be built twice.
+			# lookup_targets keeps the first occurrence
+			for dom in ${doms}
+			do
+				abl_append lu_recs "${instance}__${dom} ${dom} ${ns_ips}" "${_NL_}"
+			done
+		done
+
+		add2list lt_checked_ids "${set_id}"
+	done
+
+	[ -n "${lt_checked_ids}" ] || return 0
+
+	reg_action -purple "" "${LT_ACTION_MSG:?}" || return 1
+
+	# Target IDs name their instance, so every instance shares one run, one job pool and one result list.
+	LOOKUP_NOERR=1 lookup_targets resolved_ids "${lu_recs}" "${timeout_s}"
+	case ${?} in 0|2) ;; *)
+		reg_failure "${me}: failed to look up domains."
+		[ -n "${ASSERT_NOEXIT}" ] || exit 1 # exit on internal scheduler errors
+		return 1
+	esac
+
+	for set_id in ${lt_checked_ids}
+	do
+		eval "set_insts=\"\${insts_${set_id}}\" set_doms=\"\${doms_${set_id}}\""
+		ok=0 cnt=0 failed_insts=
+		for instance in ${set_insts}
+		do
+			cnt=$((cnt+1))
+			# for each blockset, require at least one domain resolving
+			hit=
+			for dom in ${set_doms}
+			do
+				is_included "${instance}__${dom}" "${resolved_ids}" && { hit=1; break; }
+			done
+			[ -n "${hit}" ] && { ok=$((ok+1)); continue; }
+			add2list failed_insts "${instance}"
+		done
+
+		[ "${ok}" = "${cnt}" ] &&
+			{ add2list "${lt_out_var}" "${set_id}"; continue; }
+		abl_append fail_report \
+			"blockset '${set_id}' on dnsmasq instance(s): ${failed_insts}" "${_NL_}"
+	done
+
+	[ -n "${fail_report}" ] && [ -z "${LOOKUP_NOERR}" ] &&
+		reg_failure "No domain resolved:${_NL_}${fail_report}"
+
 	:
 }
 
+# Succeeds when every target resolved
+#
+# A target is a (domain, nameserver set) pair under a caller-chosen ID. It resolves as
+# soon as any one of its own nameservers answers, so the same domain can be tested
+# against several nameserver sets independently by giving each pair its own ID.
+# A repeated target ID is ignored after its first occurrence.
+#
+# 1: (optional) var name for output of the IDs of the targets which resolved
+# 2: newline-separated records: '<target ID> <domain> <nameserver>...'
+#    Vet config-sourced domain names with validate_doms first
+# 3: timeout (seconds)
+#
+# Env vars:
+#   LOOKUP_NOERR: do not print a message when the condition is not satisfied
+#   LOOKUP_FAIL_EARLY: stop as soon as the condition can no longer be satisfied. Leaves the
+#     remaining targets untested, so don't set it when the per-target results are needed.
+# shellcheck disable=SC2329
+lookup_targets()
+{
+	lookup_dom_cb()
+	{
+		local port
+		case "${ns}" in
+			*"#"*)
+				port="${ns##*"#"}"
+				ns="${ns%"#${port}"}"
+		esac
+		${NSLOOKUP_CMD:?} -port="${port:-53}" "${dom:?}" "${ns:?}" 1>/dev/null 2>/dev/null
+	}
+
+	lookup_done_cb()
+	{
+		if [ "${2}" = 0 ]
+		then
+			ASSERT_NOEXIT=1 assert_set "F_lookup_done_cb" dom job_tgt_index || return 1
+			# target may resolve on multiple nameservers - only count it once
+			test_exp "resolved_${job_tgt_index} == 0" &&
+				resolved_cnt=$((resolved_cnt+1))
+			set_int "resolved_${job_tgt_index}=1"
+			add2list RESOLVED_IDXS "${job_tgt_index}"
+			# rv 80 = terminate on early success
+			[ "${resolved_cnt}" = "${tgt_cnt}" ] && return 80
+			return 0
+		fi
+
+		# target only counts as failed once every one of its nameservers failed
+		set_int "failed_ns_${job_tgt_index} = failed_ns_${job_tgt_index} + 1"
+		# this target can no longer resolve, so neither can all of them
+		test_exp "failed_ns_${job_tgt_index} >= tgt_ns_cnt_${job_tgt_index}" &&
+			[ -n "${LOOKUP_FAIL_EARLY}" ] && [ -n "${is_last_round}" ] &&
+				return 2
+		:
+	}
+
+	finalize_lookups_cb()
+	{
+		[ -n "${RESOLVED_IDXS}" ] && printf '%s\n' "${RESOLVED_IDXS}" > "${RESOLVED_IDXS_FILE}"
+		[ "${1}" = 80 ] && return 0 # code 80 means early success
+		[ "${resolved_cnt}" = "${tgt_cnt}" ] && return 0
+		return 2
+	}
+
+	local \
+		me=lookup_targets \
+		IFS="${_NL_}" \
+		lookup_max_jobs=24 \
+		SCHED_ID=lookup \
+		rec fld fld_index \
+		tgt_id tgt_ids tgt_ns tgt_ns_cnt tgt_cnt=0 tgt_index \
+		dom all_doms unresolved_doms \
+		resolved_idxs resolved_cnt=0 \
+		job_tgt_index \
+		ns all_ns \
+		id ids job_cnt=0 \
+		lookup_rv \
+		RESOLVED_IDXS \
+		RESOLVED_IDXS_FILE="${ABL_TMP_DIR}/resolved-tgts" \
+		is_last_round \
+		sched_timeout_s \
+		lookup_start_cs lookup_elapsed_cs \
+			resolved_out_var="${1}" recs_in="${2}" lookup_timeout_s="${3:-0}"
+
+	[ -n "${resolved_out_var}" ] && unset_vars "${resolved_out_var}"
+
+	[ -n "${recs_in}" ] || return 0
+
+	# the record list is split before the first iteration, so IFS can be restored inside the loop
+	for rec in ${recs_in}
+	do
+		IFS="${DEFAULT_IFS}"
+		tgt_id='' dom='' tgt_ns='' fld_index=0
+		for fld in ${rec}
+		do
+			fld_index=$((fld_index+1))
+			case "${fld_index}" in
+				1) tgt_id="${fld}" ;;
+				2) dom="${fld}" ;;
+				*) add2list tgt_ns "${fld}" # remove duplicates
+			esac
+		done
+		[ -n "${tgt_id}" ] && [ -n "${dom}" ] && [ -n "${tgt_ns}" ] || bad_args "${me}" "${@}"
+
+		case "${dom}" in
+			*[!A-Za-z0-9._-]*)
+				reg_failure "${me}: invalid domain name '${dom}'."
+				return 1
+		esac
+		is_included "${tgt_id}" "${tgt_ids}" && continue
+
+		cnt_lines tgt_ns_cnt "${tgt_ns//[ $'\t']/$'\n'}"
+		tgt_cnt=$((tgt_cnt+1))
+		job_cnt=$((job_cnt+tgt_ns_cnt))
+		abl_append tgt_ids "${tgt_id}"
+		add2list all_doms "${dom}"
+		add2list all_ns "${tgt_ns}"
+		local \
+			"tgt_id_${tgt_cnt}=${tgt_id}" \
+			"tgt_dom_${tgt_cnt}=${dom}" \
+			"tgt_ns_${tgt_cnt}=${tgt_ns}" \
+			"tgt_ns_cnt_${tgt_cnt}=${tgt_ns_cnt}" \
+			"resolved_${tgt_cnt}=0" \
+			"failed_ns_${tgt_cnt}=0"
+	done
+
+	[ "${tgt_cnt}" = 0 ] && bad_args "${me}" "${@}"
+
+	sched_timeout_s=$(( 5 * (job_cnt/lookup_max_jobs + (job_cnt % lookup_max_jobs > 0) ) + 1 ))
+	[ "${sched_timeout_s}" -gt 30 ] && sched_timeout_s=30
+
+	get_uptime_cs lookup_start_cs
+
+	while :
+	do
+		: > "${RESOLVED_IDXS_FILE}"
+
+		# Only give up early on last attempt.
+		# Otherwise let running lookups finish to try and exclude more targets from the next round.
+		is_last_round=1
+		[ "${lookup_timeout_s}" -gt 0 ] &&
+		{
+			get_elapsed_time_cs lookup_elapsed_cs "${lookup_start_cs}"
+			[ $(( lookup_elapsed_cs + sched_timeout_s*100 < lookup_timeout_s*100 )) = 1 ] &&
+				is_last_round=
+		}
+
+		ids=
+		id=0
+		tgt_index=0
+		while [ "${tgt_index}" -lt "${tgt_cnt}" ]
+		do
+			tgt_index=$((tgt_index+1))
+			test_exp "resolved_${tgt_index} == 1" && continue # Ignore targets resolved earlier
+			set_int "failed_ns_${tgt_index} = 0"
+			eval "dom=\"\${tgt_dom_${tgt_index}}\" tgt_ns=\"\${tgt_ns_${tgt_index}}\""
+			for ns in ${tgt_ns}
+			do
+				id=$((id+1))
+				jobs_init "${id}"
+				abl_append ids "${id}"
+				job_set_params "${id}" \
+					"dom=${dom}" \
+					"ns=${ns}" \
+					"job_tgt_index=${tgt_index}"
+			done
+		done
+
+		DO_JOB_CB=lookup_dom_cb \
+		JOB_DONE_CB=lookup_done_cb \
+		SCHED_FINALIZE_CB=finalize_lookups_cb \
+		SCHED_FAIL_MSG_CB=reg_failure \
+		SCHED_DIR="${ABL_TMP_DIR}" \
+		SCHED_MAX_JOBS=${lookup_max_jobs} \
+		SCHED_JOB_TIMEOUT_S=3 \
+		SCHED_TIMEOUT_S=${sched_timeout_s} \
+		SCHED_IDLE_TIMEOUT_S=4 \
+			schedule_jobs "${ids}" &
+
+		SCHEDULER_PID=${!}
+		wait ${SCHEDULER_PID}
+		lookup_rv=${?}
+		SCHEDULER_PID=
+
+		# Record this round's hits, so the next round can skip them.
+		resolved_idxs=
+		read_str_from_file -D "resolved domains" -q -v resolved_idxs -f "${RESOLVED_IDXS_FILE}" -F "" -a 1 -n 4096 || [ ${?} = 2 ] || return 1
+		for tgt_index in ${resolved_idxs}
+		do
+			is_uint "${tgt_index}" && [ "${tgt_index}" -ge 1 ] && [ "${tgt_index}" -le "${tgt_cnt}" ] &&
+				set_int "resolved_${tgt_index} = 1"
+		done
+
+		resolved_cnt=0
+		tgt_index=0
+		while [ "${tgt_index}" -lt "${tgt_cnt}" ]
+		do
+			tgt_index=$((tgt_index+1))
+			test_exp "resolved_${tgt_index} == 1" &&
+				resolved_cnt=$((resolved_cnt+1))
+		done
+
+		case "${lookup_rv}" in
+			0) break ;;
+			2) : ;;
+			*) reg_failure "Scheduler failure when testing domains resolution."; return 1
+		esac
+
+		[ "${resolved_cnt}" = "${tgt_cnt}" ] && { lookup_rv=0; break; }
+
+		[ "${lookup_timeout_s}" -gt 0 ] || break
+		get_elapsed_time_cs lookup_elapsed_cs "${lookup_start_cs}"
+		[ $(( lookup_elapsed_cs < lookup_timeout_s*100 )) = 1 ] || break
+
+		sleep 1 &
+		wait ${!}
+	done
+
+
+	rm -f "${RESOLVED_IDXS_FILE}"
+
+	tgt_index=0
+	while [ "${tgt_index}" -lt "${tgt_cnt}" ]
+	do
+		tgt_index=$((tgt_index+1))
+		eval "tgt_id=\"\${tgt_id_${tgt_index}}\" dom=\"\${tgt_dom_${tgt_index}}\""
+
+		if test_exp "resolved_${tgt_index} == 1"
+		then
+			[ -n "${resolved_out_var}" ] && add2list "${resolved_out_var}" "${tgt_id}"
+		else
+			add2list unresolved_doms "${dom}"
+		fi
+	done
+
+	[ "${lookup_rv}" = 0 ] && return 0
+
+	[ -z "${LOOKUP_NOERR}" ] &&
+		reg_failure "Failed to satisfy domain resolution condition: ${all_doms}" \
+			"Unresolved domains: ${unresolved_doms}" "Tried nameservers: ${all_ns}"
+
+	return "${lookup_rv:-1}"
+}
 
 ### METADATA
 
@@ -2040,7 +2579,7 @@ unset_metadata()
 		for meta_param in ${META_PARAMS:?}
 		do
 			unset "${UNSET_PREFIX}${meta_param}_${set_id}"
-			unset_dbg="${unset_dbg}${unset_dbg:+"${_NL_}"}unset ${UNSET_PREFIX}${meta_param}_${set_id}"
+			abl_append unset_dbg "unset ${UNSET_PREFIX}${meta_param}_${set_id}" "${_NL_}"
 		done
 	done
 	[ -n "${unset_dbg}" ] && debug_msg "${_NL_}${unset_dbg}"
@@ -2064,7 +2603,7 @@ try_commit_metadata()
 		GBP_PREFIX \
 		param_set param_set_bl param param_val uci_fail \
 		set_id \
-		curr_path \
+		cur_path \
 		meta_fname \
 		meta_locations="${COMMIT_META_LOCATIONS:-"RAM PERSIST"}" \
 		meta_file="${META_FILE}"
@@ -2083,8 +2622,8 @@ try_commit_metadata()
 
 		for set_id in ${SET_IDS}
 		do
-			get_params "${set_id}" curr_path
-			[ -n "${curr_path}" ] || continue
+			get_params "${set_id}" cur_path
+			[ -n "${cur_path}" ] || continue
 
 			uci_tmp set "${META_FNAME}.${set_id}=blockset_id" || { uci_fail=1; break; }
 			for param in ${META_PARAMS}
@@ -2114,8 +2653,8 @@ try_commit_metadata()
 	for set_id in ${SET_IDS}
 	do
 		local persist_dir
-		get_params "${set_id}" persist_dir curr_path
-		is_persist "${curr_path}" "${set_id}" || continue
+		get_params "${set_id}" persist_dir cur_path
+		is_persist "${cur_path}" "${set_id}" || continue
 
 		[ -d "${persist_dir}" ] || { reg_failure -fb "${set_id}" "Can not update persistent metadata file{} because directory '${persist_dir}' is not found."; continue; }
 
@@ -2167,7 +2706,7 @@ read_blockset_metadata()
 try_read_blockset_metadata()
 {
 	append_err() {
-		[ -n "${1}" ] && rbm_errors="${rbm_errors}${rbm_errors:+"${_NL_}"}${1}"
+		[ -n "${1}" ] && abl_append rbm_errors "${1}" "${_NL_}"
 		is_included "${set_id}" "${req_ids}" && rbm_rv=1
 	}
 
@@ -2177,7 +2716,7 @@ try_read_blockset_metadata()
 			pv_param \
 			meta_val \
 			bl_md5 \
-			curr_path curr_cnt curr_md5 \
+			cur_path cur_cnt cur_md5 \
 			set_id="${1}"
 		local set_id_pr="blockset '${set_id}'"
 
@@ -2193,8 +2732,8 @@ try_read_blockset_metadata()
 			debug_msg "${blue}set metadata${n_c}: ${rbm_prefix}${pv_param}_${set_id}=${meta_val}"
 		done
 
-		GBP_PREFIX="${rbm_prefix}" get_params "${set_id}" curr_cnt curr_md5 curr_path
-		[ -n "${curr_path}" ] || return 0
+		GBP_PREFIX="${rbm_prefix}" get_params "${set_id}" cur_cnt cur_md5 cur_path
+		[ -n "${cur_path}" ] || return 0
 
 		is_included "${set_id}" "${req_ids}" ||
 		{
@@ -2204,21 +2743,21 @@ try_read_blockset_metadata()
 		}
 
 		# check md5
-		get_md5 bl_md5 "${curr_path}" ||
+		get_md5 bl_md5 "${cur_path}" ||
 			{ append_err; return 1; }
 
-		[ "${curr_md5}" = "${bl_md5}" ] ||
-			append_err "MD5 sum not matching in ${sp_f_pr} for ${set_id_pr}, path '${curr_path}'. Metadata file has: '${curr_md5}', blockset file has: '${bl_md5}'."
+		[ "${cur_md5}" = "${bl_md5}" ] ||
+			append_err "MD5 sum not matching in ${sp_f_pr} for ${set_id_pr}, path '${cur_path}'. Metadata file has: '${cur_md5}', blockset file has: '${bl_md5}'."
 
 		# set persist params
 		[ "${rbm_type}" = PERSIST ] &&
 		{
-			[ "${curr_path%/*}" = "${meta_file%/*}" ] ||
+			[ "${cur_path%/*}" = "${meta_file%/*}" ] ||
 			{
-				append_err "Persistent blockset dir not matching in ${sp_f_pr} for ${set_id_pr}. Metadata file has: '${curr_path%/*}', metadata is at: '${meta_file%/*}'."
+				append_err "Persistent blockset dir not matching in ${sp_f_pr} for ${set_id_pr}. Metadata file has: '${cur_path%/*}', metadata is at: '${meta_file%/*}'."
 				return 1
 			}
-			set_params "${set_id}" curr_persist_md5="${curr_md5}" curr_persist_cnt="${curr_cnt}"
+			set_params "${set_id}" cur_persist_md5="${cur_md5}" cur_persist_cnt="${cur_cnt}"
 		}
 		:
 	}
@@ -2265,8 +2804,7 @@ try_read_blockset_metadata()
 	UNSET_PREFIX="${rbm_prefix}" unset_metadata "${req_ids}"
 
 	dbg_off
-	UCI_CONFIG_DIR="${meta_file%/*}" config_load "${meta_file##*/}" ||
-		{ reg_failure "${me}: failed to load ${sp_f_pr}."; return 1; }
+	UCI_CONFIG_DIR="${meta_file%/*}" config_load_a "${meta_file##*/}" || return 1
 	dbg_on
 
 	config_foreach populate_vars blockset_id

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -3,22 +3,17 @@
 
 # silence shellcheck warnings
 : "${blockset_part_failed_action:=}" \
-	"${max_download_retries:=}" "${deduplication:=}" \
+	"${max_download_attempts:=}" "${deduplication:=}" \
 	"${blue:=}" "${lblue:=}" "${green:=}" "${red:=}" "${yellow:=}" "${orange:=}" "${n_c:=}"
 
 PROCESSED_PARTS_DIR="${ABL_TMP_DIR}/blockset_parts"
 
 ERR_F="${ABL_TMP_DIR}/process-errors"
 
-SCHEDULE_DIR="${ABL_TMP_DIR}/schedule"
-
-PROCESSING_TIMEOUT_S=900 # 15 minutes
-IDLE_TIMEOUT_S=300 # 5 minutes
-
 ABL_TEST_DOM_BASE="adblocklean-test.totallybogus"
 
-ALL_LIST_FORMATS="raw dnsmasq hosts"
-ALL_LIST_TYPES="allow block ipv4_block"
+ALL_PART_FORMATS="raw hosts"
+ALL_PART_TYPES="allow block ipv4_block"
 
 
 # shellcheck disable=SC2034
@@ -26,13 +21,13 @@ hagezi_lists="anti.piracy blocklist-referral doh doh-vpn-proxy-bypass dyndns fak
 light multi native.amazon native.apple native.huawei native.lgwebos native.oppo-realme native.roku native.samsung \
 native.tiktok native.tiktok.extended native.vivo native.winoffice native.xiaomi nosafesearch nsfw popupads \
 pro pro.mini pro.plus pro.plus.mini social tif tif.medium tif.mini ultimate ultimate.mini urlshortener whitelist-referral" \
-hagezi_formats="raw dnsmasq" \
+hagezi_formats="raw" \
 hagezi_mirrors="github gitlab" \
 	hagezi_github_url="https://raw.githubusercontent.com/hagezi/dns-blocklists/main" \
 	hagezi_gitlab_url="https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists" \
 \
 oisd_lists="big small nsfw nsfw-small" \
-oisd_formats="raw dnsmasq" \
+oisd_formats="raw" \
 oisd_mirrors="oisd github" \
 	oisd_oisd_url="oisd.nl" \
 	oisd_github_url="https://raw.githubusercontent.com/sjhgvr/oisd/main" \
@@ -45,36 +40,6 @@ stevenblack_mirrors="github sbc_io" \
 
 
 # UTILITY FUNCTIONS
-
-# 1 - var name for centiseconds output
-get_uptime_cs() {
-	local __uptime i_cs gu_cs gu_s
-	unset_vars "${1}"
-
-	read -r __uptime _ < /proc/uptime &&
-	case "${__uptime}" in
-		''|*.*.*) false ;;
-		*.*) ;;
-		*) false ;;
-	esac &&
-	i_cs="${__uptime##*.}" &&
-	case "${i_cs}" in
-		'') gu_cs=00 ;;
-		?) gu_cs="${i_cs}0" ;;
-		??) gu_cs="${i_cs}" ;;
-		??*) gu_cs="${i_cs%"${i_cs#??}"}"
-	esac &&
-	gu_s="${__uptime%.*}" &&
-	is_uint "${gu_s}" "${gu_cs}" ||
-	{
-		reg_failure "Failed to get uptime from /proc/uptime."
-		export -n "${1}"=0
-		return 1
-	}
-	gu_cs="${gu_s:-0}${gu_cs:-00}"
-	gu_cs="${gu_cs#"${gu_cs%%[!0]*}"}"
-	export -n "${1}=${gu_cs:-0}"
-}
 
 # To use, first get initial uptime: 'get_uptime_cs INITIAL_UPTIME'
 # Then call this function to get elapsed time string at desired intervals, e.g.:
@@ -113,15 +78,15 @@ get_elapsed_time_human() {
 # HELPER FUNCTIONS
 
 # Env vars: TESTED_URLS
-# TODO: Parallelize domains lookup
-test_url_domains()
+test_fetch_doms()
 {
-	local list lists list_cat list_author url mirror all_urls type format dom \
+	local list lists list_cat feed_author url mirror all_urls type format \
+		doms valid_doms dom recs \
 		set_id="${1:?}"
 
 	for type in block ipv4_block allow
 	do
-		for format in ${ALL_LIST_FORMATS:?}
+		for format in ${ALL_PART_FORMATS:?}
 		do
 			local list_cat="${format}_${type}_lists"
 			get_bl_param_gl_var _ "${list_cat}" || continue # ignore invalid combinations
@@ -134,14 +99,14 @@ test_url_domains()
 				case "${list}" in
 					'') continue ;;
 					hagezi:*|oisd:*|stevenblack:*)
-						list_author="${list%%":"*}"
-						eval "mirror=\"\${${list_author}_default_mirror}\""
-						eval "url=\"\${${list_author}_${mirror}_url}\""
+						feed_author="${list%%":"*}"
+						eval "mirror=\"\${${feed_author}_default_mirror}\""
+						eval "url=\"\${${feed_author}_${mirror}_url}\""
 						[ -n "${url}" ] ;;
 					*) url="${list}"
 				esac &&
-				! is_included "${url}" "${TESTED_URLS}" "${_NL_}" &&
-				all_urls="${all_urls:+"${all_urls}${_NL_}"}${url}"
+				is_included "${url}" "${TESTED_URLS}" "${_NL_}" && continue
+				abl_append all_urls "${url}" "${_NL_}"
 			done
 		done
 	done
@@ -151,63 +116,73 @@ test_url_domains()
 	reg_action "Testing connectivity." || exit 1
 	debug_msg "URLs:${_NL_}${all_urls}"
 
-	printf '%s\n' "${all_urls}" |
-	${SED_CMD:?} -n '/http/{s~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;p;}' |
-	${SORT_CMD:?} -u |
-	while IFS="${_NL_}" read -r dom || [ -n "${dom}" ]
+	doms="$(
+		printf '%s\n' "${all_urls}" |
+		${SED_CMD:?} -n '/http/{s~^http[s]*[:]*[/]*~~g;s~/.*~~;/^$/d;p;}' |
+		${SORT_CMD:?} -u)
+	"
+
+	[ -n "${doms}" ] || return 0
+
+	# Get list of valid domain names, ignore invalid
+	validate_doms valid_doms "${doms}" || return 1
+
+	# Every domain is tested against the same nameservers, so one pseudo-instance ID suffices
+	for dom in ${valid_doms}
 	do
-		[ -n "${dom}" ] || continue
-		try_lookup_domain "${dom}" "127.0.0.1" 2 ||
-			{ reg_failure "Lookup of '${dom}' failed."; exit 1; }
-	done || return 1
-	TESTED_URLS="${TESTED_URLS:+"${TESTED_URLS}${_NL_}"}${all_urls}"
+		abl_append recs "con__${dom} ${dom} ${PRIMARY_NS:?}" "${_NL_}"
+	done
+
+	# All url-domains must resolve
+	LOOKUP_FAIL_EARLY=1 lookup_targets _ "${recs}" 7 || return 1
+
+	abl_append TESTED_URLS "${all_urls}" "${_NL_}"
 	:
 }
 
 # 1 - var name for output
 # 2 - list URL or short identifier
-# 3 - list format (raw|dnsmasq)
+# 3 - list format (raw|hosts)
 # 4 - DL mirror
 # shellcheck disable=SC2329
-get_list_url()
+get_feed_url()
 {
-	local base_url prefix suffix raw_suffix dnsmasq_suffix hosts_suffix \
-		res_url list_author list_name lists list_id_lc formats \
+	local base_url prefix suffix raw_suffix hosts_suffix \
+		gfu_res feed_author list_name lists list_id_lc formats \
 		mirrors first_mirror \
-		out_var="${1}" list_id="${2}" format="${3}" mirror="${4}"
+		gfu_out_var="${1}" list_id="${2}" format="${3}" mirror="${4}"
 
-	unset_vars "${out_var}"
+	unset_vars "${gfu_out_var}"
 
-	case "${format}" in raw|dnsmasq|hosts) ;; *) reg_failure "Unexpected list format '${format}'."; return 1; esac
+	case "${format}" in raw|hosts) ;; *) reg_failure "Unexpected list format '${format}'."; return 1; esac
 
 	tolower list_id_lc "${list_id}"
 	case "${list_id_lc}" in hagezi:*|oisd:*|stevenblack:*) ;; *)
-		export -n "${out_var}=${list_id}"
+		export -n "${gfu_out_var}=${list_id}"
 		return 0
 	esac
 	list_id="${list_id_lc}"
 
-	list_author="${list_id%%\:*}" list_name="${list_id#*\:}"
+	feed_author="${list_id%%\:*}" list_name="${list_id#*\:}"
 
-	eval "lists=\"\${${list_author}_lists}\""
-	eval "base_url=\"\${${list_author}_${mirror}_url}\""
-	[ -n "${base_url}" ] || { reg_failure "Failed to get base URL for ${list_author} mirror '${mirror}'."; return 1; }
+	eval "lists=\"\${${feed_author}_lists}\""
+	eval "base_url=\"\${${feed_author}_${mirror}_url}\""
+	[ -n "${base_url}" ] || { reg_failure "Failed to get base URL for ${feed_author} mirror '${mirror}'."; return 1; }
 
-	is_included "${list_name}" "${lists}" || { reg_failure "Unknown ${list_author} list '${2}'."; return 1; }
+	is_included "${list_name}" "${lists}" || { reg_failure "Unknown ${feed_author} list '${2}'."; return 1; }
 
-	eval "formats=\"\${${list_author}_formats}\""
+	eval "formats=\"\${${feed_author}_formats}\""
 	is_included "${format}" "${formats}" ||
 		{ reg_failure "${list_id} is only available in formats: ${formats}."; return 1; }
 
-	eval "mirrors=\"\${${list_author}_mirrors}\""
+	eval "mirrors=\"\${${feed_author}_mirrors}\""
 	is_included "${mirror}" "${mirrors}" ||
-		{ reg_failure "Unexpected mirror '${mirror}' for list author ${list_author}."; return 1; }
+		{ reg_failure "Unexpected mirror '${mirror}' for list author ${feed_author}."; return 1; }
 
-	case "${list_author}" in
+	case "${feed_author}" in
 		hagezi)
 			prefix="${base_url}"
-			raw_suffix="/wildcard/${list_name}-onlydomains.txt"
-			dnsmasq_suffix="/dnsmasq/${list_name}.txt" ;;
+			raw_suffix="/wildcard/${list_name}-onlydomains.txt" ;;
 		stevenblack)
 			prefix="${base_url}"
 			case "${list_name}" in
@@ -218,241 +193,44 @@ get_list_url()
 			case "${mirror}" in
 				oisd)
 					prefix="https://${list_name}.${base_url}"
-					raw_suffix="/domainswild2"
-					dnsmasq_suffix="/dnsmasq2" ;;
+					raw_suffix="/domainswild2" ;;
 				github)
 					prefix="${base_url}"
 					list_name="${list_name//-/_}"
-					raw_suffix="/domainswild2_${list_name}.txt"
-					dnsmasq_suffix="/dnsmasq2_${list_name}.txt"
+					raw_suffix="/domainswild2_${list_name}.txt" ;;
 			esac
 	esac
 
 	eval "suffix=\"\${${format}_suffix}\""
-	res_url="${prefix}${suffix}"
-	[ -n "${res_url}" ] || { reg_failure "Failed to construct URL for list identifier '${list_id}'."; return 1; }
+	gfu_res="${prefix}${suffix}"
+	[ -n "${gfu_res}" ] || { reg_failure "Failed to construct URL for list identifier '${list_id}'."; return 1; }
 
-	: "${raw_suffix}" "${dnsmasq_suffix}" "${hosts_suffix}"
-	export -n "${out_var}=${res_url}"
+	: "${raw_suffix}" "${hosts_suffix}"
+	export -n "${gfu_out_var}=${gfu_res}"
 }
 
-
-# JOB SCHEDULER FUNCTIONS
-
-# get current job PID
-# 1 - var name for output
-get_curr_job_pid()
+get_part_process_path()
 {
-	local __pid pid_line
-	unset_vars "${1}"
-	IFS="${_NL_}" read -r -n512 -d '' _ _ _ _ _ pid_line _ < /proc/self/status
-	__pid="${pid_line##*[^0-9]}"
-	is_uint "${__pid}" || { reg_failure "Failed to get current job PID."; return 1; }
-	export -n "${1}=${__pid}"
-}
-
-# sets var named $1 to remaining time based on $PROCESSING_TIMEOUT_S or to $IDLE_TIMEOUT_S, whichever is lower
-# if timeout is hit, returns 1
-# 1 - var name to output remaining time
-get_remaining_time()
-{
-	local ct_curr_time_cs ct_curr_time_s ct_total_time_s ct_remaining_time_s
-	export -n "${1}"=0
-
-	get_uptime_cs ct_curr_time_cs || return 1
-	ct_curr_time_s=$((ct_curr_time_cs/100))
-	ct_total_time_s=$((INITIAL_UPTIME_S-ct_curr_time_s))
-
-	ct_remaining_time_s=$((PROCESSING_TIMEOUT_S-ct_total_time_s))
-	[ "${ct_remaining_time_s}" -gt 0 ] ||
-	{
-		reg_failure "Processing timeout (${PROCESSING_TIMEOUT_S} s) for scheduler (PID: ${scheduler_pid})."
-		return 1
-	}
-
-	case "$(( IDLE_TIMEOUT_S - (ct_curr_time_s-${CT_PREV_TIME_S:-${INITIAL_UPTIME_S}}) ))" in
-		0|-*)
-			reg_failure "Idle timeout (${IDLE_TIMEOUT_S} s) for scheduler (PID: ${scheduler_pid})."
-			return 1
-	esac
-
-	case $((IDLE_TIMEOUT_S-ct_remaining_time_s)) in
-		-*) ct_remaining_time_s="${IDLE_TIMEOUT_S}"
-	esac
-
-	CT_PREV_TIME_S=${ct_curr_time_s}
-	export -n "${1}=${ct_remaining_time_s}"
-}
-
-# 1 - job PID
-# 2 - job return code
-handle_done_job()
-{
-	local me=handle_done_job \
-		done_id fail_act_msg \
-		done_pid="${1}" done_job_rv="${2}"
-	[ -n "${done_pid}" ] || { reg_failure "${me}: received empty string for PID."; return 1; }
-	[ -n "${done_job_rv}" ] || { reg_failure "${me}: received empty string instead of return code for job ${done_pid}."; return 1; }
-
-	subtract_a_from_b "${done_pid}" "${RUNNING_PIDS}" RUNNING_PIDS
-	RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT-1))
-
-	if [ "${done_job_rv}" != 0 ]
-	then
-		eval "done_id=\"\${JOB_PRINT_ID_${done_pid}}\""
-		fail_act_msg="Skipping file and continuing."
-		[ "${blockset_part_failed_action}" = "STOP" ] && fail_act_msg="blockset_part_failed_action is set to 'STOP', exiting."
-
-		reg_failure "" "Processing job (PID ${done_pid:-unknown}) for list '${done_id:-unknown}' returned error code '${done_job_rv}'." "${yellow}${fail_act_msg}${n_c}"
-		[ "${blockset_part_failed_action}" = STOP ] && return 1
-	fi
-	:
-}
-
-# 1: list types (allow|block|ipv4_block)
-schedule_jobs()
-{
-	finalize_scheduler()
-	{
-		trap ':' USR1
-		[ -n "${USR_TRIG}" ] && log_msg -yellow "" "Job scheduler is stopping on receipt of USR1 signal."
-		[ "${1}" != 0 ] && [ -n "${RUNNING_PIDS}" ] &&
-		{
-			reg_msg -yellow "" "Stopping unfinished jobs (PIDS: ${RUNNING_PIDS})."
-			kill_pids_recursive "${RUNNING_PIDS}"
-			rm -rf "${PROCESSED_PARTS_DIR}"
-		}
-		rm -f "${sched_cb_fifo}"
-		exit "${1}"
-	}
-
-	local list_type format index list_indexes \
-		remaining_time_s \
-		done_pid done_rv \
-		origin print_id \
-		scheduler_pid \
-		RUNNING_PIDS \
-		RUNNING_JOBS_CNT=0 \
-		list_types="${1:?}"
-
-	get_curr_job_pid scheduler_pid || finalize_scheduler 1
-
-	trap 'USR_TRIG=1 finalize_scheduler 1' USR1
-
-	local sched_cb_fifo="${SCHEDULE_DIR:?}/scheduler_callback_${scheduler_pid}"
-	mkfifo "${sched_cb_fifo}" &&
-	exec 3<>"${sched_cb_fifo}" || { reg_failure "Failed to create FIFO '${sched_cb_fifo}'."; finalize_scheduler 1; }
-
-	for list_type in ${list_types}
-	do
-		eval "list_indexes=\"\${proc_indexes_${list_type}}\""
-		[ -n "${list_indexes}" ] || continue
-
-		for index in ${list_indexes}
-		do
-			get_remaining_time remaining_time_s || finalize_scheduler 1
-
-			# wait for job vacancy
-			while [ "${RUNNING_JOBS_CNT}" -ge "${PARALLEL_JOBS}" ] && [ -e "${sched_cb_fifo}" ] &&
-				read -t "${remaining_time_s}" -r done_pid done_rv < "${sched_cb_fifo}"
-			do
-				get_remaining_time remaining_time_s &&
-				handle_done_job "${done_pid}" "${done_rv}" || finalize_scheduler 1
-			done
-
-			get_remaining_time remaining_time_s || finalize_scheduler 1
-
-			eval \
-				"format=\"\${FORMAT_${index}}\"" \
-				"origin=\"\${ORIGIN_${index}}\"" \
-				"print_id=\"\${PRINT_ID_${index}}\""
-			assert_set "F_schedule_jobs" format origin print_id || finalize_scheduler 1
-
-			RUNNING_JOBS_CNT=$((RUNNING_JOBS_CNT+1))
-			process_set_part "${index}" "${list_type}" "${format}" "${origin}" "${print_id}" "${scheduler_pid}" &
-
-			RUNNING_PIDS="${RUNNING_PIDS} ${!}"
-			export -n "JOB_PRINT_ID_${!}"="${print_id}"
-		done
-	done
-
-	# wait for jobs to finish and handle errors
-	get_remaining_time remaining_time_s || return 1
-	while [ "${RUNNING_JOBS_CNT}" -gt 0 ] && [ -e "${sched_cb_fifo}" ] &&
-		read -t "${remaining_time_s}" -r done_pid done_rv < "${sched_cb_fifo}"
-	do
-		get_remaining_time remaining_time_s &&
-		handle_done_job "${done_pid}" "${done_rv}" || finalize_scheduler 1
-	done
-	get_remaining_time remaining_time_s || finalize_scheduler 1
-	[ "${RUNNING_JOBS_CNT}" = 0 ] ||
-		{ reg_failure "Not all jobs are done: RUNNING_JOBS_CNT=${RUNNING_JOBS_CNT}"; finalize_scheduler 1; }
-
-	finalize_scheduler 0
+	export -n "${1:?}=${PROCESSED_PARTS_DIR:?}/part_${2:?}${INTERM_COMPR_EXT}"
 }
 
 # 1: list index
 # 2: list type (block|ipv4_block|allow)
-# 3: list format (raw|dnsmasq|hosts)
+# 3: list format (raw|hosts)
 # 4: blockset ID
 # 5: scheduler PID
 # the rest of the args passed as-is to workers
 #
 # return codes:
-# 0 - Success
-# 1 - Fatal error (stop processing)
-# 2 - Download failure
-# 3 - Processing failure
+# 0: Success
+# 1: Fatal error (stop processing)
+# 2: Download failure
+# 3: Processing failure
+# 4: Size exceeded
 # shellcheck disable=SC2317,SC2329
 process_set_part()
 {
-	finalize_job()
-	{
-		[ -n "${2}" ] && reg_failure "${me}: ${2}"
-		case "${1}" in
-			0)
-				local list_size_human stats_pad suffix_pad
-				bytes2human list_size_human "${part_size_B}" -p
-				get_pad stats_pad "${print_id}" 42
-				get_pad suffix_pad "${cnt_human}" 9
-				log_msg "Successfully processed list:    ${green}${print_id}${n_c} ${stats_pad}[ ${orange}${list_size_human}${n_c}  - ${suffix_pad}${orange}${cnt_human} entries${n_c} ]" ;;
-			*)
-				rm -f "${dest_file}" "${list_stats_file}"
-				[ "${1}" = 1 ] &&
-				{
-					if [ -n "${curr_job_pid}" ]
-					then
-						: "${print_id:=unknown}"
-						reg_failure "Fatal error in processing job (PID: ${curr_job_pid}) for list '${print_id}'."
-					else
-						reg_failure "Fatal error reported by unknown processing job."
-					fi
-
-					[ -n "${scheduler_pid}" ] && [ -d "/proc/${scheduler_pid}" ] && {
-						kill -s USR1 "${scheduler_pid}"
-						wait_on_pid "${scheduler_pid}" 5
-					}
-
-					exit 1
-				}
-		esac
-
-		printf '%s\n' "${curr_job_pid} ${1}" > "${sched_cb_fifo}"
-		exit "${1}"
-	}
-
-	dl_list() { ${UCL_CMD:?} "${1}" -O- --timeout=3 2> "${ucl_err_file}"; }
-
-	conv_dnsmasq_to_raw()
-	{
-		local conv_prefix='s~^[ \t]*(local|server|address)=/~~' conv_suffix
-		case "${1}" in
-			block) conv_suffix='s~/$~~' ;;
-			ipv4_block) conv_prefix="s~^[ \t]*bogus-nxdomain=~~" ;;
-			allow) conv_suffix='s~/#$~~'
-		esac
-		${SED_CMD} -E "${conv_prefix};${conv_suffix}" | tr '/' '\n'
-	}
+	dl_feed() { ${UCL_CMD:?} "${1}" -O- --timeout=3 2> "${ucl_err_file}"; }
 
 	conv_hosts_to_raw()
 	{
@@ -470,98 +248,126 @@ process_set_part()
 
 	case_conv() { tr 'A-Z' 'a-z'; }
 
-	local me=process_set_part \
-		curr_job_pid msg msg_mirr \
-		pad print_id_pad mirror_pad \
-		print_id origin \
-		list_path list_author mirrors mirror curr_mirror first_mirror loop_prev_mirror \
-		min_entries \
-		index="${1:?}" list_type="${2:?}" format="${3:?}" origin="${4:?}" print_id="${5:?}" scheduler_pid="${6:?}"
+	local index="${1:?}"
 
-	debug_msg "${me}: index: ${index}; list_type: ${list_type}; format: ${format}; origin: ${origin}; print_id: ${print_id}; scheduler_pid: ${scheduler_pid}"
+	local \
+		me=process_set_part \
+		\
+		feed_author \
+		feed_path \
+		\
+		part_cnt \
+		cnt_human \
+		part_size_B \
+		part_size_human \
+		stats_pad \
+		suffix_pad \
+		\
+		min_part_entries_human \
+		fetch_cmd \
+		\
+		pipeline_rv \
+		pipeline_msg \
+		ucl_err \
+		\
+		mirrors \
+		mirror \
+		cur_mirror \
+		first_mirror \
+		loop_prev_mirror \
+		msg_mirr \
+		\
+		msg \
+		pad \
+		print_id_pad \
+		mirror_pad \
+		\
+		ucl_err_file="${ABL_TMP_DIR}/ucl_err_${index}" \
+		rogue_el_file="${ABL_TMP_DIR}/rogue_el_${index}" \
+		part_compr_or_cat="${INTERM_COMPR_OR_CAT_STDOUT:?}"
 
-	get_curr_job_pid curr_job_pid || finalize_job 1
+	# vars set by the scheduler
+	assert_set "F_${me}" \
+		format \
+		origin \
+		print_id \
+		dest_file \
+		part_stats_file \
+		is_ipv4 \
+		max_download_attempts \
+		max_part_size \
+		min_part_entries || return 1
 
-	eval "min_entries=\"\${min_${list_type}_part_entries}\""
-
-	list_path="${print_id}"
+	debug_msg "${me}: scheduler_pid: ${SCHEDULER_PID}; index: ${index}; format: ${format}; origin: ${origin}; print_id: ${print_id}; dest_file: ${dest_file}; stats_file: ${part_stats_file}; is_ipv4: ${is_ipv4}; max_part_size: ${max_part_size}"
 
 	if [ "${origin}" = DL ] &&
-		list_author="${print_id%:*}" &&
-		case "${list_author}" in
+		feed_author="${print_id%:*}" &&
+		case "${feed_author}" in
 			hagezi|oisd|stevenblack) : ;;
 			*) false
 		esac
 	then
-		eval "mirrors=\"\${${list_author}_mirrors}\"" &&
+		eval "mirrors=\"\${${feed_author}_mirrors}\"" &&
 		trim_spaces mirrors &&
 		[ -n "${mirrors}" ] &&
 		first_mirror="${mirrors%% *}" &&
-		[ -n "${first_mirror}" ] || finalize_job 1 "Failed to process download mirrors for list author ${list_author}."
+		[ -n "${first_mirror}" ] || { reg_failure "Failed to process download mirrors for list author ${feed_author}."; return 1; }
 
-		eval "curr_mirror=\"\${${list_author}_default_mirror}\""
-		: "${curr_mirror:="${first_mirror}"}"
+		eval "cur_mirror=\"\${${feed_author}_default_mirror}\""
+		: "${cur_mirror:="${first_mirror}"}"
 	fi
 
-	local dest_file="${PROCESSED_PARTS_DIR}/${list_type}_${index}${INTERM_COMPR_EXT}" \
-		ucl_err_file="${ABL_TMP_DIR}/ucl_err_${index}" \
-		rogue_el_file="${ABL_TMP_DIR}/rogue_el_${index}" \
-		list_stats_file="${ABL_TMP_DIR}/${index}_stats" \
-		part_cnt cnt_human min_entries_human \
-		part_size_B retry=1 \
-		fetch_cmd \
-		part_compr_or_cat="${INTERM_COMPR_OR_CAT_STDOUT:?}" \
-		format_conv_or_cat="${CAT_CMD:?}" \
-		case_conv_or_cat="${CAT_CMD:?}" \
-		pipeline_msg ucl_err pipeline_rv
-
 	case "${origin}" in
-		DL) fetch_cmd=dl_list ;;
+		DL) fetch_cmd=dl_feed ;;
 		LOCAL) fetch_cmd="${CAT_CMD:?}" ;;
-		*) finalize_job 1 "Invalid list origin '${origin}'."
+		*) reg_failure "Invalid list origin '${origin}'."; return 1
 	esac
 
-	case "${list_type}" in
-		allow|block) val_entry_regex='^[[:alnum:]-]+$|^(\*|[[:alnum:]_-]+)([.][[:alnum:]_-]+)+$' ;;
-		ipv4_block) val_entry_regex='^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])$' ;;
-		*) finalize_job 1 "Invalid list type '${list_type}'"
-	esac
+	local \
+		format_conv_or_cat="${CAT_CMD:?}" \
+		case_conv_or_cat="case_conv" \
+		val_entry_regex='^[[:alnum:]-]+$|^(\*|[[:alnum:]_-]+)([.][[:alnum:]_-]+)+$'
 
-	case "${format}" in
-		dnsmasq|hosts) format_conv_or_cat="conv_${format}_to_raw ${list_type}"
-	esac
+	[ "${format}" = hosts ] &&
+		format_conv_or_cat="conv_hosts_to_raw"
 
-	case "${list_type}" in
-		allow|block) case_conv_or_cat="case_conv"
-	esac
+	if [ "${is_ipv4}" = 1 ]
+	then
+		case_conv_or_cat="${CAT_CMD:?}"
+		val_entry_regex='^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])$'
+	fi
 
+	local prev_mirror attempt=1
 	while :
 	do
-		# use forced mirror for this list author if set
-		if [ "${origin}" = DL ] && [ -n "${list_author}" ]
+		feed_path="${print_id}"
+		if [ "${origin}" = DL ] && [ -n "${feed_author}" ]
 		then
-			read_str_from_file -v curr_mirror -f "${SCHEDULE_DIR}/${list_author}-forced-mirror" -a 1 -q -n 128 -V "${curr_mirror}"
-			get_list_url list_path "${print_id}" "${format}" "${curr_mirror}" || finalize_job 1
+			prev_mirror="${cur_mirror}"
+			read_str_from_file -v cur_mirror -f "${PROCESSED_PARTS_DIR}/${feed_author}-forced-mirror" -a 1 -q -n 128 ||
+				cur_mirror="${prev_mirror}"
+			# Get URL, taking into account forced mirror for this feed author if set
+			get_feed_url feed_path "${print_id}" "${format}" "${cur_mirror}" || return 1
 		fi
 
-		get_pad mirror_pad "${curr_mirror}" 8
+		get_pad mirror_pad "${cur_mirror}" 8
 		msg_mirr=
-		[ -n "${curr_mirror}" ] && msg_mirr=" [   mirror: ${curr_mirror}${mirror_pad} ]"
+		[ -n "${cur_mirror}" ] && msg_mirr=" [   mirror: ${cur_mirror}${mirror_pad} ]"
 
-		rm -f "${rogue_el_file}" "${list_stats_file}" "${ucl_err_file}"
+		rm -f "${rogue_el_file}" "${part_stats_file}" "${ucl_err_file}"
 
-		msg="Processing ${format} ${list_type}list"
+		msg="Processing ${format} blockset part"
 		get_pad pad "${msg}" 30
 		get_pad print_id_pad "${print_id}" 42
 
 		reg_msg "${msg}: ${pad}${lblue}${print_id}${n_c}${msg_mirr:+"${print_id_pad}"}${msg_mirr}"
 
-		# Download or cat the list
-		${fetch_cmd} "${list_path}" |
+		# Download or cat the part
+		${fetch_cmd} "${feed_path}" |
 
 		# Limit size
 		{
-			head -c "${max_part_size_KB:?}k"
+			head -c "${max_part_size:?}k"
 			if read -rn1 -d ''
 			then cat 1>/dev/null; false
 			else :
@@ -571,11 +377,11 @@ process_set_part()
 		# Remove comment lines and trailing comments, remove whitespaces
 		${SED_CMD} 's/#.*$//; s/^[ \t]*//; s/[ \t]*$//; /^$/d' |
 
-		# Convert dnsmasq format to raw format
+		# Convert hosts to raw format
 		${format_conv_or_cat} |
 
 		# Count bytes and entries
-		tee >(wc -wc > "${list_stats_file}") |
+		tee >(wc -wc > "${part_stats_file}") |
 
 		# Convert to lowercase
 		${case_conv_or_cat} |
@@ -589,22 +395,18 @@ process_set_part()
 		pipeline_rv=${?}
 
 		# read stats
-		read_str_from_file -v "part_cnt part_size_B _" -f "${list_stats_file}" -a 2 -D "list stats" || finalize_job 1
+		read_str_from_file -n 64 -v "part_cnt part_size_B _" -f "${part_stats_file}" -a 2 -D "list stats" || return 1
 
 		# size-exceeded check
-		if ! [ $(( 1 + part_size_B / 1024)) -lt "${max_part_size_KB}" ]
-		then
-			reg_failure "" "Size of blockset part '${print_id}' reached the maximum value set in config (${max_part_size_KB} KB)."
-			log_msg "Consider either increasing this value in the config or removing the corresponding blockset part identifier or URL from config."
-			finalize_job 2
-		fi
+		[ $(( part_size_B <= max_part_size*1024 )) = 1 ] ||
+			return 4
 
 		if [ "${pipeline_rv}" = 0 ]
 		then
 			# rogue elements check
 			if [ -s "${rogue_el_file}" ]
 			then
-				read_str_from_file -d -n 512 -v "rogue_element" -f "${rogue_el_file}" -a 2 -D "rogue element"
+				read_str_from_file -d -n 512 -F "" -v "rogue_element" -f "${rogue_el_file}" -q -a 2 -D "rogue element"
 				local rogue_el_print
 				if [ -n "${rogue_element}" ]
 				then
@@ -613,25 +415,24 @@ process_set_part()
 					rogue_el_print="Unknown rogue element"
 				fi
 
-				case "${rogue_element}" in *"${CR_LF}"*)
-					log_msg -warn "blockset part '${print_id}' contains Windows-format (CR LF) newlines." \
-						"This file needs to be converted to Unix newline format (LF)."
-						finalize_job 3 ;;
+				case "${rogue_element}" in *"${CR}"*)
+					log_msg -warn "blockset part '${print_id}' contains Non-Unix (CR) newlines." \
+						"This file needs to be converted to Unix newline style (LF)."
+						return 3 ;;
 				esac
 
 				log_msg -warn "${rogue_el_print} identified in blockset part '${print_id}'."
-				[ -n "${rogue_element}" ] || finalize_job 3
+				[ -n "${rogue_element}" ] || return 3
 			fi
 
-			# min_entries check
-			int2human cnt_human "${part_cnt}" || finalize_job 1    # ${cnt_human} also used in finalize_job()
-
+			# min_part_entries check
+			int2human cnt_human "${part_cnt}" &&
 			local lines_cnt_low=
-			if [ "${origin}" = DL ] && [ "${part_cnt}" -lt "${min_entries}" ]
+			if [ "${origin}" = DL ] && [ "${part_cnt}" -lt "${min_part_entries}" ]
 			then
 				lines_cnt_low=1
-				int2human min_entries_human "${min_entries}" || finalize_job 1
-				reg_failure "Entries count in downloaded blockset part '${print_id}' is ${cnt_human}, which is less than configured minimum: ${min_entries_human}."
+				int2human min_part_entries_human "${min_part_entries}" || return 1
+				reg_failure "Entries count in downloaded blockset part '${print_id}' is ${cnt_human}, which is less than configured minimum: ${min_part_entries_human}."
 			fi
 		fi
 
@@ -651,63 +452,174 @@ process_set_part()
 		elif [ "${pipeline_rv}" != 0 ]
 		then
 			reg_failure "" "${pipeline_msg}"
-			finalize_job 1
+			return 1
 		else
+			bytes2human part_size_human "${part_size_B}" -p
+			get_pad stats_pad "${print_id}" 42
+			get_pad suffix_pad "${cnt_human}" 9
+			log_msg "Successfully processed part:    ${green}${print_id}${n_c} ${stats_pad}[ ${orange}${part_size_human}${n_c}  - ${suffix_pad}${orange}${cnt_human} entries${n_c} ]"
+
 			rm -f "${ucl_err_file}"
 			# set this mirror as forced if this is not the first DL attempt
-			[ "${origin}" = DL ] && [ -n "${list_author}" ] && [ "${retry}" != 1 ] &&
-				printf '%s\n' "${curr_mirror}" > "${SCHEDULE_DIR}/${list_author}-forced-mirror"
-			finalize_job 0
+			[ "${origin}" = DL ] && [ -n "${feed_author}" ] && [ "${attempt}" != 1 ] &&
+				printf '%s\n' "${cur_mirror}" > "${PROCESSED_PARTS_DIR}/${feed_author}-forced-mirror"
+			return 0
 		fi
 
-		retry=$((retry + 1))
-		if [ "${retry}" -gt "${max_download_retries}" ]
+		attempt=$((attempt + 1))
+		if [ ! "${attempt}" -le "${max_download_attempts}" ]
 		then
-			finalize_job 2 "${max_download_retries} download attempts failed for list '${print_id}'."
+			reg_failure "${max_download_attempts} download attempts failed for list '${print_id}'."
+			return 2
 		fi
 
 		log_msg -yellow "" "Processing job for list '${print_id}' is sleeping for 5 seconds after failed download attempt."
 		sleep 5 &
 		wait ${!}
 
-		if [ "${origin}" = DL ] && [ -n "${list_author}" ]
+		if [ "${origin}" = DL ] && [ -n "${feed_author}" ]
 		then
 			# cycle to the next mirror
 			next_mirror='' loop_prev_mirror=''
 			for mirror in ${mirrors}
 			do
-				[ "${loop_prev_mirror}" = "${curr_mirror}" ] && { next_mirror="${mirror}"; break; }
+				[ "${loop_prev_mirror}" = "${cur_mirror}" ] && { next_mirror="${mirror}"; break; }
 				loop_prev_mirror="${mirror}"
 			done
-			curr_mirror="${next_mirror:-"${first_mirror}"}"
+			cur_mirror="${next_mirror:-"${first_mirror}"}"
 		fi
 	done
 }
 
+part_size_exceeded()
+{
+	reg_failure "Size of blockset part '${1}' exceeded the maximum value set in config option 'max_part_size_KB' (${2} KB)."
+	log_msg "Consider either increasing this value in the blockset config or removing the corresponding blockset part identifier or URL from same config."
+}
+
+# shellcheck disable=SC2329
 gen_set_parts()
 {
+	processing_done_cb()
+	{
+		local \
+			index \
+			failed \
+			dest_file \
+			part_stats_file \
+			fail_jobs="${4}" \
+			unfinished_jobs="${5}" \
+			undispatched_jobs="${6}" \
+			expired_jobs="${7}" \
+			aborted_jobs="${8}"
+
+		[ "${?}" = 0 ] || return ${?}
+
+		failed="${fail_jobs}${unfinished_jobs}${undispatched_jobs}${expired_jobs}${aborted_jobs}"
+
+		[ -z "${failed}" ] && return 0
+
+		for index in ${failed}
+		do
+			job_get_params "${index}" part_stats_file dest_file || return 1
+			rm -f "${dest_file}"
+			printf 'FAIL 0\n' > "${part_stats_file}"
+		done
+
+		return 0
+	}
+
+	part_done_cb()
+	{
+		local indexes abort_sets set_id \
+			abort_indexes abort_sets \
+			index="${1}" rv="${2}"
+
+		# vars delivered by the scheduler
+		assert_set F_part_done_cb print_id dest_file part_stats_file max_part_size || exit 1
+
+		[ "${rv}" = 0 ] ||
+			rm -f "${dest_file}" "${part_stats_file}"
+
+		case "${rv}" in
+			0) return 0 ;;
+			1)
+				if [ -n "${print_id}" ]
+				then
+					reg_failure "Fatal error in processing job for list '${print_id}'."
+				else
+					reg_failure "Fatal error reported by unknown processing job."
+				fi
+				return 1
+		esac
+
+		if [ "${rv}" = 4 ]
+		then
+			part_size_exceeded "${print_id}" "${max_part_size}"
+		else
+			reg_failure "" "Processing job for list '${print_id:-unknown}' returned error code '${rv}'."
+		fi
+
+		for set_id in ${PROC_SET_IDS}
+		do
+			eval "indexes=\"\${set_indexes_${set_id}}\""
+			is_included "${index}" "${indexes}" || continue
+			[ "${blockset_part_failed_action}" = STOP ] &&
+			{
+				abl_append abort_sets "${set_id}"
+				add2list abort_indexes "${indexes}"
+				continue
+			}
+		done
+
+		[ -n "${abort_sets}" ] &&
+		{
+			log_msg -ob "${abort_sets}" "" "blockset_part_failed_action is set to 'STOP'. Stopping processing{}."
+			jobs_abort ${abort_indexes}
+		}
+
+		return 0
+	}
+
 	# shellcheck disable=SC2034
-	local INITIAL_UPTIME_S="${1:?}" list_types="${2:-"${ALL_LIST_TYPES}"}"
+	SCHEDULER_PID=
+	local part_type part_indexes index indexes \
+		set_ids="${1:?}"
+
+	assert_set F_gen_set_parts ALL_PART_TYPES || return 1
 
 	# clean up before processing
-	rm -rf "${PROCESSED_PARTS_DIR}" "${SCHEDULE_DIR}"
+	rm -rf "${PROCESSED_PARTS_DIR}"
 
-	try_mkdir -p "${SCHEDULE_DIR}" &&
 	try_mkdir -p "${PROCESSED_PARTS_DIR}" || return 1
 
 	reg_action -1 -purple "" "Downloading and processing blockset parts (max parallel jobs: ${PARALLEL_JOBS})."
 
 	# Asynchronously download and process parts, allowlist must be processed separately and first
-	schedule_jobs "${list_types}" &
+	for part_type in ${ALL_PART_TYPES}
+	do
+		eval "part_indexes=\"\${indexes_${part_type}}\""
+		[ -n "${part_indexes}" ] || continue
+		abl_append indexes "${part_indexes}"
+	done
+
+	DO_JOB_CB=process_set_part \
+	JOB_DONE_CB=part_done_cb \
+	SCHED_FINALIZE_CB=processing_done_cb \
+	SCHED_FAIL_MSG_CB=reg_failure \
+	SCHED_MAX_JOBS="${PARALLEL_JOBS}" \
+	SCHED_TIMEOUT_S=900 \
+	SCHED_IDLE_TIMEOUT_S=500 \
+	SCHED_JOB_TIMEOUT_S=300 \
+	SCHED_AUTO_JOB_TERM=1 \
+		schedule_jobs "${indexes}" &
+
 	SCHEDULER_PID=${!}
 
 	wait "${SCHEDULER_PID}"
 	local sched_rv=${?}
 	SCHEDULER_PID=
-	[ ${sched_rv} = 0 ] || return ${sched_rv}
-
-	reg_msg -green "" "Successfully generated preprocessed blockset files."
-	:
+	return ${sched_rv}
 }
 
 gen_blocksets()
@@ -715,13 +627,14 @@ gen_blocksets()
 	local \
 		me=gen_blocksets \
 		IFS="${DEFAULT_IFS}" \
-		processed_bl_file \
+		processed_set_file \
+		part \
 		set_id \
 		run_state \
-		curr_path \
-		curr_cnt \
-		curr_persist_path \
-		curr_persist_cnt \
+		cur_path \
+		cur_cnt \
+		cur_persist_path \
+		cur_persist_cnt \
 		conn_check_req \
 		skip_load_stop \
 		file_to_bk \
@@ -734,20 +647,17 @@ gen_blocksets()
 		install_path \
 		totalmem \
 		TESTED_URLS \
+		SCHED_ID=process \
 		\
 		raw_block_lists \
-		dnsmasq_block_lists\
 		hosts_block_lists \
-		local_list \
+		local_part \
 		\
-		all_process_lists \
-		dl_lists \
-		\
-		list_type format \
-		proc_index=0 \
+		part_type \
+		format \
+		index=0 \
 		set_indexes \
-		proc_set_ids \
-		blocksets_out_var="${1:?}" set_ids="${2:?}" initial_uptime_cs="${3:?}"
+		blocksets_out_var="${1:?}" set_ids="${2:?}"
 
 	: "${skip_load_stop}" "${bk_cnt}"
 
@@ -756,7 +666,7 @@ gen_blocksets()
 	if [ "${force_unload}" = auto ]
 	then
 		read -r _ totalmem _ < /proc/meminfo
-		if is_uint "${totalmem}" && [ "${totalmem}" -ge 410000 ]
+		if is_gr_eq 410000 "${totalmem}"
 		then
 			force_unload=0
 		else
@@ -768,19 +678,17 @@ gen_blocksets()
 	local no_local_found_msgs
 	for set_id in ${set_ids}
 	do
-		for list_type in ${ALL_LIST_TYPES}
+		for part_type in ${ALL_PART_TYPES}
 		do
-			for format in ${ALL_LIST_FORMATS:?}
-			do
-				[ "${format}" = raw ] &&
-				[ "${list_type}" != ipv4_block ] || continue
-				eval "local_list=\"\${local_${list_type}list_path_${set_id}}\""
-				{ [ -n "${local_list}" ] && [ -f "${local_list}" ]; } ||
-				{
-					export -n "local_${list_type}list_path_${set_id}="
-					no_local_found_msgs="${no_local_found_msgs}${no_local_found_msgs:+"${_NL_}"}${set_id}:No local ${list_type}list identified{}."
-				}
-			done
+			get_params "${set_id}" \
+				"local_part=local_${part_type}list_path"
+
+			{ [ -n "${local_part}" ] && [ -f "${local_part}" ]; } ||
+			{
+				export -n "local_${part_type}list_path_${set_id}="
+				abl_append no_local_found_msgs "${set_id}:No local ${part_type}list file found{}." "${_NL_}"
+			}
+
 		done
 	done
 
@@ -797,25 +705,30 @@ gen_blocksets()
 		IFS="${DEFAULT_IFS}"
 	}
 
-	for format in ${ALL_LIST_FORMATS:?}
+	local dl_parts
+	for format in ${ALL_PART_FORMATS:?}
 	do
-		local "all_process_lists_${format}="
-		for list_type in ${ALL_LIST_TYPES}
+		local "all_process_parts_${format}="
+
+		for part_type in ${ALL_PART_TYPES}
 		do
-			local "proc_indexes_${list_type}="
+			local "indexes_${part_type}="
+
+			# hosts-format is only valid for type 'block'
+			[ "${format}" = hosts ] && [ "${part_type}" != block ] && continue
 
 			for set_id in ${set_ids}
 			do
 				local "set_indexes_${set_id}="
+				get_params "${set_id}" \
+					"dl_parts=${format}_${part_type}_lists" \
+					"local_part=local_${part_type}list_path"
 
-				local_list=
-				eval "dl_lists=\"\${${format}_${list_type}_lists_${set_id}}\""
-				[ "${format}" = raw ] && eval "local_list=\"\${local_${list_type}list_path_${set_id}}\""
-				[ -n "${dl_lists}${local_list}" ] || continue
+				[ -n "${dl_parts}${local_part}" ] || continue
 
-				[ -n "${dl_lists}" ] &&
+				[ -n "${dl_parts}" ] &&
 				{
-					invalid_urls="$(printf %s "${dl_lists}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
+					invalid_urls="$(printf %s "${dl_parts}" | tr ' ' '\n' | grep -E '^(http[s]*://)*(www\.)*github\.com')" &&
 					{
 						reg_failure "Invalid URLs detected:" "${invalid_urls}"
 						return 1
@@ -823,15 +736,14 @@ gen_blocksets()
 
 					[ "${format}" = raw ] &&
 					{
-						bad_hagezi_urls="$(printf %s "${dl_lists}" | tr ' ' '\n' | grep '/hagezi/.*/dnsmasq/')" &&
+						bad_hagezi_urls="$(printf %s "${dl_parts}" | tr ' ' '\n' | grep '/hagezi/.*/dnsmasq/')" &&
 						{
-							reg_failure "Following Hagezi URLs are in dnsmasq format and should be either changed to raw list URLs" \
-								"or moved to one of the 'dnsmasq_' config entries:" "${bad_hagezi_urls}"
+							reg_failure "Following Hagezi lists are in dnsmasq format and should be changed to raw-format lists:" "${bad_hagezi_urls}"
 							return 1
 						}
-						case "${list_type}" in block|allow)
+						case "${part_type}" in block|allow)
 							bad_hagezi_urls="$(
-								printf %s "${dl_lists}" |
+								printf %s "${dl_parts}" |
 								tr ' ' '\n' |
 								${SED_CMD} -En '/(raw.githubusercontent.com\/hagezi\/dns-blocklists\/|gitlab.com\/hagezi\/mirror\/)/{/onlydomains\./d;p;}'
 							)"
@@ -845,81 +757,129 @@ gen_blocksets()
 					}
 				}
 
-				for list in ${dl_lists}
+				for part in ${dl_parts}
 				do
-					add2list "all_process_lists_${format}" "${list}" "${_NL_}"
+					add2list "all_process_parts_${format}" "${part}" "${_NL_}"
 				done
-				[ -n "${local_list}" ] && add2list "all_process_lists_${format}" "local=${local_list}" "${_NL_}"
+				[ -n "${local_part}" ] && add2list "all_process_parts_${format}" "local=${local_part}" "${_NL_}"
 			done
 		done
 	done
 
+	local \
+		PROC_SET_IDS \
+		all_process_parts \
+		max_part_size \
+		max_part_size_prev \
+		min_part_entries \
+		min_part_entries_prev \
+		is_ipv4 \
+		is_ipv4_prev
 
-	for format in ${ALL_LIST_FORMATS:?}
+	for format in ${ALL_PART_FORMATS:?}
 	do
-		eval "all_process_lists=\"\${all_process_lists_${format}}\""
-		[ -n "${all_process_lists}" ] || continue
+		eval "all_process_parts=\"\${all_process_parts_${format}}\""
+		[ -n "${all_process_parts}" ] || continue
 
-		debug_msg "all_process_lists_${format}: '${all_process_lists}'"
+		debug_msg "all_process_parts_${format}: '${all_process_parts}'"
 
 		IFS="${_NL_}"
-		for list in ${all_process_lists}
+		for part in ${all_process_parts}
 		do
-			[ -n "${list}" ] || continue
+			[ -n "${part}" ] || continue
+
 			IFS="${DEFAULT_IFS}"
-			proc_index=$((proc_index+1))
-			export -n "INDEX_REFS_${proc_index}="
+			index=$((index+1))
+			export -n "INDEX_REFS_${index}="
 
 			origin=DL
-			case "${list}" in local=*)
+			case "${part}" in local=*)
 				origin=LOCAL
 			esac
-			export -n \
-				"FORMAT_${proc_index}=${format}" \
-				"ORIGIN_${proc_index}=${origin}" \
-				"PRINT_ID_${proc_index}=${list#"local="}"
 
-			for list_type in ${ALL_LIST_TYPES:?}
+			get_part_process_path dest_file "${index}"
+			job_set_params "${index}" \
+				"format=${format}" \
+				"origin=${origin}" \
+				"print_id=${part#"local="}" \
+				"dest_file=${PROCESSED_PARTS_DIR}/part_${index}${INTERM_COMPR_EXT}" \
+				"part_stats_file=${PROCESSED_PARTS_DIR}/${index}_stats"
+
+			for part_type in ${ALL_PART_TYPES:?}
 			do
+				# hosts-format is only valid for type 'block'
+				[ "${format}" = hosts ] && [ "${part_type}" != block ] && continue
+
+				case "${part_type}" in
+					ipv4_*) is_ipv4=1 ;;
+					*) is_ipv4=0 ;;
+				esac
+				eval "min_part_entries=\"\${min_${part_type}_part_entries}\""
+				assert_set "F_${me}" min_part_entries || return 1
+
 				for set_id in ${set_ids}
 				do
-					eval "dl_lists=\"\${${format}_${list_type}_lists_${set_id}}\""
-					eval "local_list=\"\${local_${list_type}list_path_${set_id}}\""
-					[ -n "${dl_lists}${local_list}" ] || continue
+					get_params "${set_id}" \
+						max_part_size \
+						"dl_parts=${format}_${part_type}_lists" \
+						"local_part=local_${part_type}list_path"
 
-					is_included "${list}" "${dl_lists}" ||
-					{ [ -n "${local_list}" ] && [ "${list}" = "local=${local_list}" ]; } ||
+					[ -n "${dl_parts}${local_part}" ] || continue
+
+					is_included "${part}" "${dl_parts}" ||
+					{ [ -n "${local_part}" ] && [ "${part}" = "local=${local_part}" ]; } ||
 						continue
 
-					add2list "INDEX_REFS_${proc_index}" "${set_id}"
-					add2list "proc_indexes_${list_type}" "${proc_index}"
-					add2list proc_set_ids "${set_id}"
-					add2list "set_indexes_${set_id}" "${proc_index}"
-					export -n "TYPE_${set_id}_${proc_index}=${list_type}"
+					# min_part_entries may be different if same feed is used as allow- in one blockset but as block- in another
+					job_get_params "${index}" \
+						"max_part_size_prev=max_part_size" \
+						"min_part_entries_prev=min_part_entries" \
+						"is_ipv4_prev=is_ipv4"
+
+					[ -n "${is_ipv4_prev}" ] && [ "${is_ipv4}" != "${is_ipv4_prev}" ] &&
+						{ reg_failure "Blockset part '${part#"local="}' is specified as both ipv4 and not."; return 1; }
+
+					[ -n "${min_part_entries_prev}" ] &&
+					[ "${min_part_entries_prev}" -lt "${min_part_entries}" ] &&
+						min_part_entries=${min_part_entries_prev}
+
+					[ -n "${max_part_size_prev}" ] &&
+					[ "${max_part_size_prev}" -gt "${max_part_size}" ] &&
+						max_part_size=${max_part_size_prev}
+
+					job_set_params "${index}" \
+						"max_part_size=${max_part_size}" \
+						"min_part_entries=${min_part_entries}" \
+						"is_ipv4=${is_ipv4}" \
+						"part_type_${set_id}=${part_type}"
+
+					abl_append "indexes_${part_type}" "${index}"
+					abl_append "set_indexes_${set_id}" "${index}"
+					add2list "INDEX_REFS_${index}" "${set_id}"
+					add2list PROC_SET_IDS "${set_id}"
 				done
 			done
 		done
 		IFS="${DEFAULT_IFS}"
 	done
 
-	[ -n "${proc_set_ids}" ] || { reg_failure "Nothing to process."; return 1; }
+	[ -n "${PROC_SET_IDS}" ] || { reg_failure "Nothing to process."; return 1; }
 
 	for set_id in ${set_ids}
 	do
-		is_included "${set_id}" "${proc_set_ids}" || { reg_failure -fb "${set_id}" "Nothing to process{}."; continue; }
+		is_included "${set_id}" "${PROC_SET_IDS}" || { reg_failure -fb "${set_id}" "Nothing to process{}."; continue; }
 		debug_msg "Processing bockset ${set_id}."
 		get_params -f "${me}" "${set_id}" run_state || return 1
 		get_params "${set_id}" \
-			curr_path \
-			curr_cnt \
-			curr_persist_path \
-			curr_persist_cnt \
+			cur_path \
+			cur_cnt \
+			cur_persist_path \
+			cur_persist_cnt \
 			bk_ext \
 			raw_block_lists \
-			dnsmasq_block_lists\
 			hosts_block_lists
 
-		[ -n "${raw_block_lists}${dnsmasq_block_lists}${hosts_block_lists}" ] ||
+		[ -n "${raw_block_lists}${hosts_block_lists}" ] ||
 			log_msg -yellow "" "NOTE: No URLs specified for blocklist download."
 
 		skip_load_stop=
@@ -934,7 +894,7 @@ gen_blocksets()
 
 		[ "${force_unload_bl}" = 1 ] ||
 		[ -z "${conn_check_req}" ] ||
-		test_url_domains "${set_id}" ||
+		test_fetch_doms "${set_id}" ||
 			force_unload_bl=1
 
 		[ "${force_unload_bl}" = 1 ] &&
@@ -944,14 +904,14 @@ gen_blocksets()
 
 		bk_file=
 		file_to_bk=
-		if [ -n "${curr_path}" ]
+		if [ -n "${cur_path}" ]
 		then
-			file_to_bk=${curr_path}
-			bk_cnt=${curr_cnt}
-		elif [ -n "${curr_persist_path}" ]
+			file_to_bk=${cur_path}
+			bk_cnt=${cur_cnt}
+		elif [ -n "${cur_persist_path}" ]
 		then
-			file_to_bk=${curr_persist_path}
-			bk_cnt=${curr_persist_cnt}
+			file_to_bk=${cur_persist_path}
+			bk_cnt=${cur_persist_cnt}
 		fi
 
 		if [ -n "${file_to_bk}" ] &&
@@ -961,7 +921,7 @@ gen_blocksets()
 		is_dir_writable "${set_id}" "${file_to_bk%/*}"
 		then
 			bk_file="${BK_SET_BASE_PATH:?}-${set_id}${bk_ext}"
-			reg_action -fb "${set_id}" "Creating backup of current blockset file{}." &&
+			reg_action -fb "${set_id}" "" "Creating backup of current blockset file{}." &&
 			mv_blockset "${file_to_bk}" "${bk_file}" "${INTERM_COMPR_TO_FILE}" "${set_id}" ||
 			{
 				reg_failure "Failed to create backup of current blockset file '${file_to_bk}'."
@@ -974,35 +934,35 @@ gen_blocksets()
 			# for persistent blockset in 'manual' mode, the original file is used as a backup
 			bk_file="${file_to_bk}"
 		else
-			reg_msg -2 -fb "${set_id}" "No existing blockset file found{}."
+			reg_msg -2 -fb "${set_id}" "" "No existing blockset file found{}."
 		fi
 		set_params "${set_id}" bk_file bk_cnt
 	done
 
-	KEEP_BK=1 KEEP_PERSIST=0 rm_blocksets "${proc_set_ids}"
-	[ -z "${blocksets_to_stop}" ] || KEEP_BK=1 KEEP_PERSIST=0 do_stop "${blocksets_to_stop}" || return 1
+	KEEP_BK=1 KEEP_PERSIST=0 rm_blocksets "${PROC_SET_IDS}"
+	[ -z "${blocksets_to_stop}" ] || KEEP_BK=1 KEEP_PERSIST=0 do_stop "${blocksets_to_stop}" || exit 1
 
-	gen_set_parts "$(( ${initial_uptime_cs:?} / 100 ))" ||
+	gen_set_parts "${set_ids}" ||
 	{
 		reg_failure "Failed to generate blockset parts."
 		return 1
 	}
 
-	for set_id in ${proc_set_ids}
+	for set_id in ${PROC_SET_IDS}
 	do
 		eval "set_indexes=\"\${set_indexes_${set_id}}\""
 		get_params -f "${me}" "${set_id}" install_path || return 1
 		get_params "${set_id}" final_compr_ext
 
-		processed_bl_file="${ABL_TMP_DIR}/processed-${set_id}${final_compr_ext}"
+		processed_set_file="${ABL_TMP_DIR}/processed-${set_id}${final_compr_ext}"
 
-		if gen_blockset "${set_id}" "${processed_bl_file}" "${set_indexes}" &&
-			try_mv "${processed_bl_file}" "${install_path}"
+		if gen_blockset "${set_id}" "${processed_set_file}" "${set_indexes}" &&
+			try_mv "${processed_set_file}" "${install_path}"
 		then
 			add2list "${blocksets_out_var}" "${set_id}"
 			debug_msg "install_path: ${install_path};"
 		else
-			rm -f "${processed_bl_file}"
+			rm -f "${processed_set_file}"
 			reg_failure -fb "${set_id}" "Failed to generate new blockset file{}."
 		fi
 	done
@@ -1069,37 +1029,28 @@ gen_blockset()
 			END {print A "\n"}'
 	}
 
-	# 1 - blockset ID
-	# 2 - extension incl '.'
-	# 2 - list type (block|ipv4_block)
-	# 3 - decompression command or 'cat'
+	# 1 - part indexes
 	print_set_parts()
 	{
-		print_file_cb()
-		{
-			${PART_EXTR_OR_CAT_STDOUT:?} "${1}"
-			local index_refs rv=${?}
+		local index index_refs part_file \
+			indexes="${1:?}"
 
+		for index in ${indexes}
+		do
+			get_part_process_path part_file "${index}"
+			${PART_EXTR_OR_CAT_STDOUT:?} "${part_file}"
+			rv=${?}
 			eval "index_refs=\"\${INDEX_REFS_${index}}\""
 			[ -z "${index_refs}" ] && rm -f "${1}"
-			return "${rv}"
-		}
-
-		local index \
-			list_type="${1:?}" set_id="${2:?}" set_indexes="${3:?}"
-
-		for index in ${set_indexes}
-		do
-			FF_EXEC="print_file_cb {}" \
-				find_files _ "${PROCESSED_PARTS_DIR}" "${list_type}_${index}" "" "${INTERM_COMPR_EXT}" "${set_id}" && printed=1
+			[ ${rv} = 0 ] || { printf ''; reg_failure "Failed command: '${PART_EXTR_OR_CAT_STDOUT:?} ${part_file}'."; return 1; }
 		done
-		[ -n "${printed}" ] || printf ''
 	}
 
 	local me=gen_blockset \
 		install_path \
-		min_good_entries min_good_entries_human \
-		max_blockset_file_size_KB \
+		min_entries min_entries_human \
+		max_part_size \
+		max_set_size \
 		errors \
 		dedup_cmd_or_cat="${CAT_CMD:?}" \
 		allow_filter_or_cat="${CAT_CMD:?}" \
@@ -1107,7 +1058,8 @@ gen_blockset()
 		final_compr_or_cat_stdout \
 		install_1_instance \
 		use_allowlist use_ipv4_blocklist \
-		merged_allow_f="${PROCESSED_PARTS_DIR}/allow" \
+		merged_allow_f \
+		proc_dir \
 		test_domains \
 		whitelist_mode \
 		\
@@ -1115,12 +1067,18 @@ gen_blockset()
 		out_f="${2:?}" \
 		set_indexes="${3:?}"
 
+	proc_dir="${ABL_TMP_DIR}/process-${set_id}"
+	merged_allow_f="${proc_dir}/allow"
+
+	rm -rf "${proc_dir}"
+
 	reg_action -purple -fb "${set_id}" "" "Generating blockset file{}."
 
 	get_params -f "${me}" "${set_id}" \
 		install_path \
-		max_blockset_file_size_KB \
-		min_good_entries\
+		max_part_size \
+		max_set_size \
+		min_entries \
 		final_compr_or_cat_stdout || return 1
 
 	get_params "${set_id}" \
@@ -1135,7 +1093,7 @@ gen_blockset()
 		*) assert_set "F_${me}" INTERM_COMPR_EXT || return 1
 	esac
 
-	local max_size_b=$((max_blockset_file_size_KB*1024))
+	local max_size_b=$((max_set_size*1024))
 	[ "${deduplication}" = 1 ] && dedup_cmd_or_cat="${SORT_CMD} -u -"
 
 	case "${AWK_CMD:?}" in
@@ -1144,31 +1102,59 @@ gen_blockset()
 
 	# shellcheck disable=SC2034
 	# Process results
-	local part_cnt part_size_B list_cnt_raw list_size_B index list_type print_id index_refs \
+	local part_file part_cnt part_size_B list_cnt_raw part_size_B index part_type print_id index_refs \
 		set_cnt_raw=0 set_size_B_raw=0 allow_cnt_raw=0 block_cnt_raw=0 ipv4_block_cnt_raw=0 \
-		set_cnt_raw_human set_size_B_raw_human set_size_B set_size_B_human
-
-	rm -f "${PROCESSED_PARTS_DIR:?}/allow" "${ABL_TMP_DIR:?}/block_stats" "${ABL_TMP_DIR}/ipv4_block_stats" "${ABL_TMP_DIR}/allow_stats" "${ABL_TMP_DIR}/abl-too-big.tmp"
+		set_cnt_raw_human set_size_B_raw_human set_size_B set_size_B_human \
+		block_indexes allow_indexes ipv4_block_indexes
 
 	for index in ${set_indexes}
 	do
 		eval "index_refs=\"\${INDEX_REFS_${index}}\""
 		subtract_a_from_b "${set_id}" "${index_refs}" "INDEX_REFS_${index}"
 
-		[ -s "${ABL_TMP_DIR}/${index}_stats" ] || continue
+		[ -s "${PROCESSED_PARTS_DIR}/${index}_stats" ] || { reg_failure "${me}: can not find file '${PROCESSED_PARTS_DIR}/${index}_stats'."; return 1; }
 
-		eval \
-			"list_type=\"\${TYPE_${set_id}_${index}}\"" \
-			"print_id=\"\${PRINT_ID_${index}}\"" &&
-		[ -n "${list_type}" ] &&
-		read_str_from_file -v "part_cnt part_size_B" -f "${ABL_TMP_DIR}/${index}_stats" -V 0 &&
-		is_uint "${part_cnt}" "${part_size_B}" &&
-		set_cnt_raw=$((set_cnt_raw+part_cnt)) &&
+		job_get_params "${index}" print_id "part_type=part_type_${set_id}" &&
+		[ -n "${part_type}" ] &&
+		read_str_from_file -n 64 -v "part_cnt part_size_B" -f "${PROCESSED_PARTS_DIR}/${index}_stats" -V 0 &&
+		{
+			[ "${part_cnt}" != FAIL ] || continue
+		} &&
+		is_uint "${part_cnt}" "${part_size_B}" ||
+			{ reg_failure "Failed to read processed stats for blockset part with index ${index} (ID '${print_id}', type '${part_type}')."; return 1; }
+
+		# This second part size check is necessary because download-time limit is against max of all sets
+		[ $(( part_size_B <= max_part_size*1024)) = 1 ] ||
+		{
+			get_part_process_path part_file "${index}"
+			rm -f "${part_file}"
+			part_size_exceeded "${print_id}" "${max_part_size}"
+			if [ "${blockset_part_failed_action}" = STOP ]
+			then
+				log_msg -ob "${set_id}" "blockset_part_failed_action is set to 'STOP'. Stopping processing{}."
+				for index in ${set_indexes}
+				do
+					get_part_process_path part_file "${index}"
+					rm -f "${part_file}"
+				done
+				return 1
+			elif [ "${set_indexes}" = "${index}" ]
+			then
+				log_msg -ib "${set_id}" "Failed to generate the only part{}."
+				return 1
+			else
+				log_msg "blockset_part_failed_action is set to 'SKIP'. Skipping part and continuing.."
+				continue
+			fi
+		}
+
+		set_cnt_raw=$((set_cnt_raw + part_cnt)) &&
 		set_size_B_raw=$((set_size_B_raw + part_size_B)) &&
-		eval \
-			"${list_type}_cnt_raw=\"\$(( ${list_type}_cnt_raw + part_cnt ))\"" \
-			"${list_type}_size_B=\"\$(( ${list_type}_size_B + part_size_B ))\"" ||
-				{ reg_failure "Failed to read processed stats for blockset part with index ${index} (ID '${print_id}', type '${list_type}')."; return 1; }
+		{
+			set_int "${part_type}_cnt_raw = ${part_type}_cnt_raw + part_cnt"
+			set_int "${part_type}_size_B = ${part_type}_size_B + part_size_B"
+		}
+		abl_append "${part_type}_indexes" "${index}"
 	done
 
 	[ "${set_cnt_raw}" -gt 0 ] ||
@@ -1179,31 +1165,33 @@ gen_blockset()
 
 	reg_msg "Uncompressed blockset parts size: ${orange}${set_size_B_raw_human}${n_c}, entries count: ${orange}${set_cnt_raw_human}${n_c}."
 
-	local list_cnt_raw_human list_size_B_human
-	for list_type in ${ALL_LIST_TYPES}
+	try_mkdir -p "${proc_dir}" || return 1
+
+	local list_cnt_raw_human part_size_B_human
+	for part_type in ${ALL_PART_TYPES}
 	do
 		# count entries for current list type
-		eval "list_cnt_raw=\"\${${list_type}_cnt_raw:-0}\"" \
-			"list_size_B=\"\${${list_type}_size_B:-0}\""
+		eval "list_cnt_raw=\"\${${part_type}_cnt_raw:-0}\"" \
+			"part_size_B=\"\${${part_type}_size_B:-0}\""
 
-		if ! [ "${list_cnt_raw}" -gt 0 ] || ! [ "${list_size_B}" -gt 0 ]
+		if ! [ "${list_cnt_raw}" -gt 0 ] || ! [ "${part_size_B}" -gt 0 ]
 		then
-			[ "${list_type}" = block ] &&
+			[ "${part_type}" = block ] &&
 			{
 				[ "${whitelist_mode}" = 1 ] || {
-					bytes2human list_size_B_raw_human "${list_size_B_raw:-0}"
+					bytes2human part_size_B_raw_human "${part_size_B_raw:-0}"
 					int2human list_cnt_raw_human "${list_cnt_raw:-0}"
-					reg_failure "Total entries count and size of block-entries: ${list_cnt_raw_human}, ${list_size_B_human}."
+					reg_failure "Total entries count and size of block-entries: ${list_cnt_raw_human}, ${part_size_B_human}."
 					return 1
 				}
 				log_msg -yellow "Whitelist mode is on - accepting empty blocklist."
 			}
-		elif [ "${list_type}" = ipv4_block ]
+		elif [ "${part_type}" = ipv4_block ]
 		then
 			use_ipv4_blocklist=1
-		elif [ "${list_type}" = allow ]
+		elif [ "${part_type}" = allow ]
 		then
-			print_set_parts allow "${set_id}" "${set_indexes}" |
+			print_set_parts "${allow_indexes}" |
 			# optional deduplication
 			${dedup_cmd_or_cat} >> "${merged_allow_f}" || return 1
 			use_allowlist=1
@@ -1234,7 +1222,7 @@ gen_blockset()
 	{
 		{
 			# print blockset parts
-			print_set_parts block "${set_id}" "${set_indexes}" |
+			print_set_parts "${block_indexes}" |
 			# optional deduplication
 			${dedup_cmd_or_cat} |
 
@@ -1242,7 +1230,7 @@ gen_blockset()
 			${allow_filter_or_cat} |
 
 			# count entries
-			tee >(wc -w > "${ABL_TMP_DIR}/block_stats") |
+			tee >(wc -w > "${proc_dir}/block_stats") |
 
 			# pack entries in 1024 characters long lines
 			${pack_cmd} block || exit 1
@@ -1250,10 +1238,10 @@ gen_blockset()
 			# print ipv4 blockset parts
 			if [ -n "${use_ipv4_blocklist}" ]
 			then
-				print_set_parts ipv4_block "${set_id}" "${set_indexes}" |
+				print_set_parts "${ipv4_block_indexes}" |
 				# optional deduplication
 				${dedup_cmd_or_cat} |
-				tee >(wc -w > "${ABL_TMP_DIR}/ipv4_block_stats") |
+				tee >(wc -w > "${proc_dir}/ipv4_block_stats") |
 				# add prefix
 				${SED_CMD} 's/^/bogus-nxdomain=/' || exit 1
 			fi
@@ -1263,7 +1251,7 @@ gen_blockset()
 			then
 				# optional deduplication
 				${dedup_cmd_or_cat} < "${merged_allow_f}" |
-				tee >(wc -w > "${ABL_TMP_DIR}/allow_stats") |
+				tee >(wc -w > "${proc_dir}/allow_stats") |
 				# pack entries in 1024 characters long lines
 				${pack_cmd} allow || exit 1
 
@@ -1286,7 +1274,7 @@ gen_blockset()
 		} |
 
 		# limit size
-		{ head -c "${max_size_b}"; read -rn1 -d '' && { touch "${ABL_TMP_DIR}/abl-too-big.tmp"; cat 1>/dev/null; } || true; } |
+		{ head -c "${max_size_b}"; read -rn1 -d '' && { touch "${proc_dir}/abl-too-big.tmp"; cat 1>/dev/null; } || true; } |
 
 		# compress or cat
 		${final_compr_or_cat_stdout} > "${out_f}"
@@ -1298,24 +1286,25 @@ gen_blockset()
 			[ -n "${errors}" ] && log_msg "STDERR output:${_NL_}${errors}"
 			return 1
 		}
+
 	rm -f "${ERR_F}"
 
-	if [ -f "${ABL_TMP_DIR}/abl-too-big.tmp" ]
+	if [ -f "${proc_dir}/abl-too-big.tmp" ]
 	then
 		rm -f "${out_f}"
-		reg_failure -fb "${set_id}" "Final uncompressed blockset file size{} exceeded ${max_blockset_file_size_KB} kiB set in max_blockset_file_size_KB config option!"
+		reg_failure -fb "${set_id}" "Final uncompressed blockset file size{} exceeded ${max_set_size} kiB set in max_blockset_size_KB config option!"
 		log_msg "Consider either increasing this value in the config or changing the blockset URLs."
 		return 1
 	fi
 
-	# check total entries count vs min_good_entries
+	# check total entries count vs min_entries
 	local read_cnt block_cnt ipv4_block_cnt allow_cnt \
 		gen_cnt=0 gen_cnt_human
-	for list_type in block ipv4_block allow
+	for part_type in block ipv4_block allow
 	do
 		read_cnt=0
-		read -r read_cnt 2>/dev/null < "${ABL_TMP_DIR}/${list_type}_stats"
-		local "${list_type}_cnt=${read_cnt:-0}"
+		read -r read_cnt 2>/dev/null < "${proc_dir}/${part_type}_stats"
+		local "${part_type}_cnt=${read_cnt:-0}"
 	done
 
 	gen_cnt=$(( block_cnt + ipv4_block_cnt + allow_cnt ))
@@ -1326,21 +1315,21 @@ gen_blockset()
 
 	int2human gen_cnt_human "${gen_cnt}" || return 1
 
-	if [ "${gen_cnt}" -lt "${min_good_entries}" ]
+	if [ "${gen_cnt}" -lt "${min_entries}" ]
 	then
-		int2human min_good_entries_human "${min_good_entries}" || return 1
-		reg_failure "Entries count (${gen_cnt_human}) is below the minimum value set in config (${min_good_entries_human})."
+		int2human min_entries_human "${min_entries}" || return 1
+		reg_failure "Entries count (${gen_cnt_human}) is below the minimum value set in config option 'min_entries' (${min_entries_human})."
 		return 1
 	fi
 
 	# check the final blockset with dnsmasq --test
-	reg_action "Checking the processed blockset file with 'dnsmasq --test'." || return 1
+	reg_action "Checking the processed blockset file with '${DMSQ_CMD:?} --test'." || return 1
 
 	rm -f "${ERR_F}"
 
 	{
 		try_extract -stdout "${out_f}" |
-		dnsmasq --test -C -
+		${DMSQ_CMD:?} --test -C -
 	} 2> "${ERR_F}"
 
 	if [ ${?} != 0 ] || ! grep -q "syntax check OK" "${ERR_F}"

--- a/usr/lib/adblock-lean/abl-scheduler.sh
+++ b/usr/lib/adblock-lean/abl-scheduler.sh
@@ -1,0 +1,931 @@
+#!/bin/sh
+# shellcheck disable=SC3043,SC3045,SC3003
+
+### Helpers
+
+sch_is_included() {
+	is_included "${@}"
+}
+
+sch_append() {
+	abl_append "${@}"
+}
+
+sch_rm_elem() {
+	subtract_a_from_b "${2}" "${3}" "${1}"
+}
+
+sch_is_uint() {
+	is_uint "${@}"
+}
+
+sch_get_uptime_cs() {
+	get_uptime_cs "${@}"
+}
+
+sch_fail_msg() {
+	reg_failure "${@}"
+}
+
+sch_is_cmd() {
+	is_cmd "${@}"
+}
+
+sch_tr_leading() {
+	sch_check_name "var" "${1}" &&
+	tr_leading "${@}"
+}
+
+sch_tr_trailing() {
+	sch_check_name "var" "${1}" &&
+	tr_trailing "${@}"
+}
+
+# --- Unmodified code from upstream below
+
+sch_has_f() {
+	case "${-}" in
+		*f*) return 0 ;;
+		*) return 1
+	esac
+}
+
+# Look up PID of a job in list of '<pid>:<job ID>' entries
+# 1: out var
+# 2: job ID
+# 3: cur list
+sch_pid_of_id() {
+	local spi_l=" ${3} " spi_p
+	export -n "${1:?}="
+
+	case "${spi_l}" in
+		*":${2} "*) ;;
+		*) return 1
+	esac
+
+	spi_p="${spi_l%%":${2} "*}"
+	export -n "${1}=${spi_p##* }"
+}
+
+# Get reuse-proof '<pid>_<starttime>' of current shell process
+# 1: out-var
+sch_get_uid() {
+	local sgu_had_f sgu_pid sgu_start sgu_line \
+		IFS=" "$'\t'$'\n' \
+		sgu_out="${1:?}"
+	export -n "${sgu_out}="
+
+	IFS= read -r sgu_line 2>/dev/null < /proc/self/stat || sgu_line=
+
+	sgu_pid="${sgu_line%% *}"
+	# Strip 'pid (comm) ' greedily - comm may contain ') ' and spaces
+	sgu_line="${sgu_line##*") "}"
+
+	sch_has_f && sgu_had_f=1
+	set -f
+	set -- ${sgu_line}
+	[ -n "${sgu_had_f}" ] || set +f
+
+	# Start time is stat field 22; the strip leaves state (field 3) first
+	[ "${#}" -ge 20 ] && shift 19 && sgu_start="${1}"
+
+	sch_is_uint "${sgu_pid}" "${sgu_start}" ||
+		{ sch_fail_msg "Failed to get PID and start time from /proc/self/stat."; return 1; }
+	export -n "${sgu_out}=${sgu_pid}_${sgu_start}"
+}
+
+sch_check_name() {
+	local scn_pfx="SCH_JOB_PARAMS_${#SCHED_ID}_${SCHED_ID}_" scn_max_len=2020
+
+	[ "${1}" = var ] && scn_max_len=$((scn_max_len + ${#scn_pfx}))
+
+	[ "${#2}" -le "${scn_max_len}" ] &&
+	case "${2}" in
+		''|*[!a-zA-Z0-9_]*) false ;;
+		*) : ;;
+	esac &&
+	{
+		[ "${1}" != var ] ||
+		case "${2}" in
+			[a-zA-Z_]*) : ;;
+			*) false
+		esac
+	} &&
+	return 0
+
+	sch_fail_msg "${3}${3:+": "}${1}${1:+ }'${2}' is empty string or contains incompatible characters, or is too long."
+	return 1
+}
+
+# Validate user-supplied var name
+# 1: name
+# 2: caller name
+sch_check_var_name() {
+	sch_check_name "var" "${1}" "${2}" || return 1
+	case "${1}" in
+		sch_*|_sch_*|SCH_*|SCHED_*|DO_JOB_CB|JOB_DONE_CB|JOB_TERM_CB|IFS)
+			sch_fail_msg "${2}: var name '${1}' is reserved for internal use."
+			return 1
+	esac
+}
+
+# 1: caller
+sch_in_main_process() {
+	local sip_uid
+	sch_get_uid sip_uid &&
+	[ "${sip_uid}" = "${SCHED_UID}" ] &&
+	eval "[ -n \"\${SCH_STARTED_${sip_uid}}\" ]" &&
+		return 0
+	sch_fail_msg "${1}: SCHED_UID is not set or scheduler is not running in this process."
+	return 1
+}
+
+# Resolve the ${SCHED_ID} namespace infix '<len of SCHED_ID>_<SCHED_ID>_'
+# 1: out var name
+# 2: caller name
+sch_get_ns() {
+	export -n "${1:?}="
+	[ -z "${SCHED_ID}" ] ||
+		sch_check_name "SCHED_ID" "${SCHED_ID}" "${2}" || return 1
+	export -n "${1}=${#SCHED_ID}_${SCHED_ID}_"
+}
+
+sch_finalize() {
+	local sch_me=sch_finalize sch_unfinished_ids sch_exp_e sch_job_id sch_running_pids \
+		IFS=" "$'\t'$'\n' \
+		sch_rv="${1}"
+
+	sch_in_main_process "${sch_me}" ||
+		return "${sch_rv:-1}"
+
+	unset "SCH_STARTED_${SCHED_UID}"
+
+	trap ':' USR1 INT TERM EXIT
+
+	[ -n "${2}" ] && [ "${sch_rv}" != 0 ] && sch_fail_msg "${2}"
+
+	exec 3>&-
+	[ -n "${sch_run_dir}" ] && rm -rf "${sch_run_dir}"
+
+	if [ -n "${SCH_HAD_F}" ]; then set -f; else set +f; fi
+
+	# Collect pids of jobs still accounted as running
+	for sch_exp_e in ${SCH_RUNNING}; do
+		sch_append sch_running_pids "${sch_exp_e%%:*}"
+	done
+
+	[ -n "${JOB_TERM_CB}" ] &&
+	[ -n "${sch_running_pids}" ] &&
+		sch_term_run ${sch_running_pids}
+
+	# Add pids of timed-out and aborted jobs to <running_pids>
+	for sch_exp_e in ${SCH_UNREAPED}; do
+		sch_append sch_running_pids "${sch_exp_e%%:*}"
+	done
+
+	# Compute sch_unfinished_ids
+	for sch_job_id in ${SCH_JOB_IDS}; do
+		sch_is_included "${sch_job_id}" "${SCH_OK_IDS} ${SCH_UNDISPATCHED_IDS} ${SCH_FAIL_IDS} ${SCH_EXPIRED_IDS} ${SCH_ABORTED_IDS}" ||
+			sch_append sch_unfinished_ids "${sch_job_id}"
+	done
+
+	[ -n "${SCHED_FINALIZE_CB}" ] && {
+		"${SCHED_FINALIZE_CB}" "${sch_rv}" "${sch_running_pids}" "${SCH_OK_IDS}" "${SCH_FAIL_IDS}" "${sch_unfinished_ids}" "${SCH_UNDISPATCHED_IDS}" "${SCH_EXPIRED_IDS}" "${SCH_ABORTED_IDS}"
+		sch_rv=${?}
+	}
+
+	exit "${sch_rv}"
+}
+
+sch_start_job() {
+	local \
+		sch_job_rv \
+		sch_job_id="${1:?}"
+
+	shift
+
+	trap '
+		sch_job_rv=${?}
+		printf "%s %s\n" "${sch_job_rv}" "${sch_job_id}" >&3 2>/dev/null
+		exit "${sch_job_rv}"
+	' EXIT
+
+	job_get_params -export "${sch_job_id}" sch_all || exit 1
+
+	if [ -n "${SCHED_INNER_SUBSHELL}" ]; then
+		( "${DO_JOB_CB:?}" "${sch_job_id}" "${@}" 3>&- )
+	else
+		"${DO_JOB_CB:?}" "${sch_job_id}" "${@}"
+	fi
+
+	exit "${?}"
+}
+
+# Invoke JOB_DONE_CB, export params unconditionally
+# 1: callback command
+# 2: job ID
+# Extra args: passed to the callback as-is
+sch_run_done_cb() {
+	local sch_me=sch_run_done_cb \
+		sch_had_f \
+		sch_p \
+		sch_names \
+		sch_ns \
+		sch_cb="${1}" \
+		sch_dc_id="${2}"
+
+	shift
+
+	sch_get_ns sch_ns "${sch_me}" || return 1
+	eval "sch_names=\"\${SCH_JOB_PARAMS_${sch_ns}${sch_dc_id}}\""
+
+	sch_has_f && sch_had_f=1
+	set -f
+
+	# 'local' with invalid name aborts busybox ash
+	for sch_p in ${sch_names}; do
+		sch_check_var_name "${sch_p}" "${sch_me}" || { sch_names=; break; }
+	done
+
+	[ -z "${sch_names}" ] || {
+		#shellcheck disable=SC2086
+		local ${sch_names}
+		job_get_params -export "${sch_dc_id}" sch_all
+	}
+
+	[ -n "${sch_had_f}" ] || set +f
+
+	"${sch_cb}" "${@}"
+}
+
+sch_read_rec() {
+	local srr_out="${1:?}" srr_fifo="${2:?}" srr_t="${3:?}" \
+		srr_rec srr_tail
+
+	export -n "${srr_out}="
+	[ "${srr_t}" -gt 0 ] || return 1
+
+	IFS= read -t "${srr_t}" -r srr_rec < "${srr_fifo}" ||
+	{
+		# Timed out, possibly mid-record
+		IFS= read -t 0 -r _ < "${srr_fifo}" &&
+			IFS= read -t 1 -r srr_tail < "${srr_fifo}"
+
+		[ -n "${BASH_VERSION}" ] || [ -n "${srr_rec}" ] || srr_tail=
+
+		srr_rec="${srr_rec}${srr_tail}"
+		[ -n "${srr_rec}" ] || return 1
+	}
+
+	[ -n "${srr_rec}" ] || return 0
+
+	export -n "${srr_out}=${srr_rec}"
+}
+
+# Take the completion records queued on the IPC FIFO, act on them, then sweep expired deadlines.
+# Called only when no job can be dispatched, so the wait for a record is unconditional.
+# Wait is capped by the run's remaining time and by the nearest job deadline.
+# 1: current time (centiseconds)
+sch_process_records() {
+	local \
+		sch_cs \
+		sch_now_cs \
+		sch_read_t_cs \
+		sch_read_t_s \
+		sch_rec \
+		sch_n \
+		sch_batch \
+		sch_dl_prev \
+		sch_job_pid \
+		sch_job_id \
+		sch_done_rv \
+		sch_done_id \
+		sch_had_f \
+		sch_e \
+		sch_cur_time_cs="${1:?}"
+
+	sch_has_f && sch_had_f=1
+
+	# Cap the wait by the nearest deadline
+	sch_read_t_cs="${SCH_REMAIN_TIME_CS}"
+	set -f
+	for sch_e in ${SCH_DEADLINES}; do
+		sch_cs=$(( ${sch_e%%:*} - sch_cur_time_cs ))
+		[ "${sch_cs}" -lt "${sch_read_t_cs}" ] && sch_read_t_cs="${sch_cs}"
+	done
+	[ -n "${sch_had_f}" ] || set +f
+
+	sch_read_t_s=$(( (sch_read_t_cs + 99) / 100 ))
+
+	# Capped at 100 records per call, so that a sustained writer cannot defer dispatch and the timeout check indefinitely
+	# A deadline already past makes the first read a no-op: count it only if it consumed a record
+	sch_n=0
+	sch_read_rec sch_rec "${SCH_IPC_FIFO}" "${sch_read_t_s}" && sch_n=1
+	while :; do
+		# Empty means a read timeout, or an empty line
+		if [ -n "${sch_rec}" ]; then
+			# ${sch_rec} comes off the FIFO unvalidated - never glob it
+			set -f
+			set -- ${sch_rec}
+			[ -n "${sch_had_f}" ] || set +f
+
+			[ "${#}" = 2 ] && sch_is_uint "${1}" && sch_is_included "${2}" "${SCH_JOB_IDS}" ||
+				sch_finalize 1 "Malformed completion record: '${sch_rec}'."
+			sch_append sch_batch "${1}:${2}"
+		fi
+
+		[ "${sch_n}" -lt 100 ] || break
+
+		# 'read -t 0' reports whether more data is waiting, consumes nothing
+		IFS= read -t 0 -r _ < "${SCH_IPC_FIFO}" || break
+		sch_n=$((sch_n+1))
+		sch_read_rec sch_rec "${SCH_IPC_FIFO}" 1
+	done
+
+	# One reading serves both the progress stamp and the expiry sweep. Taken before any
+	#   callback runs, so time a callback spends counts against the idle timeout
+	sch_get_uptime_cs sch_now_cs || sch_finalize 1
+
+	# Arrival wins over expiry: records are handled before deadlines are swept.
+	for sch_e in ${sch_batch}; do
+		sch_done_rv="${sch_e%%:*}"
+		sch_done_id="${sch_e#*:}"
+
+		if sch_pid_of_id sch_job_pid "${sch_done_id}" "${SCH_UNREAPED}"; then
+			# Late record from a job already timed out or aborted - discard
+			sch_rm_elem SCH_UNREAPED "${sch_job_pid}:${sch_done_id}" "${SCH_UNREAPED}"
+		elif sch_pid_of_id sch_job_pid "${sch_done_id}" "${SCH_RUNNING}"; then
+			sch_rm_elem SCH_RUNNING "${sch_job_pid}:${sch_done_id}" "${SCH_RUNNING}"
+			SCH_RUNNING_JOBS_CNT=$((SCH_RUNNING_JOBS_CNT - 1))
+
+			[ -n "${SCH_DEADLINES}" ] &&
+				sch_deadline_rm_id SCH_DEADLINES "${sch_done_id}" "${SCH_DEADLINES}"
+
+			if [ "${sch_done_rv}" = 0 ]; then
+				sch_append SCH_OK_IDS "${sch_done_id}"
+			else
+				sch_append SCH_FAIL_IDS "${sch_done_id}"
+			fi
+
+			# Only a genuine completion is progress; a discarded late record is not
+			SCH_LAST_PROGRESS_TIME_CS="${sch_now_cs}"
+
+			[ -z "${JOB_DONE_CB}" ] ||
+			sch_run_done_cb "${JOB_DONE_CB}" "${sch_done_id}" "${sch_done_rv}" ||
+				sch_finalize ${?}
+		else
+			sch_finalize 1 "Unexpected completion record for job ID '${sch_done_id}'."
+		fi
+	done
+
+	[ -n "${SCH_DEADLINES}" ] && {
+		# Rebuild the list, acting on entries that expired (deadline <= now).
+		# Carries run state a callback can reach, so the split runs with globbing off
+		sch_dl_prev="${SCH_DEADLINES}"
+		SCH_DEADLINES=
+		set -f
+		for sch_e in ${sch_dl_prev}; do
+			# Restored per iteration: the expiry path calls into user code
+			[ -n "${sch_had_f}" ] || set +f
+
+			if [ "${sch_e%%:*}" -le "${sch_now_cs}" ]; then
+				sch_job_id="${sch_e#*:}"
+
+				# Gone from SCH_RUNNING: a callback above aborted it - drop the entry,
+				#   the job is already classified
+				sch_pid_of_id sch_job_pid "${sch_job_id}" "${SCH_RUNNING}" || continue
+				sch_rm_elem SCH_RUNNING "${sch_job_pid}:${sch_job_id}" "${SCH_RUNNING}"
+				SCH_RUNNING_JOBS_CNT=$((SCH_RUNNING_JOBS_CNT - 1))
+				sch_append SCH_EXPIRED_IDS "${sch_job_id}"
+				sch_append SCH_UNREAPED "${sch_job_pid}:${sch_job_id}"
+
+				# Kill the timed-out job's whole process tree (wrapper included)
+				[ -n "${JOB_TERM_CB}" ] &&
+					sch_term_run "${sch_job_pid}"
+
+				[ -z "${JOB_DONE_CB}" ] ||
+				sch_run_done_cb "${JOB_DONE_CB}" "${sch_job_id}" 124 "${sch_job_pid}" ||
+					sch_finalize ${?}
+			else
+				sch_append SCH_DEADLINES "${sch_e}"
+			fi
+		done
+		[ -n "${sch_had_f}" ] || set +f
+	}
+
+	return 0
+}
+
+
+# Remove job's entry from list of '<deadline>:<job ID>' entries
+sch_deadline_rm_id() {
+	local sdr_e=" ${3} "
+
+	case "${sdr_e}" in
+		*":${2} "*) ;;
+		*) export -n "${1:?}=${3}"; return 1
+	esac
+
+	sdr_e="${sdr_e%%":${2} "*}"
+	sdr_e="${sdr_e##* }:${2}"
+	sch_rm_elem "${1}" "${sdr_e}" "${3}"
+}
+
+
+# Args: passed to the command
+sch_term_run() {
+	"${JOB_TERM_CB}" "${@}" ||
+		sch_fail_msg "Job termination callback '${JOB_TERM_CB}' returned code ${?}."
+	:
+}
+
+#
+# Job termination functions
+#
+
+# Job termination callback (ppid-walk mechanism)
+# Args: job PIDs
+sched_job_term_mini() {
+	local \
+		me=sched_job_term_mini \
+		sjt_had_f \
+		sjt_p sjt_seeds sjt_all sjt_prev sjt_found sjt_try
+
+	sjt_seeds=
+	for sjt_p in "${@}"; do
+		sch_is_uint "${sjt_p}" ||
+			{ sch_fail_msg "${me}: ignoring invalid PID '${sjt_p}'."; continue; }
+		sch_append sjt_seeds "${sjt_p}"
+	done
+	[ -n "${sjt_seeds}" ] || return 0
+
+	# Freeze, re-scan to fixpoint, kill
+	sjt_all="${sjt_seeds}"
+	sjt_prev=
+
+	sch_has_f && sjt_had_f=1
+	set -f
+
+	for sjt_try in 1 2 3; do
+		kill -STOP ${sjt_all} 2>/dev/null
+
+		# Get all live descendant PIDs (space-separated, seeds excluded).
+		sjt_found="$(
+			set +f
+			cat /proc/[0-9]*/stat 2>/dev/null | {
+				set -f
+				# shellcheck disable=SC2016
+				${SCHED_AWK_CMD:-awk} -v seeds="${sjt_all}" '
+				/^[0-9]+ \(/ {
+					pid = $1
+					s = $0
+					# Strip "pid (comm) X " (X = single state char).
+					# comm may contain spaces and parens - the greedy match handles those;
+					#   a line that does not match is a fragment of a newline-containing comm - skip
+					if (!sub(/^[0-9]+ \(.*\) . /, "", s)) next
+					split(s, f, " ")
+					if (f[1] !~ /^[0-9]+$/) next
+					ppid[pid] = f[1]
+					valid++
+				}
+				END {
+					if (!valid) exit 1
+					n = split(seeds, a, " ")
+					for (i = 1; i <= n; i++)
+						if (a[i] ~ /^[0-9]+$/) {
+							seed[a[i]] = 1
+							want[a[i]] = 1
+						}
+					do {
+						changed = 0
+						for (p in ppid)
+							if (!(p in want) && (ppid[p] in want)) { want[p] = 1; changed = 1 }
+					} while (changed)
+					for (p in want) if (!(p in seed)) printf "%s ", p
+				}'
+			}
+		)" || {
+			sch_fail_msg "${me}: /proc scan failed."
+			break
+		}
+
+		sch_append sjt_all "${sjt_found}"
+		sch_tr_trailing sjt_all " "
+		[ "${sjt_all}" = "${sjt_prev}" ] && break
+		sjt_prev="${sjt_all}"
+	done
+
+	kill -KILL ${sjt_all} 2>/dev/null
+
+	[ -n "${sjt_had_f}" ] || set +f
+	:
+}
+
+#
+# User-facing functions
+#
+
+schedule_jobs() {
+	# 1: var name
+	# 2: required(1/empty)
+	sch_check_cb() {
+		local val
+		sch_check_name "var" "${1}" "sch_check_cb" || return 1
+		eval "val=\"\${${1}}\""
+		[ -z "${val}" ] && [ -z "${2}" ] && return 0
+		[ -z "${val}" ] && { sch_fail_msg "Required callback is missing (set via \${${1}})."; return 1; }
+		sch_is_cmd "${val}" || { sch_fail_msg "Invalid value of ${1} '${val}'."; return 1; }
+	}
+
+	# Normalize delimiters to single-space
+	sch_normalize_ids() {
+		local \
+			IFS=" "$'\t'$'\n' \
+			out_var="${1}"
+
+		set -f
+		set -- ${2}
+		IFS=" "
+		export -n "${out_var}=${*}"
+		[ -n "${SCH_HAD_F}" ] || set +f
+	}
+
+	sch_normalize_uint() {
+		local val="${2}"
+		export -n "${1:?}="
+		[ -z "${val}" ] && [ -z "${3}" ] && return 0
+		sch_is_uint "${val}" && [ "${val}" -ge 1 ] ||
+			{ sch_fail_msg "Invalid value '${val}' of env var SCHED_${1#SCH_}."; return 1; }
+		sch_tr_leading val "0"
+		export -n "${1}=${val}"
+	}
+
+	local \
+		SCH_RV_IDLE_TIMEOUT=81 \
+		SCH_RV_GLOBAL_TIMEOUT=82 \
+		SCH_RV_USR1=83 \
+		SCH_RV_INT_TERM=84
+
+	local \
+		IFS=" "$'\t'$'\n' \
+		SCHED_PID \
+		SCHED_UID \
+		sch_cur_time_cs \
+		sch_idle_remain_time_cs \
+		sch_job_id \
+		sch_job_pid \
+		sch_ns \
+		sch_seen_ids \
+		sch_job_to \
+		sch_dl_now_cs \
+		sch_run_dir \
+		sch_run_n \
+		sch_dir="/tmp" \
+		\
+		SCH_RUNNING_JOBS_CNT=0 \
+		SCH_IPC_FIFO \
+		SCH_HAD_F \
+		SCH_REMAIN_TIME_CS \
+		SCH_INIT_UPTIME_CS \
+		SCH_LAST_PROGRESS_TIME_CS \
+		SCH_IN_FAIL_MSG_CB \
+		SCH_RUNNING \
+		SCH_MAX_JOBS \
+		SCH_TIMEOUT_S \
+		SCH_IDLE_TIMEOUT_S \
+		SCH_JOB_TIMEOUT_S \
+		SCH_DEADLINES \
+		SCH_UNREAPED \
+		\
+		SCH_PENDING_IDS \
+		SCH_ABORTED_IDS \
+		SCH_UNDISPATCHED_IDS \
+		SCH_OK_IDS \
+		SCH_FAIL_IDS \
+		SCH_EXPIRED_IDS \
+		\
+		SCH_JOB_IDS="${1?}"
+	
+	: "${SCH_REMAIN_TIME_CS}" "${SCH_JOB_TIMEOUT_S}" # Silence shellcheck warning
+
+	shift 1
+
+	sch_has_f && SCH_HAD_F=1
+
+	[ -n "${SCHED_AUTO_JOB_TERM}" ] && JOB_TERM_CB=sched_job_term_mini
+
+	# Check callbacks
+	sch_check_cb SCHED_FAIL_MSG_CB &&
+	sch_check_cb SCHED_FINALIZE_CB &&
+	sch_check_cb DO_JOB_CB required &&
+	sch_check_cb JOB_DONE_CB &&
+	sch_check_cb JOB_TERM_CB &&
+	sch_check_cb SCHED_DISPATCH_TICK_CB || exit 1
+
+	# Check env vars, normalize into internal copies
+	sch_normalize_uint SCH_MAX_JOBS "${SCHED_MAX_JOBS}" required &&
+	sch_normalize_uint SCH_TIMEOUT_S "${SCHED_TIMEOUT_S:-900}" &&
+	sch_normalize_uint SCH_IDLE_TIMEOUT_S "${SCHED_IDLE_TIMEOUT_S:-300}" &&
+	sch_normalize_uint SCH_JOB_TIMEOUT_S "${SCHED_JOB_TIMEOUT_S}" || exit 1
+
+	# Check namespace; register scheduler start
+	sch_get_ns sch_ns "schedule_jobs" &&
+	sch_get_uptime_cs SCH_INIT_UPTIME_CS &&
+	sch_get_uid SCHED_UID ||
+		exit 1
+	SCHED_PID="${SCHED_UID%%_*}"
+	export -n "SCH_STARTED_${SCHED_UID}=1"
+
+	sch_normalize_ids SCH_JOB_IDS "${SCH_JOB_IDS}" || exit 1
+
+	# Validate job IDs, check duplicates
+	set -f
+	for sch_job_id in ${SCH_JOB_IDS}; do
+		[ -n "${SCH_HAD_F}" ] || set +f
+		sch_check_name "job ID" "${sch_job_id}" || exit 1
+		sch_is_included "${sch_job_id}" "${sch_seen_ids}" &&
+			{ sch_fail_msg "Duplicate Job ID '${sch_job_id}'."; exit 1; }
+		sch_append sch_seen_ids "${sch_job_id}"
+	done
+	[ -n "${SCH_HAD_F}" ] || set +f
+
+	SCH_UNDISPATCHED_IDS="${SCH_JOB_IDS}"
+	SCH_PENDING_IDS="${SCH_JOB_IDS}"
+
+	# Main logic
+
+	SCH_LAST_PROGRESS_TIME_CS="${SCH_INIT_UPTIME_CS}"
+
+	mkdir -p "${sch_dir}" ||
+		sch_finalize 1 "Failed to create directory '${sch_dir}'."
+
+	sch_run_n=0
+	while :; do
+		sch_run_dir="${sch_dir}/sched_${SCHED_UID}.${sch_run_n}"
+		SCH_IPC_FIFO="${sch_run_dir}/ipc"
+		# Owner-only FIFO and run dir
+		(
+			umask 077
+			mkdir "${sch_run_dir}" 2>/dev/null &&
+			{
+				mkfifo "${SCH_IPC_FIFO}" || {
+					rm -rf "${sch_run_dir}"
+					false
+				}
+			}
+		) && break
+		sch_run_n=$((sch_run_n + 1))
+		[ "${sch_run_n}" -lt 16 ] ||
+			sch_finalize 1 "Failed to create run directory or FIFO file under '${sch_dir}'."
+	done
+
+	exec 3<>"${SCH_IPC_FIFO}" ||
+		sch_finalize 1 "Failed to open FIFO '${SCH_IPC_FIFO}'."
+
+	trap 'sch_finalize "${SCH_RV_USR1}"' USR1
+	trap 'sch_finalize "${SCH_RV_INT_TERM}"' INT TERM
+	trap 'sch_finalize "${?}" "Scheduler process exited unexpectedly."' EXIT
+
+	# Start jobs
+
+	# Filling a free concurrency slot outranks everything:
+	#   the FIFO is only read, and deadlines only swept, once no slot can be filled.
+	# ${SCH_PENDING_IDS} shrinks as jobs are dispatched; jobs_abort() may also remove from it
+	while [ -n "${SCH_PENDING_IDS}" ] || [ "${SCH_RUNNING_JOBS_CNT}" -gt 0 ]; do
+		[ -e "${SCH_IPC_FIFO}" ] || sch_finalize 1 "Scheduler FIFO disappeared."
+
+		# Check if global or idle timeout is due, update SCH_REMAIN_TIME_CS
+		sch_get_uptime_cs sch_cur_time_cs || sch_finalize 1
+		SCH_REMAIN_TIME_CS=$(( SCH_TIMEOUT_S*100 - (sch_cur_time_cs-SCH_INIT_UPTIME_CS) ))
+		sch_idle_remain_time_cs=$(( SCH_IDLE_TIMEOUT_S*100 - (sch_cur_time_cs-SCH_LAST_PROGRESS_TIME_CS) ))
+
+		if [ ! "${SCH_REMAIN_TIME_CS}" -gt 0 ]; then
+			sch_finalize "${SCH_RV_GLOBAL_TIMEOUT}" "Processing timeout (${SCH_TIMEOUT_S} s) for scheduler (PID: ${SCHED_PID})."
+		elif [ ! "${sch_idle_remain_time_cs}" -gt 0 ]; then
+			sch_finalize "${SCH_RV_IDLE_TIMEOUT}" "Idle timeout (${SCH_IDLE_TIMEOUT_S} s) for scheduler (PID: ${SCHED_PID})."
+		fi
+
+		if [ "${sch_idle_remain_time_cs}" -lt "${SCH_REMAIN_TIME_CS}" ]; then
+			SCH_REMAIN_TIME_CS="${sch_idle_remain_time_cs}"
+		fi
+
+		sch_job_id="${SCH_PENDING_IDS%% *}"
+
+		if [ "${SCH_RUNNING_JOBS_CNT}" -lt "${SCH_MAX_JOBS}" ] && [ -n "${sch_job_id}" ]; then
+			# Callback may have broken the contract by changing sch_ns or SCHED_ID - recompute sch_ns before fork
+			sch_get_ns sch_ns "schedule_jobs" || sch_finalize 1
+
+			SCH_RUNNING_JOBS_CNT=$((SCH_RUNNING_JOBS_CNT + 1))
+
+			sch_start_job "${sch_job_id}" "${@}" &
+			sch_job_pid="${!}"
+			# Track the child first - on a signal, finalize can only kill what's listed here
+			sch_append SCH_RUNNING "${sch_job_pid}:${sch_job_id}"
+
+			sch_rm_elem SCH_PENDING_IDS "${sch_job_id}" "${SCH_PENDING_IDS}"
+			sch_rm_elem SCH_UNDISPATCHED_IDS "${sch_job_id}" "${SCH_UNDISPATCHED_IDS}"
+
+			# Reset the idle timeout at job start
+			sch_get_uptime_cs sch_dl_now_cs || sch_finalize 1
+			SCH_LAST_PROGRESS_TIME_CS="${sch_dl_now_cs}"
+
+			# Register job's timeout deadline if it has one
+			eval "sch_job_to=\"\${SCH_TIMEOUT_JOB_${sch_ns}${sch_job_id}:-\${SCH_JOB_TIMEOUT_S}}\""
+
+			[ -n "${sch_job_to}" ] &&
+				sch_append SCH_DEADLINES "$((sch_dl_now_cs + sch_job_to*100)):${sch_job_id}"
+
+			[ -z "${SCHED_DISPATCH_TICK_CB}" ] ||
+				"${SCHED_DISPATCH_TICK_CB}" "${sch_job_id}"
+
+			# Keep filling free slots before any completion record is acted on
+			continue
+		fi
+
+		# Waits for a completion record.
+		# Updates ${SCH_RUNNING_JOBS_CNT}; ${SCH_RUNNING}; ${SCH_LAST_PROGRESS_TIME_CS}
+		sch_process_records "${sch_cur_time_cs}"
+	done
+
+	sch_finalize 0
+}
+
+# args: one or more whitespace-separated job ID lists
+jobs_init() {
+	local \
+		IFS=" "$'\t'$'\n' \
+		sch_had_f \
+		sch_cur_params \
+		sch_param \
+		sch_job_id \
+		sch_ns \
+		sch_rv=0
+
+	# Resolved before any name is built: 'unset' with an invalid name aborts busybox ash
+	sch_get_ns sch_ns "jobs_init" || return 1
+
+	sch_has_f && sch_had_f=1
+	set -f
+
+	#shellcheck disable=SC2048
+	for sch_job_id in ${*}; do
+		sch_check_name "job ID" "${sch_job_id}" "jobs_init" ||
+			{ sch_rv=1; break; }
+		eval "sch_cur_params=\"\${SCH_JOB_PARAMS_${sch_ns}${sch_job_id}}\""
+
+		for sch_param in ${sch_cur_params}; do
+			case "${sch_param}" in
+				''|*[!a-zA-Z0-9_]*) continue ;;
+			esac
+			unset "SCH_JOB_PARAM_${sch_ns}${#sch_job_id}_${sch_job_id}_${sch_param}"
+		done
+		unset "SCH_JOB_PARAMS_${sch_ns}${sch_job_id}" \
+			"SCH_TIMEOUT_JOB_${sch_ns}${sch_job_id}"
+	done
+
+	[ -n "${sch_had_f}" ] || set +f
+	return "${sch_rv}"
+}
+
+# 1: job ID
+# Extra args: <param=value> pairs
+job_set_params() {
+	local sch_me=job_set_params \
+		IFS=" "$'\t'$'\n' \
+		sch_param \
+		sch_val \
+		sch_cur_params \
+		sch_pair \
+		sch_pair_seen \
+		sch_ns \
+		sch_job_id="${1}"
+
+	[ -n "${1+x}" ] && shift
+
+	sch_get_ns sch_ns "${sch_me}" || return 1
+	sch_check_name "job ID" "${sch_job_id}" "${sch_me}" || return 1
+
+	for sch_pair; do
+		sch_pair_seen=1
+		case "${sch_pair}" in
+			*=*) ;;
+			*)
+				sch_fail_msg "${sch_me}: Invalid key-value pair '${sch_pair}'."
+				return 1
+		esac
+
+		sch_param="${sch_pair%%=*}"
+		sch_val="${sch_pair#"${sch_param}="}"
+		sch_check_name "param" "${sch_param}" "${sch_me}" || return 1
+
+		eval "sch_cur_params=\"\${SCH_JOB_PARAMS_${sch_ns}${sch_job_id}}\""
+		sch_is_included "${sch_param}" "${sch_cur_params}" ||
+		sch_append "SCH_JOB_PARAMS_${sch_ns}${sch_job_id}" "${sch_param}" ||
+			return 1
+		export -n "SCH_JOB_PARAM_${sch_ns}${#sch_job_id}_${sch_job_id}_${sch_param}=${sch_val}"
+	done
+
+	[ -n "${sch_pair_seen}" ] ||
+		{ sch_fail_msg "${sch_me}: no params specified."; return 1; }
+}
+
+# 0 (optional): '-export'
+# 1: job ID
+# Extra args: "sch_all" or <list of params, one per argument>, or <list of var=param>
+job_get_params() {
+	local sch_export
+	[ "${1}" = '-export' ] && { sch_export="export "; shift; }
+
+	local sch_me=job_get_params \
+		IFS=" "$'\t'$'\n' \
+		sch_param \
+		sch_var \
+		sch_had_f \
+		sch_job_params \
+		sch_param_seen \
+		sch_ns \
+		sch_job_id="${1}"
+
+	[ -n "${1+x}" ] && shift
+	sch_get_ns sch_ns "${sch_me}" || return 1
+	sch_check_name "job ID" "${sch_job_id}" "${sch_me}" || return 1
+
+	[ "${*}" = sch_all ] && {
+		eval "sch_job_params=\"\${SCH_JOB_PARAMS_${sch_ns}${sch_job_id}}\""
+		[ -n "${sch_job_params}" ] || return 0
+
+		sch_has_f && sch_had_f=1
+		set -f
+		set -- ${sch_job_params}
+		[ -n "${sch_had_f}" ] || set +f
+	}
+
+	for sch_param; do
+		sch_param_seen=1
+		sch_var="${sch_param}"
+		case "${sch_param}" in
+			*=*)
+				sch_var="${sch_param%%=*}"
+				sch_param="${sch_param#*=}"
+		esac
+
+		sch_check_name "param" "${sch_param}" "${sch_me}" &&
+		sch_check_var_name "${sch_var}" "${sch_me}" || return 1
+
+		eval "${sch_export}${sch_var}=\"\${SCH_JOB_PARAM_${sch_ns}${#sch_job_id}_${sch_job_id}_${sch_param}}\""
+	done
+
+	[ -n "${sch_param_seen}" ] ||
+		{ sch_fail_msg "${sch_me}: no params specified."; return 1; }
+}
+
+# Set a per-job timeout, overriding ${SCHED_JOB_TIMEOUT_S} for this job
+# 1: job ID
+# 2: timeout in seconds
+job_set_timeout() {
+	local sch_me=job_set_timeout \
+		IFS=" "$'\t'$'\n' \
+		sch_val="${2}" \
+		sch_ns \
+		sch_job_id="${1}"
+
+	sch_get_ns sch_ns "${sch_me}" &&
+	sch_check_name "job ID" "${sch_job_id}" "${sch_me}" || return 1
+
+	sch_is_uint "${sch_val}" && [ "${sch_val}" -ge 1 ] || {
+		sch_fail_msg "${sch_me}: invalid timeout value '${sch_val}' for job '${sch_job_id}'."
+		return 1
+	}
+	sch_tr_leading sch_val "0"
+	export -n "SCH_TIMEOUT_JOB_${sch_ns}${sch_job_id}=${sch_val}"
+}
+
+jobs_abort() {
+	local \
+		sch_me=jobs_abort \
+		IFS=" "$'\t'$'\n' \
+		sch_job_id sch_job_pid sch_kill_pids
+
+	# guard against calls from DO_JOB_CB, SCHED_FINALIZE_CB or outside the scheduler
+	sch_in_main_process "${sch_me}" || return 1
+
+	for sch_job_id in "${@}"; do
+		sch_check_name "job ID" "${sch_job_id}" "${sch_me}" || continue
+		sch_is_included "${sch_job_id}" "${SCH_JOB_IDS}" || { sch_fail_msg "${sch_me}: unknown job ID '${sch_job_id}'."; continue; }
+		# Not dispatched yet: stays undispatched rather than aborted - outcome matters more than cause
+		if sch_is_included "${sch_job_id}" "${SCH_PENDING_IDS}"; then
+			sch_rm_elem SCH_PENDING_IDS "${sch_job_id}" "${SCH_PENDING_IDS}"
+		elif sch_pid_of_id sch_job_pid "${sch_job_id}" "${SCH_RUNNING}"; then
+			sch_rm_elem SCH_RUNNING "${sch_job_pid}:${sch_job_id}" "${SCH_RUNNING}"
+			[ -n "${SCH_DEADLINES}" ] &&
+				sch_deadline_rm_id SCH_DEADLINES "${sch_job_id}" "${SCH_DEADLINES}"
+			SCH_RUNNING_JOBS_CNT=$((SCH_RUNNING_JOBS_CNT - 1))
+			sch_append SCH_UNREAPED "${sch_job_pid}:${sch_job_id}"
+			sch_append SCH_ABORTED_IDS "${sch_job_id}"
+			[ -n "${JOB_TERM_CB}" ] && sch_append sch_kill_pids "${sch_job_pid}"
+		fi
+	done
+	[ -n "${sch_kill_pids}" ] || return 0
+	sch_term_run ${sch_kill_pids}
+	:
+}

--- a/usr/lib/adblock-lean/abl-scheduler.sh
+++ b/usr/lib/adblock-lean/abl-scheduler.sh
@@ -31,24 +31,20 @@ sch_is_cmd() {
 	is_cmd "${@}"
 }
 
+sch_job_term_ppid() {
+	term_ppid "${@}"
+}
+
+sch_has_f() {
+	has_f
+}
+
 sch_tr_leading() {
 	sch_check_name "var" "${1}" &&
 	tr_leading "${@}"
 }
 
-sch_tr_trailing() {
-	sch_check_name "var" "${1}" &&
-	tr_trailing "${@}"
-}
-
 # --- Unmodified code from upstream below
-
-sch_has_f() {
-	case "${-}" in
-		*f*) return 0 ;;
-		*) return 1
-	esac
-}
 
 # Look up PID of a job in list of '<pid>:<job ID>' entries
 # 1: out var
@@ -95,11 +91,11 @@ sch_get_uid() {
 }
 
 sch_check_name() {
-	local scn_pfx="SCH_JOB_PARAMS_${#SCHED_ID}_${SCHED_ID}_" scn_max_len=2020
+	local pfx="SCH_JOB_PARAMS_${#SCHED_ID}_${SCHED_ID}_" max_len=2020
 
-	[ "${1}" = var ] && scn_max_len=$((scn_max_len + ${#scn_pfx}))
+	[ "${1}" = var ] && max_len=$((max_len + ${#pfx}))
 
-	[ "${#2}" -le "${scn_max_len}" ] &&
+	[ "${#2}" -le "${max_len}" ] &&
 	case "${2}" in
 		''|*[!a-zA-Z0-9_]*) false ;;
 		*) : ;;
@@ -130,13 +126,18 @@ sch_check_var_name() {
 }
 
 # 1: caller
+# any extra args attached to err msg
 sch_in_main_process() {
-	local sip_uid
-	sch_get_uid sip_uid &&
-	[ "${sip_uid}" = "${SCHED_UID}" ] &&
-	eval "[ -n \"\${SCH_STARTED_${sip_uid}}\" ]" &&
+	local uid arg args caller="${1}"
+	sch_get_uid uid &&
+	[ "${uid}" = "${SCHED_UID}" ] &&
+	eval "[ -n \"\${SCH_STARTED_${uid}}\" ]" &&
 		return 0
-	sch_fail_msg "${1}: SCHED_UID is not set or scheduler is not running in this process."
+	[ "${#}" -ge 1 ] && shift
+	for arg in "${@}"; do
+		args="${args}${args:+, }'${arg}'"
+	done
+	sch_fail_msg "${caller}: Scheduler is not running in this process or SCHED_UID '${SCHED_UID}' doesn't match this process UID '${uid}'.${args:+" args: ${args}"}"
 	return 1
 }
 
@@ -155,7 +156,7 @@ sch_finalize() {
 		IFS=" "$'\t'$'\n' \
 		sch_rv="${1}"
 
-	sch_in_main_process "${sch_me}" ||
+	sch_in_main_process "${sch_me}" "${@}" ||
 		return "${sch_rv:-1}"
 
 	unset "SCH_STARTED_${SCHED_UID}"
@@ -242,7 +243,6 @@ sch_run_done_cb() {
 	sch_has_f && sch_had_f=1
 	set -f
 
-	# 'local' with invalid name aborts busybox ash
 	for sch_p in ${sch_names}; do
 		sch_check_var_name "${sch_p}" "${sch_me}" || { sch_names=; break; }
 	done
@@ -271,7 +271,7 @@ sch_read_rec() {
 		IFS= read -t 0 -r _ < "${srr_fifo}" &&
 			IFS= read -t 1 -r srr_tail < "${srr_fifo}"
 
-		[ -n "${BASH_VERSION}" ] || [ -n "${srr_rec}" ] || srr_tail=
+		[ -n "${BASH_VERSION}" ] || [ -n "${SHED_VERSION}" ] || [ -n "${srr_rec}" ] || srr_tail=
 
 		srr_rec="${srr_rec}${srr_tail}"
 		[ -n "${srr_rec}" ] || return 1
@@ -440,88 +440,6 @@ sch_term_run() {
 }
 
 #
-# Job termination functions
-#
-
-# Job termination callback (ppid-walk mechanism)
-# Args: job PIDs
-sched_job_term_mini() {
-	local \
-		me=sched_job_term_mini \
-		sjt_had_f \
-		sjt_p sjt_seeds sjt_all sjt_prev sjt_found sjt_try
-
-	sjt_seeds=
-	for sjt_p in "${@}"; do
-		sch_is_uint "${sjt_p}" ||
-			{ sch_fail_msg "${me}: ignoring invalid PID '${sjt_p}'."; continue; }
-		sch_append sjt_seeds "${sjt_p}"
-	done
-	[ -n "${sjt_seeds}" ] || return 0
-
-	# Freeze, re-scan to fixpoint, kill
-	sjt_all="${sjt_seeds}"
-	sjt_prev=
-
-	sch_has_f && sjt_had_f=1
-	set -f
-
-	for sjt_try in 1 2 3; do
-		kill -STOP ${sjt_all} 2>/dev/null
-
-		# Get all live descendant PIDs (space-separated, seeds excluded).
-		sjt_found="$(
-			set +f
-			cat /proc/[0-9]*/stat 2>/dev/null | {
-				set -f
-				# shellcheck disable=SC2016
-				${SCHED_AWK_CMD:-awk} -v seeds="${sjt_all}" '
-				/^[0-9]+ \(/ {
-					pid = $1
-					s = $0
-					# Strip "pid (comm) X " (X = single state char).
-					# comm may contain spaces and parens - the greedy match handles those;
-					#   a line that does not match is a fragment of a newline-containing comm - skip
-					if (!sub(/^[0-9]+ \(.*\) . /, "", s)) next
-					split(s, f, " ")
-					if (f[1] !~ /^[0-9]+$/) next
-					ppid[pid] = f[1]
-					valid++
-				}
-				END {
-					if (!valid) exit 1
-					n = split(seeds, a, " ")
-					for (i = 1; i <= n; i++)
-						if (a[i] ~ /^[0-9]+$/) {
-							seed[a[i]] = 1
-							want[a[i]] = 1
-						}
-					do {
-						changed = 0
-						for (p in ppid)
-							if (!(p in want) && (ppid[p] in want)) { want[p] = 1; changed = 1 }
-					} while (changed)
-					for (p in want) if (!(p in seed)) printf "%s ", p
-				}'
-			}
-		)" || {
-			sch_fail_msg "${me}: /proc scan failed."
-			break
-		}
-
-		sch_append sjt_all "${sjt_found}"
-		sch_tr_trailing sjt_all " "
-		[ "${sjt_all}" = "${sjt_prev}" ] && break
-		sjt_prev="${sjt_all}"
-	done
-
-	kill -KILL ${sjt_all} 2>/dev/null
-
-	[ -n "${sjt_had_f}" ] || set +f
-	:
-}
-
-#
 # User-facing functions
 #
 
@@ -556,7 +474,7 @@ schedule_jobs() {
 		[ -z "${val}" ] && [ -z "${3}" ] && return 0
 		sch_is_uint "${val}" && [ "${val}" -ge 1 ] ||
 			{ sch_fail_msg "Invalid value '${val}' of env var SCHED_${1#SCH_}."; return 1; }
-		sch_tr_leading val "0"
+		sch_tr_leading val "${val}" "0"
 		export -n "${1}=${val}"
 	}
 
@@ -582,8 +500,8 @@ schedule_jobs() {
 		sch_run_n \
 		sch_dir="/tmp" \
 		\
-		SCH_RUNNING_JOBS_CNT=0 \
 		SCH_IPC_FIFO \
+		SCH_RUNNING_JOBS_CNT=0 \
 		SCH_HAD_F \
 		SCH_REMAIN_TIME_CS \
 		SCH_INIT_UPTIME_CS \
@@ -612,7 +530,7 @@ schedule_jobs() {
 
 	sch_has_f && SCH_HAD_F=1
 
-	[ -n "${SCHED_AUTO_JOB_TERM}" ] && JOB_TERM_CB=sched_job_term_mini
+	[ -n "${SCHED_AUTO_JOB_TERM}" ] && JOB_TERM_CB=sch_job_term_ppid
 
 	# Check callbacks
 	sch_check_cb SCHED_FAIL_MSG_CB &&
@@ -754,37 +672,37 @@ schedule_jobs() {
 jobs_init() {
 	local \
 		IFS=" "$'\t'$'\n' \
-		sch_had_f \
-		sch_cur_params \
-		sch_param \
-		sch_job_id \
-		sch_ns \
-		sch_rv=0
+		had_f \
+		cur_params \
+		param \
+		job_id \
+		ns \
+		rv=0
 
 	# Resolved before any name is built: 'unset' with an invalid name aborts busybox ash
-	sch_get_ns sch_ns "jobs_init" || return 1
+	sch_get_ns ns "jobs_init" || return 1
 
-	sch_has_f && sch_had_f=1
+	sch_has_f && had_f=1
 	set -f
 
 	#shellcheck disable=SC2048
-	for sch_job_id in ${*}; do
-		sch_check_name "job ID" "${sch_job_id}" "jobs_init" ||
-			{ sch_rv=1; break; }
-		eval "sch_cur_params=\"\${SCH_JOB_PARAMS_${sch_ns}${sch_job_id}}\""
+	for job_id in ${*}; do
+		sch_check_name "job ID" "${job_id}" "jobs_init" ||
+			{ rv=1; break; }
+		eval "cur_params=\"\${SCH_JOB_PARAMS_${ns}${job_id}}\""
 
-		for sch_param in ${sch_cur_params}; do
-			case "${sch_param}" in
+		for param in ${cur_params}; do
+			case "${param}" in
 				''|*[!a-zA-Z0-9_]*) continue ;;
 			esac
-			unset "SCH_JOB_PARAM_${sch_ns}${#sch_job_id}_${sch_job_id}_${sch_param}"
+			unset "SCH_JOB_PARAM_${ns}${#job_id}_${job_id}_${param}"
 		done
-		unset "SCH_JOB_PARAMS_${sch_ns}${sch_job_id}" \
-			"SCH_TIMEOUT_JOB_${sch_ns}${sch_job_id}"
+		unset "SCH_JOB_PARAMS_${ns}${job_id}" \
+			"SCH_TIMEOUT_JOB_${ns}${job_id}"
 	done
 
-	[ -n "${sch_had_f}" ] || set +f
-	return "${sch_rv}"
+	[ -n "${had_f}" ] || set +f
+	return "${rv}"
 }
 
 # 1: job ID
@@ -896,36 +814,36 @@ job_set_timeout() {
 		sch_fail_msg "${sch_me}: invalid timeout value '${sch_val}' for job '${sch_job_id}'."
 		return 1
 	}
-	sch_tr_leading sch_val "0"
+	sch_tr_leading sch_val "${sch_val}" "0"
 	export -n "SCH_TIMEOUT_JOB_${sch_ns}${sch_job_id}=${sch_val}"
 }
 
 jobs_abort() {
 	local \
-		sch_me=jobs_abort \
+		me=jobs_abort \
 		IFS=" "$'\t'$'\n' \
-		sch_job_id sch_job_pid sch_kill_pids
+		job_id job_pid kill_pids
 
 	# guard against calls from DO_JOB_CB, SCHED_FINALIZE_CB or outside the scheduler
-	sch_in_main_process "${sch_me}" || return 1
+	sch_in_main_process "${me}" "${@}" || return 1
 
-	for sch_job_id in "${@}"; do
-		sch_check_name "job ID" "${sch_job_id}" "${sch_me}" || continue
-		sch_is_included "${sch_job_id}" "${SCH_JOB_IDS}" || { sch_fail_msg "${sch_me}: unknown job ID '${sch_job_id}'."; continue; }
+	for job_id in "${@}"; do
+		sch_check_name "job ID" "${job_id}" "${me}" || continue
+		sch_is_included "${job_id}" "${SCH_JOB_IDS}" || { sch_fail_msg "${me}: unknown job ID '${job_id}'."; continue; }
 		# Not dispatched yet: stays undispatched rather than aborted - outcome matters more than cause
-		if sch_is_included "${sch_job_id}" "${SCH_PENDING_IDS}"; then
-			sch_rm_elem SCH_PENDING_IDS "${sch_job_id}" "${SCH_PENDING_IDS}"
-		elif sch_pid_of_id sch_job_pid "${sch_job_id}" "${SCH_RUNNING}"; then
-			sch_rm_elem SCH_RUNNING "${sch_job_pid}:${sch_job_id}" "${SCH_RUNNING}"
+		if sch_is_included "${job_id}" "${SCH_PENDING_IDS}"; then
+			sch_rm_elem SCH_PENDING_IDS "${job_id}" "${SCH_PENDING_IDS}"
+		elif sch_pid_of_id job_pid "${job_id}" "${SCH_RUNNING}"; then
+			sch_rm_elem SCH_RUNNING "${job_pid}:${job_id}" "${SCH_RUNNING}"
 			[ -n "${SCH_DEADLINES}" ] &&
-				sch_deadline_rm_id SCH_DEADLINES "${sch_job_id}" "${SCH_DEADLINES}"
+				sch_deadline_rm_id SCH_DEADLINES "${job_id}" "${SCH_DEADLINES}"
 			SCH_RUNNING_JOBS_CNT=$((SCH_RUNNING_JOBS_CNT - 1))
-			sch_append SCH_UNREAPED "${sch_job_pid}:${sch_job_id}"
-			sch_append SCH_ABORTED_IDS "${sch_job_id}"
-			[ -n "${JOB_TERM_CB}" ] && sch_append sch_kill_pids "${sch_job_pid}"
+			sch_append SCH_UNREAPED "${job_pid}:${job_id}"
+			sch_append SCH_ABORTED_IDS "${job_id}"
+			[ -n "${JOB_TERM_CB}" ] && sch_append kill_pids "${job_pid}"
 		fi
 	done
-	[ -n "${sch_kill_pids}" ] || return 0
-	sch_term_run ${sch_kill_pids}
+	[ -n "${kill_pids}" ] || return 0
+	sch_term_run ${kill_pids}
 	:
 }


### PR DESCRIPTION
1. Rework parts processing:
- Use abl-scheduler
- Handle processing failures for each blocksert individually (one blockset's processing may fail while another succeeds)
- At parts assembly stage, distinguish between missing parts and failed parts

2. Rewrite DNS testing/verification subsystem:
- Use abl-scheduler for parallel lookups
- abl_test_domain is now blockset-specific (the synthesized bogus domain name includes the blockset's MD5sum, or, in single-instance mode, the blockset name)
- DNS verification targets the addresses dnsmasq is actually listening on, derived this way: read dnsmasq state from ubus, correlate each instance's listening sockets with its assigned interfaces, generate a bounded prioritized list of addresses
- Support dnsmasq instances configured to listen on "wildcard" interfaces
- Support dnsmasq instances listening on arbitrary ports
- Bound DNS lookup attempts by time budget rather than by attempts count
- Report which blockset failed on which dnsmasq instance
- At-init DNS verification - in set_blocksets_env() - consists of testing only abl_test_domain, 0s time budget - no retries are made. Verification is a success when abl_test_domain resolves for **every** asociated dnsmasq instance, across **any** sockets each instance is listening on.
- Post-blockset-install DNS verification - in try_install_blocksets() - consists of testing abl_test_domain (25s budget) **and subsequently** user-configured test domains (5s budget). Verification is a success when abl_test_domain **and any user-specified test domain** resolves for **every** associated dnamsq instance, across **any** sockets each instance is listening on.
- Pre-download connectivity check - in test_fetch_doms() - tests in parallel lookups of **all** domains used for blockset download against **any** nameservers fetched from /etc/resolv.conf (rather than hard-coded loopback addresses). Time budget 7s. If any domains fail, connectivity check fails.
- Always test all blocksets affected by a dnsmasq restart

3. Remove support for dnsmasq-format lists, including config options removal

4. Identify dnsmasq instances by name rather than by index - changes config options

5. Support local ipv4 blocklist - adds config option 'local_ipv4_blocklist_path'

6. Misc changes:
- set_blocksets_env: determine run state of all blocksets before per-blockset initialization
- try_install_blocksets: update per-blockset cur_* params at install time
- Use set_int(), test_exp() for lookup arithmetic
- Shorten local variable prefixes
- read_str_from_file: error out when the file is too large
- calls to read_str_from_file: always limit max read size
- Enable noglob and pipefail shell options at init script top level
- do_setup: force stop all blocksets; use find_files
- move option max_part_size_KB back into blockset config
- parse_config: notify about deprecated options
- glob/noglob improvements
- print_def_cfg_blockset: rename options
- ver_upd_fixup: separate fields by newline only
- wait_on_pid: sleep asynchronously
- start: use ${RANDOM} for random delay computation
- uninstall: remove addnmounts more efficiently

- add abl-scheduler.sh (refactored and heavily modified+improved scheduler originating in adblock-lean and now developed [separately](https://github.com/friendly-bits/shell-scheduler))