### PR TITLE
Bugfixes

### DIFF
--- a/abl-install.sh
+++ b/abl-install.sh
@@ -263,11 +263,9 @@ try_mkdir_install()
 	:
 }
 
-print_msg_install()
-{ reg_msg_install -4 "${@}"; }
+print_msg_install() { reg_msg_install -4 "${@}"; }
 
-log_msg_install()
-{ reg_msg_install -1 "${@}"; }
+log_msg_install() { reg_msg_install -1 "${@}"; }
 
 # Depending on msg-specific log level, on global ${ABL_LOG_LEVEL} and on ${ABL_DEBUG}:
 # Prints each msg separately to console [ and to log file ] [ and sends to system log ]
@@ -354,7 +352,7 @@ write_log_file_install()
 
 reg_fail_install()
 {
-	log_msg_install -err "" "${1}"
+	log_msg_install -err "" "${@}"
 	luci_errors="${luci_errors}${1}${_NL_}"
 }
 
@@ -768,13 +766,19 @@ get_cur_main_cfg_path()
 install_abl_files()
 {
 	local IFS="${DEFAULT_IFS:?}" \
-		file preinst_path old_files='' exec_files='' \
+		file preinst_path old_files exec_files \
 		preinst_reg_file="${dist_dir}/preinst_reg.md5" \
-		cfg_fname \
+		cfg_file cfg_fname \
+		cfg_id cfg_id_orig \
 		cfg_files_to_rm \
 		cur_main_cfg_path \
-		cur_cfg_format='' upd_cfg_format='' \
+		cur_cfg_format upd_cfg_format \
 		cur_blockset_cfg_files \
+		new_cfg_path \
+		prev_cfg_files \
+		bk_cfg_f bk_f_prefix \
+		var_suffix \
+		migr_fail migrate_opts \
 		dist_dir="${1}" version="${2}" upd_channel="${3}" new_file_list="${4}"
 
 	[ -n "${1}" ] && [ -n "${2}" ] && [ -n "${3}" ] || inst_failed "install_abl_files: Missing arguments."
@@ -1091,6 +1095,7 @@ install_abl_files()
 				do
 					IFS="${DEFAULT_IFS}"
 					cfg_id_orig=
+					var_suffix=
 					get_cfg_id_install cfg_id_orig "${cfg_file}" || { migr_fail=1; break; }
 					cfg_id="${cfg_id_orig}"
 
@@ -1231,7 +1236,7 @@ fetch_and_install()
 
 	set -o pipefail
 
-	local OPTIND file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
+	local opt OPTIND file req_ver='' ver_str_arg='' ver_type='' dist_dir='' upd_ver='' tarball_url='' \
 		upd_channel='' req_upd_channel='' force_upd_channel=''
 
 	IGNORE_CACHE=

--- a/adblock-lean
+++ b/adblock-lean
@@ -475,7 +475,7 @@ read_str_from_file()
 {
 	local me=read_str_from_file rs_rv rs_del_file rs_quiet rs_num_bytes rs_limit rs_outvars rs_file rs_too_big rs_probe rs_fs=" "$'\t' \
 		rs_file_desc rs_def_val rs_read_failed rs_attempts=1 rs_attempt rs_var rs_val \
-		OPTIND IFS="${DEFAULT_IFS}"
+		opt OPTIND IFS="${DEFAULT_IFS}"
 	while getopts ":dqn:v:f:a:D:V:F:" opt
 	do
 		case "${opt}" in
@@ -759,7 +759,7 @@ rm_bk()
 # KEEP_PERSIST, KEEP_BK
 rm_blocksets()
 {
-	local set_id install_path cur_path cur_persist_path persist_mode rm_enum rm_path rm_pr \
+	local set_id install_path cur_path cur_persist_path persist_mode rm_enum rm_path rm_pr bk_file \
 		rm_rv=0 \
 		set_ids="${*:-"${SET_IDS}"}"
 
@@ -987,12 +987,12 @@ detect_main_utils()
 
 reg_fail()
 {
-	local arg fail_msg
+	local arg
 	log_msg -err "${@}"
 	for arg in "${@}"; do
-		abl_append fail_msg "${arg}" "${_NL_}"
+		abl_append ABL_FAIL_MSG "${arg}" "${_NL_}"
 	done
-	luci_errors="${fail_msg}"
+	luci_errors="${ABL_FAIL_MSG}"
 }
 
 reg_success() { log_msg -report "${@}"; }
@@ -1030,13 +1030,14 @@ reg_msg()
 
 	dbg_off
 
-	local m msgs msgs_nc msgs_prefix debug_prefix _arg err_l=info color _n_c \
+	local m c msgs msgs_nc msgs_prefix debug_prefix _arg err_l=info color _n_c \
 		print_req sys_log_req log_file_req action_req report_req noprint \
 		set_ids ids_pr_prefix fetch_ids set_ids_pr \
 		set_id_hl_on set_id_hl_off force_ids \
 		msg_level msgs_dest="${MSGS_DEST}" \
 		\
 		reg_req \
+		thresh \
 		sys_log_thresh="${LOG_VERBOSITY:-"1"}"
 
 	local IFS="${DEFAULT_IFS}"
@@ -1189,10 +1190,10 @@ cleanup_and_exit()
 	luci_log="${recent_log}"
 
 	# execute custom script actions
-	if [ -z "${ABL_LUCI_SOURCED}" ] && [ -n "${failure_msg}" ] && [ -n "${custom_scr_sourced}" ] && check_func report_failure
+	if [ -z "${ABL_LUCI_SOURCED}" ] && [ -n "${ABL_FAIL_MSG}" ] && [ -n "${custom_scr_sourced}" ] && check_func report_failure
 	then
-		[ -n "${recent_log}" ] && failure_msg="${failure_msg}${_NL_}${_NL_}Session log:${_NL_}${recent_log}"
-		report_failure "${failure_msg}"
+		[ -n "${recent_log}" ] && ABL_FAIL_MSG="${ABL_FAIL_MSG}${_NL_}${_NL_}Session log:${_NL_}${recent_log}"
+		report_failure "${ABL_FAIL_MSG}"
 	fi
 	if [ -n "${UPD_AVAIL_MSG}" ] && check_func report_update
 	then
@@ -1207,7 +1208,7 @@ cleanup_and_exit()
 
 dmsq_stop_restart_shared()
 {
-	local rv instance d_instances dmsq_instances cmd_pr cmd_fail d_fail_ids \
+	local rv instance d_instances dmsq_instances cmd_pr cmd_fail set_id d_fail_ids \
 		cmd="${1}" set_ids="${2}" d_ok_ids_out_var="${3:-_}" instances_out_var="${4:-_}"
 
 	unset_vars "${instances_out_var}" "${d_ok_ids_out_var}"
@@ -1237,7 +1238,7 @@ dmsq_stop_restart_shared()
 			[ -n "${SET_IDS}" ] && set_params "${SET_IDS}" run_state=1
 			return 1
 		}
-		return 0
+		return ${rv:-0}
 	fi
 
 	for instance in ${d_instances}
@@ -1282,10 +1283,11 @@ restart_dnsmasq()
 {
 	local rv instance instances \
 		dmsq_instances \
+		set_id \
 		p1_ok_ids \
 		restart_ok_ids \
 		restart_fail_ids \
-		res_attempts \
+		i res_attempts \
 		new_run_state="${1}" restart_ok_ids_out_var="${2:-_}" set_ids="${3}"
 
 	unset_vars "${restart_ok_ids_out_var}"
@@ -1374,6 +1376,7 @@ check_lock()
 	read_str_from_file -n 64 -v "LOCK_PID _" -f "${PID_FILE}" -a 3 -D PID || return 1
 
 	case "${LOCK_PID}" in
+		1|0*) return 1 ;;
 		"${$}") return 3 ;;
 		*[!0-9]*) reg_fail "PID file '${PID_FILE}' contains unexpected string '${LOCK_PID}'."; unset LOCK_PID; return 1 ;;
 		*) kill -0 "${LOCK_PID}" 2>/dev/null && return 2
@@ -1430,7 +1433,7 @@ report_cur_action()
 }
 
 wait_on_pids() {
-	local i=1 pids_tmp \
+	local i=1 pids_tmp pid \
 		pids="${1}" max_kill_wait_s="${2}"
 
 	while :
@@ -2265,7 +2268,7 @@ gen_blockset_config()
 	init_act "${CUR_ACT}" &&
 	set_all_env &&
 	do_gen_blockset_config set_id "${set_id}" &&
-	do_create_addnmounts "${set_id}" || return 1
+	do_create_addnmounts || return 1
 	if [ "${DO_DIALOGS}" = 1 ]
 	then
 		print_msg -bf "${set_id}" "" "Start{} now? (y|n)"
@@ -2285,7 +2288,7 @@ rm_blockset_config()
 
 do_rm_blockset_config()
 {
-	local cfg_path \
+	local cfg_path persist_dir persist_meta_file \
 		set_id="${1}"
 
 	is_known_set_id "${set_id}" rm_blockset_config &&
@@ -2438,7 +2441,7 @@ select_dnsmasq_instances()
 		)" &&
 		write_config bl "${set_id}" "${upd_cfg}" || return 1
 	done
-	do_create_addnmounts "${set_ids}" || return 1
+	do_create_addnmounts || return 1
 }
 
 # 1 - (optional) '-noexit' to return to the calling function
@@ -2474,8 +2477,8 @@ start()
 	local CUR_ACT=start
 	local CUR_CMD=${CUR_ACT}
 	init_act "${CUR_ACT}" || exit 1
-	FAIL_STOP_REQ=1 do_start "${@}"
-	start_rv=${?}
+	do_start "${@}"
+	local start_rv=${?}
 	check_for_updates
 	exit ${start_rv}
 }
@@ -2487,12 +2490,13 @@ do_start()
 	BLOCKSETS_TO_INSTALL=
 	BLOCKSETS_TO_GEN=
 
-	local CUR_CMD=start
+	local CUR_CMD=start \
+		FAIL_STOP_REQ=1
 
 	if [ "${RANDOM_DELAY}" = "1" ]
 	then
 		random_delay_mins=$(( ${RANDOM:-0} % 61))
-		reg_action -1 -purple "Delaying automatic lists update by ${random_delay_mins} minutes (thundering herd prevention)." || exit 1
+		reg_action -1 -purple "Delaying automatic lists update by ${random_delay_mins} minutes (thundering herd prevention)." || return 1
 		sleep "${random_delay_mins}m" &
 		wait ${!}
 	fi
@@ -2568,7 +2572,7 @@ do_start()
 				then
 					add2list BLOCKSETS_TO_INSTALL "${set_id}"
 				else
-					reg_fail -fb "Failed to restore ${bl_pr}."
+					reg_fail -fb "${set_id}" "Failed to restore ${bl_pr}."
 					rm_bk "${set_id}"
 				fi
 			else
@@ -2617,7 +2621,7 @@ do_start()
 		reg_msg "Processing time for blockset generation and import: ${lblue}${elapsed_time:-"${yellow}unknown"}${n_c}"
 	}
 
-	:
+	return ${do_start_rv}
 }
 
 gen_persist_blockset()
@@ -2737,7 +2741,7 @@ do_stop()
 	done
 	set -f
 
-	restart_dnsmasq 4 # all dnsmasq instances
+	restart_dnsmasq "" # all dnsmasq instances
 
 	[ -n "${SET_IDS}" ] &&
 	{
@@ -2748,7 +2752,6 @@ do_stop()
 	return 0 # uncoditional on purpose
 }
 
-# Env vars: FORCE_STOP
 stop_blocksets()
 {
 	local set_id \
@@ -2765,7 +2768,7 @@ stop_blocksets()
 	for set_id in ${set_ids}
 	do
 		get_params "${set_id}" run_state
-		[ "${run_state}" = 4 ] && [ -z "${FORCE_STOP}" ] &&
+		[ "${run_state}" = 4 ] &&
 		{
 			[ "${CUR_ACT}" = stop ] && reg_msg -fb "${set_id}" "Adblocking is already stopped{}."
 			continue
@@ -2792,7 +2795,7 @@ stop_blocksets()
 	[ -n "${stop_ok_ids}" ] &&
 		log_msg -fb "${stop_ok_ids}" "Successfully stopped adblocking{}."
 
-	[ -n "${stop_fail_ids}" ] && { reg_fail -fb "${stop_fail_ids}" "Failed to stop adblocking{}."; exit 1; }
+	[ -n "${stop_fail_ids}" ] && { reg_fail -fb "${stop_fail_ids}" "Failed to stop adblocking{}."; return 1; }
 	return ${stop_rv}
 }
 
@@ -2812,8 +2815,7 @@ reload() { restart "${@}"; }
 # 0 - adblock-lean blockset is loaded
 # 1 - error
 # 2 - adblock-lean is performing an action
-# 3 - adblock-lean is paused
-# 4 - adblock-lean is stopped
+# 3 - no blockset loaded
 status()
 {
 	check_lock
@@ -2850,7 +2852,7 @@ status()
 	elif [ -z "${SET_IDS}" ]
 	then
 		reg_fail "No blockset configs found."
-		status_rv=1
+		status_rv=3
 	elif [ -z "${set_ids}" ]
 	then
 		reg_fail "No valid blockset IDs specified."
@@ -2916,7 +2918,7 @@ pause_resume()
 	{
 		case "${1}" in
 			pause)
-				stop_blocksets "${2}" ;;
+				stop_blocksets "${2}" || exit 1 ;;
 			resume)
 				rm_conf_scripts "${2}"
 				rm_blocksets "${2}"
@@ -2946,7 +2948,6 @@ pause_resume()
 		install_1_instance \
 		pause_path \
 		state_ok_pr \
-		state_ok_msg \
 		state_changed_pr \
 		state_progr_pr \
 		FAIL_STOP_REQ=1 \
@@ -2979,20 +2980,19 @@ pause_resume()
 			0|3|4) ;;
 			*)
 				reg_fail "Run state of blockset '${set_id}' is '${run_state}'."
-				add2list prep_fail_ids
+				add2list prep_fail_ids "${set_id}"
 				continue
 		esac
 
 		case "${cmd},${run_state}" in
-			"pause,3"|"resume,0") state_ok_msg="Adblocking is ${state_ok_pr}{}."  ;;
-			"pause,4"|"resume,4") state_ok_msg="${yellow}Adblocking is stopped{}. Can not ${cmd}.${n_c}" ;;
-			*) false
-		esac &&
-		{
-			reg_msg -fb "${set_id}" "${state_ok_msg}"
-			add2list ok_ids "${set_id}"
-			continue
-		}
+			"pause,3"|"resume,0")
+				reg_msg -fb "${set_id}" "Adblocking is ${state_ok_pr}{}."
+				add2list ok_ids "${set_id}"
+				continue ;;
+			"pause,4"|"resume,4")
+				reg_msg -fb "${set_id}" "${yellow}Adblocking is stopped{}. Can not ${cmd}.${n_c}"
+				continue ;;
+		esac
 
 		log_msg -fb "${set_id}" "Preparing to ${cmd} adblocking{}."
 
@@ -3013,7 +3013,7 @@ pause_resume()
 		esac &&
 		set_params "${set_id}" cur_1_instance="${install_1_instance}" ||
 		{
-			add2list prep_fail_ids
+			add2list prep_fail_ids "${set_id}"
 			continue
 		}
 
@@ -3023,7 +3023,7 @@ pause_resume()
 	[ -n "${prep_fail_ids}" ] &&
 	{
 		reg_fail -fb "${prep_fail_ids}" "Failed to ${cmd} adblocking{}."
-		ASSERT_NOEXIT=1 KEEP_BK=0 KEEP_PERSIST=0 stop_blocksets "${prep_fail_ids}"
+		ASSERT_NOEXIT=1 KEEP_BK=0 KEEP_PERSIST=0 stop_blocksets "${prep_fail_ids}" || exit 1
 	}
 
 	[ -n "${prep_ok_ids}" ] &&
@@ -3079,16 +3079,16 @@ update()
 
 	upd_failed()
 	{
-		local fail_msg="${1}"
-		[ -s "${UCL_ERR_FILE}" ] && fail_msg="${fail_msg} uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'"
-		[ -n "${fail_msg}" ] && reg_fail "${fail_msg}"
+		local upd_fail_msg="${1}"
+		[ -s "${UCL_ERR_FILE}" ] && upd_fail_msg="${upd_fail_msg} uclient-fetch errors: '$(cat "${UCL_ERR_FILE}")'"
+		[ -n "${upd_fail_msg}" ] && reg_fail "${upd_fail_msg}"
 		reg_fail "Failed to update adblock-lean."
 		rm -rf "${ABL_UPD_DIR:-???}" "${ABL_PID_DIR:-???}" "${UCL_ERR_FILE:-???}"
 	}
 
 	unexp_arg() { upd_failed "update: unexpected argument '${1}'."; }
 
-	local OPTIND file req_ver ver_str_arg ver_type dist_dir upd_ver tarball_url \
+	local opt OPTIND file req_ver ver_str_arg ver_type dist_dir upd_ver tarball_url \
 		upd_channel req_upd_channel force_upd_channel upd_nostop \
 		cur_main_cfg_path cur_blockset_cfg_files cfg_found
 
@@ -3357,13 +3357,22 @@ calculate_limits()
 }
 
 
-export -n \
-	ABL_INIT_ACT='' \
-	CUR_ACT='' \
-	CUR_CMD='' \
-	LIBS_SOURCED='' \
-	MAIN_UTILS_DETECTED='' \
-	CDI_FATAL=''
+unset \
+	CONFIG_LOADED \
+	ABL_INIT_ACT \
+	CUR_ACT \
+	CUR_CMD \
+	LIBS_SOURCED \
+	MAIN_UTILS_DETECTED \
+	CDI_FATAL \
+	KEEP_PERSIST \
+	PARAMS_RESET \
+	STOP_NOEXIT \
+	ASSERT_NOEXIT \
+	FORCE_STOP_ALL \
+	SKIP_SET_ENV \
+	FAIL_STOP_REQ \
+	ABL_FAIL_MSG
 
 set -f
 set -o pipefail

--- a/usr/lib/adblock-lean/abl-lib.sh
+++ b/usr/lib/adblock-lean/abl-lib.sh
@@ -272,6 +272,7 @@ do_create_addnmounts()
 		IFS="${DEFAULT_IFS}" \
 		REPLY \
 		conf_dirs \
+		first_conf_dir \
 		instance dmsq_instances all_dmsq_instances \
 		req_addnm_instance \
 		\
@@ -941,7 +942,7 @@ print_def_cfg_blockset()
 # (optional) -d to print with allowed value types (otherwise print without)
 print_def_cfg_global()
 {
-	local me=print_def_cfg_global print_types preset OPTIND
+	local me=print_def_cfg_global print_types preset OPTIND opt
 	while getopts ":i:n:c:p:d" opt; do
 		case "${opt}" in
 			i|n|c) : ;; # ignore these options
@@ -1707,6 +1708,7 @@ fix_config()
 		fixed_cfg \
 		bk_prefix \
 		cfg_type \
+		cfg_path \
 			cfg_id="${1:?}" replace_keys="${2}"
 
 	get_cfg_type cfg_type "${cfg_id}" &&

--- a/usr/lib/adblock-lean/abl-manage.sh
+++ b/usr/lib/adblock-lean/abl-manage.sh
@@ -519,7 +519,7 @@ parse_dmsq_runtime()
 	local me=parse_dmsq_runtime \
 		IFS="${DEFAULT_IFS}" \
 		nonempty instance instances running l1_conf_file l1_conf_files conf_dirs_cnt conf_dirs_nl i s f dir ujail_pid line \
-		ns_parse_res \
+		ns ns_parse_res \
 		devs not_devs devs_by_instance instances_by_ujail_pid \
 		jshn_sh=/usr/share/libubox/jshn.sh
 
@@ -1164,7 +1164,8 @@ mv_blockset()
 # If src dir is protected, copy file instead of moving
 try_mv_blockset()
 {
-	local transfer_cmd="try_mv -q" \
+	local me=try_mv_blockset \
+		transfer_cmd="try_mv -q" \
 		md5_changed \
 		cur_md5 \
 		mv_src_d mv_src_ext \
@@ -1250,19 +1251,21 @@ check_persist_blockset()
 {
 	local max_set_size min_entries min_entries_human \
 		persist_check_rv \
-		persist_ext persist_mode cur_persist_path cur_persist_cnt cur_persist_cnt_human cur_persist_size_b \
+		persist_ext persist_mode persist_dir \
+		cur_persist_path cur_persist_cnt cur_persist_cnt_human cur_persist_size_b \
 		run_state \
 		cur_cnt \
 		set_id="${1}" final_compr_ext="${2}"
 
-	get_params -f "check_persist_blockset" "${set_id}" persist_mode min_entries=min_blockset_entries max_set_size run_state || return 1
+	get_params -f "check_persist_blockset" "${set_id}" persist_mode persist_dir min_entries=min_blockset_entries max_set_size run_state || return 1
 	get_params "${set_id}" cur_persist_path
 	debug_msg "Checking persistent blockset file: ${blue}${cur_persist_path}${n_c}"
 
 	{
 		[ -n "${cur_persist_path}" ] ||
 			{
-				[ "${run_state}" != 4 ] || [ "${persist_mode}" = manual ] && [ "${CUR_ACT}" != gen_persist_blockset ] &&
+				[ "${CUR_ACT}" != gen_persist_blockset ] &&
+				{ [ "${run_state}" != 4 ] || [ "${persist_mode}" = manual ]; } &&
 					reg_fail -fb "${set_id}" "Persistent blockset file{} not found in directory '${persist_dir}'."
 				false
 			}
@@ -1321,8 +1324,8 @@ check_addnmounts()
 try_check_addnmounts()
 {
 	local me=check_addnmounts \
-		IFS="${DEFAULT_IFS}" \
-		ca_instance ca_path ca_addnmounts \
+		IFS="${DEFAULT_IFS}" i \
+		ca_instance ca_path ca_path_tmp ca_addnmounts \
 		ca_missing_var="${1}" ca_instances="${2}" ca_req_addnm="${3}"
 
 	unset_vars "${ca_missing_var}"
@@ -1445,7 +1448,7 @@ set_global_env()
 # Run states:
 # 0 - running
 # 1 - error
-# 2 - (reserved)
+# 2 - transitional
 # 3 - paused
 # 4 - stopped
 #
@@ -1749,7 +1752,7 @@ set_blockset_env()
 		0|3|4) ;;
 		*)
 			case "${CUR_CMD}" in start|pause|resume)
-				KEEP_PERSIST=1 stop_blocksets "${set_id}"
+				KEEP_PERSIST=1 stop_blocksets "${set_id}" || exit 1
 				# stopping the blockset invalidated the earlier result
 				CA_NOERR=1 get_run_state "${set_id}" '?' run_state cur_path cur_1_instance || return 1
 				set_params "${set_id}" run_state cur_path cur_1_instance
@@ -1857,7 +1860,6 @@ set_blockset_env()
 	[ -n "${install_path}" ] ||
 		{ reg_fail -fb "${set_id}" "No usable path to install or load the blockset file{}."; rebuild_req_notice "${set_id}" "restart"; [ -n "${SBE_STATUS}" ] || return 1; }
 
-	[ -n "${install_path}" ] &&
 	case "${start_action}" in
 		load) add2list BLOCKSETS_TO_INSTALL "${set_id}" ;;
 		gen) add2list BLOCKSETS_TO_GEN "${set_id}" ;;
@@ -2022,18 +2024,20 @@ inst_failed()
 	subtract_a_from_b "${inst_fail_reported_ids}" "${fail_ids}" fail_report_ids
 	[ -n "${fail_report_ids}" ] &&
 	{
+		set_params "${fail_report_ids}" run_state=1
 		local set_pr=blockset
 		case "${fail_report_ids}" in *" "*) set_pr=blocksets; esac
 		reg_fail "Failed to install ${set_pr}: ${fail_ids}"
 		add2list inst_fail_reported_ids "${fail_report_ids}"
 	}
-	KEEP_BK=1 stop_blocksets "${fail_ids}"
+	KEEP_BK=1 stop_blocksets "${fail_ids}" || exit 1
 }
 
 install_blocksets()
 {
-	local inst_ok_ids inst_fail_ids INST_PERM_FAIL_IDS inst_rv \
+	local set_id inst_ok_ids inst_fail_ids INST_PERM_FAIL_IDS inst_rv \
 		inst_fail_reported_ids \
+		install_path install_path_ram install_1_instance_ram persist_mode \
 		ok_ids_out_var="${1:-_}" perm_fail_ids_out_var="${2:-_}" set_ids="${3:?}"
 
 	unset_vars "${ok_ids_out_var}" "${perm_fail_ids_out_var}"
@@ -2146,7 +2150,7 @@ try_install_blocksets()
 		add2list installed_ids "${set_id}"
 	done
 
-	[ -n "${installed_ids}" ] && restart_dnsmasq 5 dmsq_ok_ids "${installed_ids}"
+	[ -n "${installed_ids}" ] && restart_dnsmasq 2 dmsq_ok_ids "${installed_ids}"
 	subtract_a_from_b "${dmsq_ok_ids}" "${installed_ids}" dmsq_fail_ids
 	[ -n "${dmsq_fail_ids}" ] && inst_failed "${dmsq_fail_ids}"
 	[ -n "${dmsq_ok_ids}" ] || return 1

--- a/usr/lib/adblock-lean/abl-process.sh
+++ b/usr/lib/adblock-lean/abl-process.sh
@@ -337,7 +337,7 @@ process_set_part()
 		val_entry_regex='^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])$'
 	fi
 
-	local prev_mirror attempt=1
+	local prev_mirror next_mirror attempt=1
 	while :
 	do
 		feed_path="${print_id}"
@@ -640,6 +640,7 @@ gen_blocksets()
 		file_to_bk \
 		bk_file \
 		bk_ext \
+		bk_cnt \
 		final_compr_ext \
 		blocksets_to_stop \
 		force_unload_bl \
@@ -659,7 +660,7 @@ gen_blocksets()
 		set_indexes \
 		blocksets_out_var="${1:?}" set_ids="${2:?}"
 
-	: "${skip_load_stop}" "${bk_cnt}"
+	: "${skip_load_stop}"
 
 	reg_msg -fb "${set_ids}" "" "Preparing to generate blockset file(s){}."
 
@@ -746,6 +747,7 @@ gen_blocksets()
 		max_part_size_prev \
 		min_part_entries \
 		min_part_entries_prev \
+		dest_file \
 		is_ipv4 \
 		is_ipv4_prev
 
@@ -775,7 +777,7 @@ gen_blocksets()
 				"format=${format}" \
 				"origin=${origin}" \
 				"print_id=${part#"local="}" \
-				"dest_file=${PROCESSED_PARTS_DIR}/part_${index}${INTERM_COMPR_EXT}" \
+				"dest_file=${dest_file}" \
 				"part_stats_file=${PROCESSED_PARTS_DIR}/${index}_stats"
 
 			for part_type in ${ALL_PART_TYPES:?}
@@ -875,6 +877,7 @@ gen_blocksets()
 
 		set_params "${set_id}" skip_load_stop
 
+		bk_cnt=
 		bk_file=
 		file_to_bk=
 		if [ -n "${cur_path}" ]
@@ -1075,7 +1078,7 @@ gen_blockset()
 
 	# shellcheck disable=SC2034
 	# Process results
-	local part_file part_cnt part_size_B list_cnt_raw part_size_B index part_type print_id index_refs \
+	local part_file part_cnt part_size_B part_size_B_human list_cnt_raw list_cnt_raw_human part_size_B index part_type print_id index_refs \
 		set_cnt_raw=0 set_size_B_raw=0 allow_cnt_raw=0 block_cnt_raw=0 ipv4_block_cnt_raw=0 \
 		set_cnt_raw_human set_size_B_raw_human set_size_B set_size_B_human \
 		block_indexes allow_indexes ipv4_block_indexes
@@ -1140,7 +1143,6 @@ gen_blockset()
 
 	try_mkdir -p "${proc_dir}" || return 1
 
-	local list_cnt_raw_human part_size_B_human
 	for part_type in ${ALL_PART_TYPES}
 	do
 		# count entries for current list type
@@ -1152,7 +1154,7 @@ gen_blockset()
 			[ "${part_type}" = block ] &&
 			{
 				[ "${whitelist_mode}" = 1 ] || {
-					bytes2human part_size_B_raw_human "${part_size_B_raw:-0}"
+					bytes2human part_size_B_human "${part_size_B:-0}"
 					int2human list_cnt_raw_human "${list_cnt_raw:-0}"
 					reg_fail "Total entries count and size of block-entries: ${list_cnt_raw_human}, ${part_size_B_human}."
 					return 1


### PR DESCRIPTION
- Fix missing local variable declarations
- Clear internal control globals at load time so values inherited from the environment cannot alter behaviour
- Make cleanup_and_exit() the single place where emergency stop happens, removing inline stop-all calls that caused a double stop on failure
- Arm FAIL_STOP_REQ inside do_start(), so all calls to do_start() handle fatal errors identically
- Fix error code propagation in a few places
- Replace the undocumented run state 5 with the documented transitional state 2
- Corretly set per-blockset run_state to '1' when blockset installation fails
- Remove some dead code
- Fix failure records not making it into report_failure hook
- Fix missing arguments in some calls to add2list()
- Fix: pause/resume of stopped blocksets would count as a success for the matter of return code
- Reject PIDs 1 and 0* in the lock file
- Fix: per-blockset backup entries count might not be reset when iterating over blocksets
- Fix some console/log/error messages